### PR TITLE
feat: default install to Claude Code + Codex (v3.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oracle-skills",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -148,10 +148,20 @@ export const agents: Record<AgentType, AgentConfig> = {
   },
 };
 
+/** Default agents to install to (unless --agent overrides) */
+export const defaultAgentNames = ['claude-code', 'codex'];
+
 export function detectInstalledAgents(): string[] {
   return Object.entries(agents)
     .filter(([_, config]) => config.detectInstalled())
     .map(([name]) => name);
+}
+
+/** Get default agents (installed subset of defaultAgentNames, fallback to all) */
+export function getDefaultAgents(): string[] {
+  const installed = detectInstalledAgents();
+  const defaults = defaultAgentNames.filter((a) => installed.includes(a));
+  return defaults.length > 0 ? defaults : installed;
 }
 
 export function getAgentNames(): string[] {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander';
 import * as p from '@clack/prompts';
-import { agents, detectInstalledAgents } from '../agents.js';
+import { agents, getDefaultAgents } from '../agents.js';
 import { installSkills } from '../installer.js';
 import { profiles } from '../../profiles.js';
 
@@ -21,7 +21,7 @@ export function registerInit(program: Command, version: string) {
           return;
         }
 
-        const detected = detectInstalledAgents();
+        const detected = getDefaultAgents();
         if (detected.length === 0) {
           p.log.error('No agents detected. Install Claude Code, Codex, or another supported agent first.');
           return;

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander';
 import * as p from '@clack/prompts';
-import { agents, detectInstalledAgents, getAgentNames } from '../agents.js';
+import { agents, getDefaultAgents, getAgentNames } from '../agents.js';
 import { listSkills, installSkills } from '../installer.js';
 import { profiles, features as featuresDef } from '../../profiles.js';
 import type { ShellMode } from '../fs-utils.js';
@@ -32,7 +32,7 @@ export function registerInstall(program: Command, version: string) {
         let targetAgents: string[] = options.agent || [];
 
         if (targetAgents.length === 0) {
-          const detected = detectInstalledAgents();
+          const detected = getDefaultAgents();
 
           if (detected.length > 0) {
             p.log.info(`Detected agents: ${detected.map((a) => agents[a as keyof typeof agents]?.displayName).join(', ')}`);


### PR DESCRIPTION
Default agents: Claude Code + Codex. Fallback to all detected if neither installed. Use --agent to override.