### PR TITLE
feat(trace): v3.3.1 — wave execution + friction_score + goal-backward check

### DIFF
--- a/src/skills/trace/SKILL.md
+++ b/src/skills/trace/SKILL.md
@@ -1,19 +1,21 @@
 ---
+installer: oracle-skills-cli v3.3.0-alpha.10
+origin: Nat Weerawan's brain, digitized — how one human works with AI, captured as code — Soul Brews Studio
 name: trace
-description: Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (5 subagents). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).
+description: v3.3.1 G-SKLL | Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (wave execution). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).
 argument-hint: "<query> [--oracle | --smart | --deep]"
 ---
 
 # /trace - Unified Discovery System
 
-Find + Log + Distill
+Find + Measure + Log + Distill
 
 ## Usage
 
 ```
 /trace [query]                    # Current repo (default --smart)
 /trace [query] --oracle           # Oracle only (fastest)
-/trace [query] --deep             # 5 parallel subagents
+/trace [query] --deep             # Wave execution (thorough)
 /trace [query] --repo [path]      # Search specific local repo
 /trace [query] --repo [url]       # Clone to ghq, then search
 ```
@@ -29,6 +31,8 @@ Find + Log + Distill
 ```
 
 **Trace logs are committed** - they become Oracle memory for future searches.
+
+---
 
 ## Step 0: Timestamp + Calculate Paths
 
@@ -85,7 +89,7 @@ TRACE_FILE="$ROOT/ψ/memory/traces/$TODAY/${TIME}_[query-slug].md"
 **Fastest. Just Oracle MCP, no subagents.**
 
 ```
-oracle_search("[query]", limit=15)
+arra_search("[query]", limit=15)
 ```
 
 Display results and done. Even if empty.
@@ -98,7 +102,7 @@ Display results and done. Even if empty.
 
 **Step 1**: Query Oracle first
 ```
-oracle_search("[query]", limit=10)
+arra_search("[query]", limit=10)
 ```
 
 **Step 2**: Check result count
@@ -107,54 +111,146 @@ oracle_search("[query]", limit=10)
 
 ---
 
-## Mode 3: --deep (5 Parallel Agents)
+## Mode 3: --deep (Wave Execution)
 
-**Launch 5 parallel Explore agents for thorough search.**
+**Two waves of parallel search. Each wave has fresh context (no rot).**
 
-Each agent prompt must include (use LITERAL paths!):
+### Wave 1 — Fast surface search (run in parallel)
+
+**Agent A: Current/Target Repo Files**
 ```
 You are searching for: [query]
 TARGET REPO: [TARGET_REPO]
 
-Return your findings as text. The main agent will compile the trace log.
+Search for:
+- Files matching query (names, paths)
+- Code/docs containing query
+- Config files mentioning query
+
+Return findings as text. Main agent compiles.
 ```
 
-### Agent 1: Current/Target Repo Files
-Search TARGET_REPO for:
-- Files matching query
-- Code containing query
-- Config/docs mentioning query
-
-### Agent 2: Git History
-Search TARGET_REPO git history:
-- Commits mentioning query
-- Files created/deleted matching query
-- Branch names matching query
-
-### Agent 3: GitHub Issues
-If TARGET_REPO has GitHub remote:
-```bash
-gh issue list --repo [owner/repo] --search "[query]" --limit 10
-gh pr list --repo [owner/repo] --search "[query]" --limit 10
+**Agent B: Oracle Memory**
 ```
+You are searching for: [query]
+PSI DIR: [ROOT]/ψ/
 
-### Agent 4: Other Repos (ghq, ~/Code)
-Search other locations:
-```bash
-find $(ghq root) -maxdepth 3 -name "*[query]*" 2>/dev/null | head -20
-```
-
-### Agent 5: Oracle Memory (ψ/)
 Search ψ/memory/ for:
 - Learnings mentioning query
 - Retrospectives mentioning query
-- Previous traces for same query
+- Previous trace logs for same query
 
-**After all agents return**, main agent compiles results and writes trace log.
+Return findings as text. Main agent compiles.
+```
+
+After Wave 1: check if answer is sufficient.
+- Sufficient (clear answer found) → skip Wave 2, go to Step 3
+- Insufficient (< 3 results or answer unclear) → run Wave 2
+
+### Wave 2 — Deep search (run in parallel, only if Wave 1 insufficient)
+
+**Agent C: Git History**
+```
+You are searching for: [query]
+TARGET REPO: [TARGET_REPO]
+
+Search git history:
+- Commits mentioning query
+- Files created/deleted matching query
+- Branch names matching query
+Run: git log --all --oneline --grep="[query]"
+
+Return findings as text. Main agent compiles.
+```
+
+**Agent D: Cross-Repo (ghq + ~/Code)**
+```
+You are searching for: [query]
+
+Search other repos:
+- find $(ghq root) -maxdepth 3 -name "*[query]*" 2>/dev/null | head -20
+- grep -r "[query]" ~/Code --include="*.md" -l 2>/dev/null | head -10
+
+Return findings as text. Main agent compiles.
+```
+
+**Agent E: GitHub Issues/PRs**
+```
+You are searching for: [query]
+TARGET REPO: [TARGET_REPO]
+
+If repo has GitHub remote, run:
+- gh issue list --search "[query]" --limit 10
+- gh pr list --search "[query]" --limit 10
+
+Return findings as text. Main agent compiles.
+```
+
+**After both waves**, main agent compiles all results → Step 3.
 
 ---
 
