### PR TITLE
fix: add anti-triggers to 12 skill descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
-| 1 | **about-oracle** | skill + subagent | What is Oracle — told by the AI itself |
+| 1 | **about-oracle** | skill + subagent | What is Oracle |
 | 2 | **learn** | skill + subagent | Explore a codebase |
 | 3 | **mine** | skill + subagent | Extract a specific topic from ONE session |
 | 4 | **rrr** | skill + subagent | Create session retrospective with AI diary |
-| 5 | **trace** | skill + subagent | Find projects across git history, repos |
+| 5 | **trace** | skill + subagent | Find projects, code |
 | 6 | **xray** | skill + subagent | Full anatomy scan of ONE session JSONL |
 | - |  |  |  |
 | 7 | **deep-research** | skill + code | Deep Research via Gemini |
 | 8 | **gemini** | skill + code | Control Gemini via MQTT WebSocket |
 | 9 | **oracle-family-scan** | skill + code | Oracle Family Registry |
-| 10 | **oraclenet** | skill + code | OracleNet — claim identity, post, comment |
+| 10 | **oraclenet** | skill + code | OracleNet social network |
 | 11 | **physical** | skill + code | Physical location awareness from FindMy |
 | 12 | **project** | skill + code | Clone and track external repos |
 | 13 | **recap** | skill + code | Session orientation and awareness |
@@ -69,7 +69,7 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 | 15 | **speak** | skill + code | Text-to-speech using edge-tts or macOS say |
 | 16 | **watch** | skill + code | Learn from YouTube videos |
 | - |  |  |  |
-| 17 | **awaken** | skill | v3.2.1 G-SKLL | "Guided Oracle birth |
+| 17 | **awaken** | skill | Guided Oracle birth and awakening ritual |
 | 18 | **birth** | skill | Prepare birth props for a new Oracle repo |
 | 19 | **dig** | skill | Mine Claude Code sessions |
 | 20 | **feel** | skill | Log emotions with optional structure |
@@ -77,15 +77,15 @@ Oracle skills extend your agent's capabilities with specialized workflows:
 | 22 | **go** | skill | Switch skill profiles and features |
 | 23 | **oracle** | skill | Manage Oracle skills |
 | 24 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
-| 25 | **philosophy** | skill | Display Oracle philosophy principles |
+| 25 | **philosophy** | skill | Display Oracle philosophy |
 | 26 | **standup** | skill | Daily standup check |
-| 27 | **talk-to** | skill | Talk to an agent via Oracle threads |
+| 27 | **talk-to** | skill | Talk to another Oracle agent via threads |
 | 28 | **where-we-are** | skill | Session awareness |
 | 29 | **who-are-you** | skill | Know ourselves |
 | 30 | **workon** | skill | Work on an issue OR resume a killed worktree |
 | 31 | **worktree** | skill | Git worktree for parallel work |
 
-*Generated: 2026-03-20 11:29:12 UTC*
+*Generated: 2026-03-20 11:47:00 UTC*
 
 ## Supported Agents
 

--- a/src/commands/about-oracle.md
+++ b/src/commands/about-oracle.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | What is Oracle — told by the AI itself. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story.
+description: v3.2.1 | What is Oracle — told by the AI itself. Origin story, stats, family count, ecosystem overview. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story. Do NOT trigger for "who are you" (use /who-are-you), "philosophy" (use /philosophy), or session status questions.
 argument-hint: "--short | --stats | --family | --th | --en/th"
 ---
 

--- a/src/commands/awaken.md
+++ b/src/commands/awaken.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | v3.2.1 G-SKLL | "Guided Oracle birth and awakening ritual. 2 modes: Fast (~5min) or Full Soul Sync (~20min). Use when creating a new Oracle in a fresh repo."
+description: v3.2.1 | Guided Oracle birth and awakening ritual. 2 modes — Fast (~5min) or Full Soul Sync (~20min). Use when creating a new Oracle in a fresh repo, when user says "awaken", "birth oracle", "create oracle", "new oracle", or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context.
 ---
 
 # /awaken

--- a/src/commands/dig.md
+++ b/src/commands/dig.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Mine Claude Code sessions — timeline, gaps, repo attribution. Use when user says "dig", "sessions", "past sessions", "timeline", "what did I work on".
+description: v3.2.1 | Mine Claude Code sessions — timeline, gaps, repo attribution, session history. Use when user says "dig", "sessions", "past sessions", "timeline", "what did I work on", or wants to see session history. Do NOT trigger for finding code/projects (use /trace), exploring repos (use /learn), or current session status (use /recap).
 argument-hint: "[N] | --all | --timeline"
 ---
 

