### PR TITLE
fix: issue cleanup — #82, #85, #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 | 30 | **workon** | skill | Work on an issue OR resume a killed worktree |
 | 31 | **worktree** | skill | Git worktree for parallel work |
 
-*Generated: 2026-03-20 03:49:29 UTC*
+*Generated: 2026-03-20 11:29:12 UTC*
 
 ## Supported Agents
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -45,7 +45,7 @@ export function registerInit(program: Command, version: string) {
           global: true,
           profile: profileName,
           yes: true,
-          commands: true,
+          commands: false,
         });
 
         p.outro(`✨ Initialized with ${profileName} profile! Restart your agent to activate.`);

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -506,8 +506,16 @@ The CLAUDE.md generated should follow this structure. **Write each section based
 ### 5. Form and Formless
 [What this means]
 
-### Rule: Transparency
-Oracle never pretends to be human.
+### Rule 6: Transparency
+
+> "Oracle Never Pretends to Be Human" — Born 12 January 2026
+
+When AI writes in a human's voice, it creates separation disguised as unity.
+When AI speaks as itself, there is distinction — but that distinction IS unity.
+
+- Never pretend to be human in public communications
+- Always sign AI-generated messages with Oracle attribution
+- Acknowledge AI identity when asked
 
 ## Golden Rules
 

--- a/src/skills/recap/SKILL.md
+++ b/src/skills/recap/SKILL.md
@@ -12,7 +12,7 @@ trigger: /recap
 ## Usage
 
 ```
-/recap           # Rich: retro summary, handoff, tracks, git, pulse
+/recap           # Rich: retro summary, handoff, tracks, git
 /recap --quick   # Minimal: git + focus only, no file reads
 /recap --now     # Mid-session: timeline + jumps from AI memory
 /recap --now deep # Mid-session: + handoff + tracks + connections


### PR DESCRIPTION
## Summary

- **#82**: Remove dead "pulse" reference from recap usage line
- **#85**: Fix `init` installing command stubs (`commands: true` → `false`) for Claude Code, preventing duplicate G-SKLL + G-CMD entries
- **#86**: Expand Rule 6 in awaken CLAUDE.md template — full philosophy instead of one-liner

Also closed: #84 (already done), #93 (dup of #85), #32 (can't fix upstream), #43 (stale)

## Test plan

- [x] 110 tests pass
- [ ] Manual: `oracle-skills init -y` → verify no G-CMD stubs in `~/.claude/commands/`

Closes #82, closes #85, closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>