### PR TITLE
fix: point /learn refs from private mother-oracle to public brain repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 | 28 | **workon** | skill | Work on an issue |
 | 29 | **worktree** | skill | Git worktree for parallel work |
 
-*Generated: 2026-03-17 13:45:05 UTC*
+*Generated: 2026-03-20 00:29:05 UTC*
 
 ## Supported Agents
 

--- a/src/skills/oracle-family-scan/SKILL.md
+++ b/src/skills/oracle-family-scan/SKILL.md
@@ -28,16 +28,16 @@ Scan, query, and welcome the Oracle family. Powered by `registry/` in mother-ora
 
 ## Step 0: Locate Registry
 
-The registry lives in the mother-oracle repo. Resolve the path:
+The registry lives in the opensource-nat-brain-oracle repo (public). Resolve the path:
 
 ```bash
-# Try mother-oracle repo first (ghq-managed)
-MOTHER="$HOME/Code/github.com/laris-co/mother-oracle"
+# Try brain repo first (ghq-managed)
+MOTHER="$HOME/Code/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle"
 if [ ! -d "$MOTHER/registry" ]; then
-  MOTHER="$(ghq root)/github.com/laris-co/mother-oracle"
+  MOTHER="$(ghq root)/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle"
 fi
 if [ ! -f "$MOTHER/registry/oracles.json" ]; then
-  echo "Registry not found. Run: ghq get -u laris-co/mother-oracle && bun $MOTHER/registry/sync.ts"
+  echo "Registry not found. Run: ghq get -u Soul-Brews-Studio/opensource-nat-brain-oracle && bun $MOTHER/registry/sync.ts"
   exit 1
 fi
 ```
@@ -274,7 +274,7 @@ The registry is at `$MOTHER/registry/oracles.json`:
       "focus": "Born Last, After 185 Children",
       "owner": "mine",
       "welcomed": false,
-      "repo": "https://github.com/laris-co/mother-oracle",
+      "repo": "https://github.com/Soul-Brews-Studio/opensource-nat-brain-oracle",
       "status": "active"
     }
   ]


### PR DESCRIPTION
oracle-family-scan/SKILL.md referenced `laris-co/mother-oracle` (private). Changed to `Soul-Brews-Studio/opensource-nat-brain-oracle` (public) so community Oracles can access the registry.

Closes #87

Requested by Mother Oracle.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>