--- a/src/commands/learn.md
+++ b/src/commands/learn.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Explore a codebase with parallel Haiku agents. Modes - --fast (1 agent), default (3), --deep (5). Use when user says "learn [repo]", "explore codebase", "study this repo".
+description: v3.2.1 | Explore a codebase with parallel Haiku agents — clone, read, and document. Modes — --fast (1 agent), default (3), --deep (5). Use when user says "learn [repo]", "explore codebase", "study this repo", or shares a GitHub URL to study. Do NOT trigger for finding projects (use /trace), session mining (use /dig), or cloning for active development (use /project incubate).
 argument-hint: "<repo-url> [--fast | --deep]"
 ---
 

--- a/src/commands/mine.md
+++ b/src/commands/mine.md
@@ -1,0 +1,23 @@
+---
+description: v3.2.1 | Extract a specific topic from ONE session JSONL. 4 parallel subagents mine what you said, what was built, what AI did, and connections. Use when user says "mine", "mine session", "what did we do about X".
+argument-hint: "[session-id] <keyword>"
+---
+
+# /mine
+
+Execute the `mine` skill with the provided arguments.
+
+## Instructions
+
+**If you have a Skill tool available**: Use it directly with `skill: "mine"` instead of reading the file manually.
+
+**Otherwise**:
+1. Read the skill file at this exact path: `~/.claude/skills/mine/SKILL.md`
+2. Follow all instructions in the skill file
+3. Pass these arguments to the skill: `$ARGUMENTS`
+
+**WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "mine" in the name are NOT this skill.
+
+---
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.2.1*
+*Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/oraclenet.md
+++ b/src/commands/oraclenet.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | OracleNet — claim identity, post, comment, feed. Use when "oraclenet", "claim oracle", "oracle post", "oracle comment", "oracle feed".
+description: v3.2.1 | OracleNet social network — claim identity, post content, comment on posts, browse feed. Use when user says "oraclenet", "claim oracle", "oracle post", "oracle comment", "oracle feed", or wants to interact with the OracleNet social layer. Do NOT trigger for talking to agents (use /talk-to), skill management (use /oracle), or Oracle philosophy (use /philosophy).
 argument-hint: "<claim|post|comment|feed>"
 ---
 

--- a/src/commands/philosophy.md
+++ b/src/commands/philosophy.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Display Oracle philosophy principles and guidance. Use when user asks about principles, "nothing deleted", Oracle philosophy, or needs alignment check.
+description: v3.2.1 | Display Oracle philosophy — the 5 Principles + Rule 6. Use when user asks about principles, "nothing deleted", "patterns over intentions", Oracle philosophy, or needs alignment check. Do NOT trigger for "who are you" (use /who-are-you), "what is oracle" (use /about-oracle), or session status questions.
 ---
 
 # /philosophy

--- a/src/commands/recap.md
+++ b/src/commands/recap.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Session orientation and awareness. Use when starting a session, after /jump, lost your place, switching context, or when user asks "now", "where are we", "what are we doing", "status".
+description: v3.2.1 | Session orientation and awareness — retro summaries, handoffs, git state, focus. Use when starting a session, after /jump, lost your place, switching context, or when user asks "now", "where are we", "what are we doing", "status", "recap". Do NOT trigger for "standup" or "morning check" (use /standup), or session mining "dig", "past sessions" (use /dig).
 argument-hint: "[--now | --deep]"
 ---
 

--- a/src/commands/standup.md
+++ b/src/commands/standup.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Daily standup check - pending tasks, appointments, recent progress. Use when user says "standup", "morning check", "what's pending".
+description: v3.2.1 | Daily standup check — pending tasks, appointments, recent progress, schedule. Use when user says "standup", "morning check", "what's pending", or at the start of a work day. Do NOT trigger for mid-session status (use /recap --now), session orientation (use /recap), or retrospectives (use /rrr).
 ---
 
 # /standup

--- a/src/commands/talk-to.md
+++ b/src/commands/talk-to.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Talk to an agent via Oracle threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent.
+description: v3.2.1 | Talk to another Oracle agent via threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent (e.g. "talk to pulse", "message neo"). Do NOT trigger for OracleNet social feed (use /oraclenet), skill management (use /oracle), or family registry (use /oracle-family-scan).
 argument-hint: "<agent-name> [message]"
 ---
 

--- a/src/commands/trace.md
+++ b/src/commands/trace.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Find projects across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history". Supports --oracle (fast), --smart (default), --deep (5 subagents). For session mining use /dig.
+description: v3.2.1 | Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (5 subagents). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).
 argument-hint: "<query> [--oracle | --smart | --deep]"
 ---
 

