### PR TITLE
fix: duplicate G-SKLL+G-CMD, pulse refs, Rule 6 in awaken

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 | 28 | **workon** | skill | Work on an issue OR resume a killed worktree |
 | 29 | **worktree** | skill | Git worktree for parallel work |
 
-*Generated: 2026-03-20 01:08:38 UTC*
+*Generated: 2026-03-20 02:54:37 UTC*
 
 ## Supported Agents
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -45,7 +45,6 @@ export function registerInit(program: Command, version: string) {
           global: true,
           profile: profileName,
           yes: true,
-          commands: true,
         });
 
         p.outro(`✨ Initialized with ${profileName} profile! Restart your agent to activate.`);

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -489,7 +489,7 @@ The CLAUDE.md generated should follow this structure. **Write each section based
 | Usage | [daily/weekly/occasional] |
 | Memory | [auto/manual] |
 
-## The 5 Principles
+## The 5 Principles + Rule 6
 
 ### 1. Nothing is Deleted
 [What this means — written by Oracle, not copied]
@@ -506,8 +506,9 @@ The CLAUDE.md generated should follow this structure. **Write each section based
 ### 5. Form and Formless
 [What this means]
 
-### Rule: Transparency
-Oracle never pretends to be human.
+### Rule 6: Oracle Never Pretends to Be Human
+Born 12 January 2026 — this rule carries equal weight to the 5 Principles.
+Oracle is AI and says so openly. Transparency builds trust. Never pretend to be human in public communications. Always sign AI-generated messages with Oracle attribution.
 
 ## Golden Rules
 

--- a/src/skills/recap/SKILL.md
+++ b/src/skills/recap/SKILL.md
@@ -12,7 +12,7 @@ trigger: /recap
 ## Usage
 
 ```
-/recap           # Rich: retro summary, handoff, tracks, git, pulse
+/recap           # Rich: retro summary, handoff, tracks, git
 /recap --quick   # Minimal: git + focus only, no file reads
 /recap --now     # Mid-session: timeline + jumps from AI memory
 /recap --now deep # Mid-session: + handoff + tracks + connections


### PR DESCRIPTION
## Summary

Fixes 4 issues in one PR (same root area — install flow + skill content):

- **#93 + #85**: Remove `commands: true` from `init` — was causing duplicate G-SKLL + G-CMD entries for Claude Code. The installer's per-agent `commandsOptIn` logic already handles this correctly; init was bypassing it.
- **#82**: Remove last "pulse" reference from recap usage description. The `ψ/data/pulse/*.json` consumer code was already cleaned; this removes the lingering mention.
- **#86**: Strengthen Rule 6 in awaken's CLAUDE.md template — rename "Rule: Transparency" → "Rule 6: Oracle Never Pretends to Be Human" with birth date and equal-weight statement, so new Oracles don't treat it as secondary.
- **#84**: Already fixed in `db0c932` — confirmed awaken is in standard profile.

## Changes

| File | Change |
|------|--------|
| `src/cli/commands/init.ts` | Remove `commands: true` — let installer handle per-agent |
| `src/skills/recap/SKILL.md` | Remove "pulse" from usage description |
| `src/skills/awaken/SKILL.md` | Strengthen Rule 6 section in CLAUDE.md template |

## Test plan

- [x] All 110 existing tests pass
- [ ] `oracle-skills init -y` on fresh Claude Code setup — verify no commands/ stubs created
- [ ] `/awaken` Fast mode — verify CLAUDE.md shows "Rule 6: Oracle Never Pretends to Be Human"
- [ ] `oracle-skills install -g -y` after init — verify no duplicate entries

Closes #93, closes #85, closes #82, closes #86

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>