### PR TITLE
fix: enforce 3-step plan approval in /forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 | 27 | **who-are-you** | skill | Know ourselves |
 | 28 | **worktree** | skill | Git worktree for parallel work |
 
-*Generated: 2026-03-13 12:50:35 UTC*
+*Generated: 2026-03-15 03:52:47 UTC*
 
 ## Supported Agents
 

--- a/src/skills/forward/SKILL.md
+++ b/src/skills/forward/SKILL.md
@@ -59,9 +59,18 @@ Do NOT `git add` vault files — they are shared state, not committed to repos.
 - [Important file 2]
 ```
 
-## Then: MUST Enter Plan Mode
+## Then: MUST Show Plan Approval Box
 
-**CRITICAL**: You MUST call `EnterPlanMode` after writing the handoff. This is NOT optional. The whole point of /forward is to show the user a plan they can approve for the next session.
+**CRITICAL — DO NOT SKIP**: The whole point of /forward is the plan approval UI.
+You MUST do ALL 3 steps in order. If you skip any step, the user cannot approve and clear the session.
+
+1. `EnterPlanMode` — enters plan mode
+2. Write plan file — session summary + next steps
+3. `ExitPlanMode` — **THIS shows the approval box** where user can approve/reject/clear
+
+If you only do EnterPlanMode without ExitPlanMode, the user sees nothing.
+If you skip EnterPlanMode entirely, the user sees nothing.
+ALL 3 STEPS ARE REQUIRED.
 
 **Do NOT commit the handoff file** — it lives in the vault, not the repo.
 After writing the handoff, gather cleanup context:


### PR DESCRIPTION
## Summary

- /forward sometimes skips showing the plan approval box
- Made the 3-step flow explicit: EnterPlanMode → write plan → ExitPlanMode
- ExitPlanMode is what shows the approval UI — without it user sees nothing

## Test plan

- [x] 110 tests pass
- [ ] Manual: run /forward, verify plan approval box appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>