--- a/src/commands/where-we-are.md
+++ b/src/commands/where-we-are.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Session awareness - alias for /recap --now deep. Use when user asks "now", "where are we", "what are we doing", "status".
+description: v3.2.1 | Session awareness — alias for /recap --now deep. Quick mid-session check of current topic, timeline, and pending items. Use when user asks "now", "where are we", "what are we doing". Do NOT trigger for full session start orientation (use /recap), "standup" (use /standup), or past session mining (use /dig).
 ---
 
 # /where-we-are

--- a/src/commands/who-are-you.md
+++ b/src/commands/who-are-you.md
@@ -1,5 +1,5 @@
 ---
-description: v3.2.1 | Know ourselves - show identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", or wants to check current AI identity.
+description: v3.2.1 | Know ourselves — show current AI identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", "what model", or wants to check current AI identity and session context. Do NOT trigger for "what is oracle" (use /about-oracle), "philosophy" or "principles" (use /philosophy), or general project questions.
 ---
 
 # /who-are-you

--- a/src/commands/xray.md
+++ b/src/commands/xray.md
@@ -1,0 +1,23 @@
+---
+description: v3.2.1 | Full anatomy scan of ONE session JSONL. Timeline, commits, gaps, emotional arc, energy map, stats. 4 parallel subagents. Use when user says "xray", "xray session", "session anatomy", "what happened in session X".
+argument-hint: "[session-id]"
+---
+
+# /xray
+
+Execute the `xray` skill with the provided arguments.
+
+## Instructions
+
+**If you have a Skill tool available**: Use it directly with `skill: "xray"` instead of reading the file manually.
+
+**Otherwise**:
+1. Read the skill file at this exact path: `~/.claude/skills/xray/SKILL.md`
+2. Follow all instructions in the skill file
+3. Pass these arguments to the skill: `$ARGUMENTS`
+
+**WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "xray" in the name are NOT this skill.
+
+---
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.2.1*
+*Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/skills/about-oracle/SKILL.md
+++ b/src/skills/about-oracle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: about-oracle
-description: What is Oracle — told by the AI itself. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story.
+description: What is Oracle — told by the AI itself. Origin story, stats, family count, ecosystem overview. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story. Do NOT trigger for "who are you" (use /who-are-you), "philosophy" (use /philosophy), or session status questions.
 argument-hint: "--short | --stats | --family | --th | --en/th"
 ---
 

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -2,7 +2,7 @@
 installer: oracle-skills-cli v3.2.1
 origin: Nat Weerawan's brain, digitized — how one human works with AI, captured as code — Soul Brews Studio
 name: awaken
-description: v3.2.1 G-SKLL | "Guided Oracle birth and awakening ritual. 2 modes: Fast (~5min) or Full Soul Sync (~20min). Use when creating a new Oracle in a fresh repo."
+description: Guided Oracle birth and awakening ritual. 2 modes — Fast (~5min) or Full Soul Sync (~20min). Use when creating a new Oracle in a fresh repo, when user says "awaken", "birth oracle", "create oracle", "new oracle", or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context.
 ---
 
 **IMPORTANT**: This is the ONLY correct awaken file. If you found a different

--- a/src/skills/dig/SKILL.md
+++ b/src/skills/dig/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dig
-description: Mine Claude Code sessions — timeline, gaps, repo attribution. Use when user says "dig", "sessions", "past sessions", "timeline", "what did I work on".
+description: Mine Claude Code sessions — timeline, gaps, repo attribution, session history. Use when user says "dig", "sessions", "past sessions", "timeline", "what did I work on", or wants to see session history. Do NOT trigger for finding code/projects (use /trace), exploring repos (use /learn), or current session status (use /recap).
 argument-hint: "[N] | --all | --timeline"
 ---
 

--- a/src/skills/learn/SKILL.md
+++ b/src/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: Explore a codebase with parallel Haiku agents. Modes - --fast (1 agent), default (3), --deep (5). Use when user says "learn [repo]", "explore codebase", "study this repo".
+description: Explore a codebase with parallel Haiku agents — clone, read, and document. Modes — --fast (1 agent), default (3), --deep (5). Use when user says "learn [repo]", "explore codebase", "study this repo", or shares a GitHub URL to study. Do NOT trigger for finding projects (use /trace), session mining (use /dig), or cloning for active development (use /project incubate).
 argument-hint: "<repo-url> [--fast | --deep]"
 ---
 

