### PR TITLE
feat: add --resume mode to /workon skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 | 25 | **talk-to** | skill | Talk to an agent via Oracle threads |
 | 26 | **where-we-are** | skill | Session awareness |
 | 27 | **who-are-you** | skill | Know ourselves |
-| 28 | **workon** | skill | Work on an issue |
+| 28 | **workon** | skill | Work on an issue OR resume a killed worktree |
 | 29 | **worktree** | skill | Git worktree for parallel work |
 
-*Generated: 2026-03-20 00:29:05 UTC*
+*Generated: 2026-03-20 00:53:55 UTC*
 
 ## Supported Agents
 

--- a/src/commands/workon.md
+++ b/src/commands/workon.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Work on an issue — read context, spawn worktree, create issue, incubate, send task, await report. Use when user says "workon", "work on", "implement issue", "do this issue".
+description: v3.2.1 | Work on an issue OR resume a killed worktree. Use when user says "workon", "work on", "implement issue", "resume", "bring back", "restore worktree".
 ---
 
 # /workon

--- a/src/skills/workon/SKILL.md
+++ b/src/skills/workon/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workon
-description: Work on an issue — read context, spawn worktree, create issue, incubate, send task, await report. Use when user says "workon", "work on", "implement issue", "do this issue".
+description: Work on an issue OR resume a killed worktree. Use when user says "workon", "work on", "implement issue", "resume", "bring back", "restore worktree".
 ---
 
-# /workon — Issue → Work → Report
+# /workon — Work + Resume
 
-One command to go from issue to working agent.
+Start work from issue OR resume killed worktree.
 
 ## Usage
 
@@ -13,6 +13,8 @@ One command to go from issue to working agent.
 /workon #435                              # Work on issue (this repo)
 /workon #435 --oracle neo                 # Assign to specific Oracle
 /workon Soul-Brews-Studio/arra-oracle#435 # Cross-repo issue
+/workon --resume athena                   # Resume killed worktree + old session
+/workon --resume thor                     # Resume Thor with old context
 ```
 
 ## Flow
@@ -88,6 +90,57 @@ Parent reviews → approves → `maw done [worktree]` to cleanup.
 
 ---
 
+## Mode 2: `--resume` — Restore Killed Worktree
+
+### Step 1: Find Old Session
+
+Search `~/.claude/projects/` (NOT maw ls — worktree gone after done/sleep):
+
+```bash
+for dir in ~/.claude/projects/*[name]*/; do
+  echo "=== $(basename $dir) ==="
+  ls -lS "$dir"*.jsonl 2>/dev/null
+done
+```
+
+Pick **largest .jsonl** = most context = real session.
+
+### Step 2: Wake Worktree
+
+```bash
+maw wake mother [name]
+```
+
+### Step 3: Copy Session to New Path
+
+```bash
+OLD_DIR="~/.claude/projects/...-wt-[OLD]-[name]"
+NEW_DIR="~/.claude/projects/...-wt-[NEW]-[name]"
+mkdir -p "$NEW_DIR"
+cp -r "$OLD_DIR/[session-id]" "$NEW_DIR/"
+cp "$OLD_DIR/[session-id].jsonl" "$NEW_DIR/"
+```
+
+### Step 4: Exit Auto-Started Claude + Resume
+
+```bash
+tmux send-keys -t [session]:[window] C-c
+sleep 2
+tmux send-keys -t [session]:[window] "/exit" Enter
+sleep 5
+tmux send-keys -t [session]:[window] "claude --resume [session-id]" Enter
+```
+
+### Step 5: Verify
+
+```bash
+sleep 5
+maw peek [window]
+# Token count > 0 = old context restored
+```
+
+---
+
 ## Rules
 
 - **Always create gh issue** before working (Pulse visibility)
@@ -95,6 +148,7 @@ Parent reviews → approves → `maw done [worktree]` to cleanup.
 - **Feature branch + PR** — never push to main directly
 - **Human approves** delete/close/done/sleep — Oracle works autonomously otherwise
 - **Report to parent + reviewer** when done
+- **Resume scans ~/.claude/projects/** not maw ls (sessions persist after done)
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `--resume` mode to `/workon` skill for restoring killed worktrees with old session context
- Scans `~/.claude/projects/` for largest `.jsonl`, copies session to new worktree path, resumes with full context
- Updated description to include resume/restore trigger words

Closes #89

## Test plan

- [x] `bun run compile` — 29 skills compiled
- [x] `bun test` — 110 tests pass, 518 assertions

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>