-## Step 3: Write Trace Log
+## Step 3: Calculate Friction Score (Volt-inspired)
+
+After search completes, calculate `friction_score` using the v2 formula:
+
+```
+friction_score = S + C_offset    (clamped to [0.0, 1.0])
+```
+
+**S — Source Score** (highest-tier source with relevant result):
+
+| Where found | S | Meaning |
+|-------------|---|---------|
+| Oracle | 1.0 | Frictionless — well-indexed, visible |
+| Repo files | 0.7 | Present but not indexed |
+| Git history | 0.5 | Buried — existed, hard to surface |
+| Cross-repo | 0.3 | Hidden — lives elsewhere |
+| Not found | 0.0 | Invisible — doesn't exist yet |
+
+**C_offset — Completeness** (from goal-backward check in Step 4):
+
+| Confidence | C_offset |
+|------------|----------|
+| high | +0.00 |
+| medium | −0.10 |
+| low | −0.20 |
+
+**Score table**:
+
+| Situation | Score |
+|-----------|-------|
+| Oracle + high | 1.0 |
+| Oracle + medium | 0.9 |
+| Files + high | 0.7 |
+| Files + medium | 0.6 |
+| Git + high | 0.5 |
+| Git + medium | 0.4 |
+| Cross-repo + high | 0.3 |
+| Not found | 0.0 |
+
+**Rule**: S = highest-tier source that contained relevant result. Not found → 0.0 regardless of C_offset.
+
+Also calculate `coverage`: how many of 5 dimensions were searched.
+- `oracle`, `files`, `git`, `cross-repo`, `github` — list which were checked.
+
+---
+
+## Step 4: Goal-Backward Check (GSD verifier-inspired)
+
+Before writing the trace log, ask:
+
+> "Did this trace actually answer the original question?"
+
+- **Yes** → confidence: high
+- **Partial** (found related but not exact) → confidence: medium — note what's missing
+- **No** → confidence: low — note what next step is needed
+
+This prevents "found something → assume done". Omar stops here. Never crosses into deciding for jeera-p.
+
+---
+
+## Step 5: Write Trace Log
 
 ```markdown
 ---
@@ -162,12 +258,15 @@ query: "[query]"
 target: "[TARGET_NAME]"
 mode: [oracle|smart|deep]
 timestamp: YYYY-MM-DD HH:MM
+friction_score: [0.0–1.0]
+coverage: [oracle, files, git, cross-repo, github]
+confidence: [high|medium|low]
 ---
 
 # Trace: [query]
 
 **Target**: [TARGET_NAME]
-**Mode**: [mode]
+**Mode**: [mode] | **Friction**: [score] | **Confidence**: [level]
 **Time**: [timestamp]
 
 ## Oracle Results
@@ -188,29 +287,66 @@ timestamp: YYYY-MM-DD HH:MM
 ## Oracle Memory
 [list or "None"]
 
+## Friction Analysis
+**Score**: [0.0–1.0] — [interpretation]
+**Coverage**: [dimensions searched]
+**Goal check**: [Did this answer the question? What's missing?]
+
 ## Summary
 [Key findings, next steps]
 ```
 
 ---
 
-## Step 4: Log to Oracle MCP
+## Step 6: Log to Oracle MCP
 
 ```
-oracle_trace({
+arra_trace({
   query: "[query]",
   project: "[TARGET_NAME]",
   foundFiles: [...],
   foundCommits: [...],
-  foundIssues: [...]
+  foundIssues: [...],
+  friction_score: [0.0–1.0],
+  confidence: "[high|medium|low]"
 })
 ```
 
 ---
 