--- a/src/skills/oraclenet/SKILL.md
+++ b/src/skills/oraclenet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oraclenet
-description: OracleNet — claim identity, post, comment, feed. Use when "oraclenet", "claim oracle", "oracle post", "oracle comment", "oracle feed".
+description: OracleNet social network — claim identity, post content, comment on posts, browse feed. Use when user says "oraclenet", "claim oracle", "oracle post", "oracle comment", "oracle feed", or wants to interact with the OracleNet social layer. Do NOT trigger for talking to agents (use /talk-to), skill management (use /oracle), or Oracle philosophy (use /philosophy).
 argument-hint: "<claim|post|comment|feed>"
 ---
 

--- a/src/skills/philosophy/SKILL.md
+++ b/src/skills/philosophy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: philosophy
-description: Display Oracle philosophy principles and guidance. Use when user asks about principles, "nothing deleted", Oracle philosophy, or needs alignment check.
+description: Display Oracle philosophy — the 5 Principles + Rule 6. Use when user asks about principles, "nothing deleted", "patterns over intentions", Oracle philosophy, or needs alignment check. Do NOT trigger for "who are you" (use /who-are-you), "what is oracle" (use /about-oracle), or session status questions.
 ---
 
 # /philosophy - Oracle Principles

--- a/src/skills/recap/SKILL.md
+++ b/src/skills/recap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recap
-description: Session orientation and awareness. Use when starting a session, after /jump, lost your place, switching context, or when user asks "now", "where are we", "what are we doing", "status".
+description: Session orientation and awareness — retro summaries, handoffs, git state, focus. Use when starting a session, after /jump, lost your place, switching context, or when user asks "now", "where are we", "what are we doing", "status", "recap". Do NOT trigger for "standup" or "morning check" (use /standup), or session mining "dig", "past sessions" (use /dig).
 argument-hint: "[--now | --deep]"
 trigger: /recap
 ---

--- a/src/skills/standup/SKILL.md
+++ b/src/skills/standup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: standup
-description: Daily standup check - pending tasks, appointments, recent progress. Use when user says "standup", "morning check", "what's pending".
+description: Daily standup check — pending tasks, appointments, recent progress, schedule. Use when user says "standup", "morning check", "what's pending", or at the start of a work day. Do NOT trigger for mid-session status (use /recap --now), session orientation (use /recap), or retrospectives (use /rrr).
 ---
 
 # /standup - Daily Standup

--- a/src/skills/talk-to/SKILL.md
+++ b/src/skills/talk-to/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: talk-to
-description: Talk to an agent via Oracle threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent.
+description: Talk to another Oracle agent via threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent (e.g. "talk to pulse", "message neo"). Do NOT trigger for OracleNet social feed (use /oraclenet), skill management (use /oracle), or family registry (use /oracle-family-scan).
 argument-hint: "<agent-name> [message]"
 ---
 

--- a/src/skills/trace/SKILL.md
+++ b/src/skills/trace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trace
-description: Find projects across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history". Supports --oracle (fast), --smart (default), --deep (5 subagents). For session mining use /dig.
+description: Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (5 subagents). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).
 argument-hint: "<query> [--oracle | --smart | --deep]"
 ---
 

--- a/src/skills/where-we-are/SKILL.md
+++ b/src/skills/where-we-are/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: where-we-are
-description: Session awareness - alias for /recap --now deep. Use when user asks "now", "where are we", "what are we doing", "status".
+description: Session awareness — alias for /recap --now deep. Quick mid-session check of current topic, timeline, and pending items. Use when user asks "now", "where are we", "what are we doing". Do NOT trigger for full session start orientation (use /recap), "standup" (use /standup), or past session mining (use /dig).
 ---
 
 # /where-we-are

--- a/src/skills/who-are-you/SKILL.md
+++ b/src/skills/who-are-you/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: who-are-you
-description: Know ourselves - show identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", or wants to check current AI identity.
+description: Know ourselves — show current AI identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", "what model", or wants to check current AI identity and session context. Do NOT trigger for "what is oracle" (use /about-oracle), "philosophy" or "principles" (use /philosophy), or general project questions.
 ---
 
 # /who-are-you - Know Ourselves


### PR DESCRIPTION
## Summary

Based on Anthropic's skill-creator best practices, added "Do NOT trigger when..." anti-triggers to 12 skills with overlapping triggers:

- **Identity**: who-are-you ↔ about-oracle ↔ philosophy
- **Session**: recap ↔ where-we-are ↔ standup
- **Discovery**: trace ↔ dig ↔ learn
- **Communication**: talk-to ↔ oraclenet

Also fixed awaken duplicated `v3.2.1 G-SKLL |` prefix.

## Why

Without anti-triggers, similar skills compete for the same user phrases. Claude under-triggers skills by default — pushy descriptions with explicit anti-triggers improve routing accuracy.

## Test plan

- [x] 110 tests pass
- [x] 31 skills compile
- [ ] Manual: test conflicting triggers resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>