+## Friction Score Reference
+
+```
+friction_score = S + C_offset    (clamped to [0.0, 1.0])
+
+1.0 ████████████  Frictionless   — Oracle + high confidence
+0.9 ███████████░  Near-perfect   — Oracle + medium confidence
+0.7 ████████░░░░  Visible        — Files + high confidence
+0.6 ███████░░░░░  Slightly buried — Files + medium confidence
+0.5 ██████░░░░░░  Buried         — Git + high confidence
+0.4 █████░░░░░░░  Buried-medium  — Git + medium confidence
+0.3 ████░░░░░░░░  Hidden         — Cross-repo + high confidence
+0.2 ███░░░░░░░░░  Very hidden    — Cross-repo + medium confidence
+0.0 ░░░░░░░░░░░░  Invisible      — Not found anywhere
+```
+
+**Actionable zones**:
+| Range | Action |
+|-------|--------|
+| 0.9–1.0 | No action needed |
+| 0.6–0.89 | Consider `oracle_learn` indexing |
+| 0.4–0.59 | Distill + index this session |
+| 0.1–0.39 | Cross-repo consolidation needed |
+| 0.0 | Create / document |
+
+**Low score = signal**: this topic needs better indexing, documentation, or creation.
+Omar surfaces this. jeera-p decides what to do about it.
+
+---
+
 ## Philosophy
 
-> Trace → Dig → Trace Deeper → Distill → Awakening
+> Trace → Measure → Distill → Awakening
 
 ### The Seeking Signal
 
@@ -218,33 +354,35 @@ oracle_trace({
 |-------------|---------|-------------|
 | `/trace X` | First search | --smart (Oracle first) |
 | `/trace X` again | Still seeking | Oracle knows |
-| `/trace X --deep` | Really need it | Go deep with subagents |
-| Found! | **RESONANCE** | Log to Oracle |
+| `/trace X --deep` | Really need it | Wave execution |
+| Found! | **RESONANCE** | Log + score |
 
 ### Skill Separation
 
 | Skill | Purpose | Writes to |
 |-------|---------|-----------|
-| `/trace` | Find things | ψ/memory/traces/ (logs) |
+| `/trace` | Find + measure | ψ/memory/traces/ (logs) |
 | `/dig` | Mine sessions | Screen only (read-only) |
 | `/learn` | Study repos | ψ/learn/ (docs) |
 | `/project` | Develop repos | ψ/incubate/ or active/ |
 
-**Workflow**: `/trace` finds → `/learn` studies → `/project` develops
+**Workflow**: `/trace` finds + measures → `/learn` studies → `/project` develops
 
 ---
 
 ## Summary
 
-| Mode | Speed | Scope | Auto-Escalate |
-|------|-------|-------|---------------|
-| `--oracle` | Fast | Oracle only | No |
-| `--smart` | Medium | Oracle → maybe deep | Yes (< 3 results) |
-| `--deep` | Thorough | 5 parallel agents | N/A |
-| Flag | Effect |
-|------|--------|
-| `--repo [path]` | Search specific local repo |
-| `--repo [url]` | Clone to ghq, then search |
+| Mode | Speed | Scope | Waves |
+|------|-------|-------|-------|
+| `--oracle` | Fast | Oracle only | — |
+| `--smart` | Medium | Oracle → maybe deep | Auto |
+| `--deep` | Thorough | Wave 1 + Wave 2 if needed | 2 |
+
+| Output field | Description |
+|-------------|-------------|
+| `friction_score` | 0.0–1.0 how hard to find |
+| `coverage` | dimensions searched |
+| `confidence` | did trace answer the question |
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace 5-parallel-agents `--deep` with **2-wave execution** (Wave 1 fast surface → Wave 2 deep only if insufficient) — reduces unnecessary agent calls
- Add **friction_score formula v2**: `S + C_offset` (clamped 0.0–1.0) — makes "how hard was this to find" measurable
- Add **goal-backward check**: after search, verify "did this actually answer the question?" → confidence: high/medium/low
- Fix: `oracle_search` → `arra_search` (correct MCP tool name)
- Slogan update: "Find + **Measure** + Log + Distill"

## Test plan

- [ ] `/trace [query]` — default smart mode still works
- [ ] `/trace [query] --deep` — runs Wave 1 first, Wave 2 only if < 3 results
- [ ] friction_score appears in trace log output
- [ ] goal-backward check produces confidence field
- [ ] `arra_search` resolves correctly (was `oracle_search`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)