### PR TITLE
feat: restore /dig skill — session goldminer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-arra-oracle-skills
 
-23 skills for AI coding agents. Compatible with 43+ agents via [Vercel Skills CLI](https://github.com/vercel-labs/skills).
+24 skills for AI coding agents. Compatible with 43+ agents via [Vercel Skills CLI](https://github.com/vercel-labs/skills).
 
 ## Install
 
@@ -37,7 +37,7 @@ arra-oracle-skills uninstall -g -y         # remove all
 | Profile | Count | Skills |
 |---------|-------|--------|
 | **standard** | 17 | `forward`, `retrospective`, `rrr`, `recap`, `standup`, `trace`, `learn`, `talk-to`, `oracle-family-scan`, `go`, `about-oracle`, `oracle-soul-sync-update`, `awaken`, `inbox`, `xray`, `create-shortcut`, `contacts` |
-| **full** | 23 | all |
+| **full** | 24 | all |
 
 Switch anytime: `/go minimal`, `/go standard`, `/go full`, `/go + soul`
 
@@ -69,19 +69,20 @@ Switch anytime: `/go minimal`, `/go standard`, `/go full`, `/go + soul`
 | 8 | **awaken** | skill | Guided Oracle birth and awakening ritual |
 | 9 | **contacts** | skill | Manage Oracle contacts |
 | 10 | **create-shortcut** | skill | Create local skills as shortcuts |
-| 11 | **forward** | skill | Create handoff + enter plan mode for next |
-| 12 | **go** | skill | 'Switch skill profiles and features |
-| 13 | **inbox** | skill | Read and write to Oracle inbox |
-| 14 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
-| 15 | **philosophy** | skill | Display Oracle philosophy |
-| 16 | **retrospective** | skill | Quick session retrospective |
-| 17 | **rrr** | skill | Quick session retrospective (alias for |
-| 18 | **standup** | skill | Daily standup check |
-| 19 | **talk-to** | skill | Talk to another Oracle agent via threads |
-| 20 | **trace** | skill | v3.3.1 G-SKLL | Find projects, code |
-| 21 | **where-we-are** | skill | Session awareness |
-| 22 | **who-are-you** | skill | Know ourselves |
-| 23 | **xray** | skill | X-ray deep scan |
+| 11 | **dig** | skill | Mine Claude Code sessions |
+| 12 | **forward** | skill | Create handoff + enter plan mode for next |
+| 13 | **go** | skill | 'Switch skill profiles and features |
+| 14 | **inbox** | skill | Read and write to Oracle inbox |
+| 15 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
+| 16 | **philosophy** | skill | Display Oracle philosophy |
+| 17 | **retrospective** | skill | Quick session retrospective |
+| 18 | **rrr** | skill | Quick session retrospective (alias for |
+| 19 | **standup** | skill | Daily standup check |
+| 20 | **talk-to** | skill | Talk to another Oracle agent via threads |
+| 21 | **trace** | skill | v3.3.1 G-SKLL | Find projects, code |
+| 22 | **where-we-are** | skill | Session awareness |
+| 23 | **who-are-you** | skill | Know ourselves |
+| 24 | **xray** | skill | X-ray deep scan |
 
 <!-- skills:end -->
 

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -8,7 +8,7 @@ const ALL_SKILLS = [
   'oracle-soul-sync-update',
   'schedule', 'project',
   'where-we-are', 'auto-retrospective',
-  'inbox', 'xray', 'create-shortcut', 'rrr', 'contacts',
+  'inbox', 'xray', 'create-shortcut', 'rrr', 'contacts', 'dig',
 ];
 
 describe("profiles", () => {
@@ -16,10 +16,10 @@ describe("profiles", () => {
     expect(Object.keys(profiles)).toEqual(['seed', 'standard', 'full']);
   });
 
-  it("seed has 11 skills", () => {
+  it("seed has 12 skills", () => {
     const result = resolveProfile("seed", ALL_SKILLS);
-    expect(result).toEqual(['forward', 'retrospective', 'rrr', 'recap', 'standup', 'go', 'about-oracle', 'oracle-family-scan', 'oracle-soul-sync-update', 'inbox', 'xray']);
-    expect(result?.length).toBe(11);
+    expect(result).toEqual(['forward', 'retrospective', 'rrr', 'recap', 'standup', 'go', 'about-oracle', 'oracle-family-scan', 'oracle-soul-sync-update', 'inbox', 'xray', 'dig']);
+    expect(result?.length).toBe(12);
   });
 
   it("standard has 15 skills", () => {
@@ -71,8 +71,8 @@ describe("features", () => {
 describe("resolveProfileWithFeatures", () => {
   it("seed + soul = 14 skills", () => {
     const result = resolveProfileWithFeatures("seed", ["soul"], ALL_SKILLS);
-    // 11 seed + 4 soul - 1 overlap (about-oracle) = 14
-    expect(result.length).toBe(14);
+    // 12 seed + 4 soul - 1 overlap (about-oracle) = 15
+    expect(result.length).toBe(15);
     expect(result).toContain('forward');
     expect(result).toContain('awaken');
     expect(result).toContain('philosophy');
@@ -88,8 +88,8 @@ describe("resolveProfileWithFeatures", () => {
 
   it("seed + workspace = 13 skills", () => {
     const result = resolveProfileWithFeatures("seed", ["workspace"], ALL_SKILLS);
-    // 11 + 2 = 13
-    expect(result.length).toBe(13);
+    // 12 + 2 = 14
+    expect(result.length).toBe(14);
     expect(result).toContain('schedule');
     expect(result).toContain('project');
   });
@@ -101,14 +101,14 @@ describe("resolveProfileWithFeatures", () => {
 
   it("multiple features stack", () => {
     const result = resolveProfileWithFeatures("seed", ["soul", "workspace"], ALL_SKILLS);
-    // 11 + 4 + 2 - 1 (about-oracle overlap) = 16
-    expect(result.length).toBe(16);
+    // 12 + 4 + 2 - 1 (about-oracle overlap) = 17
+    expect(result.length).toBe(17);
     expect(result).toContain('awaken');
     expect(result).toContain('schedule');
   });
 
   it("empty features = just profile", () => {
     const result = resolveProfileWithFeatures("seed", [], ALL_SKILLS);
-    expect(result.length).toBe(11);
+    expect(result.length).toBe(12);
   });
 });

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -7,7 +7,7 @@
 
 export const profiles: Record<string, { include?: string[]; exclude?: string[] }> = {
   seed: {
-    include: ['forward', 'retrospective', 'rrr', 'recap', 'standup', 'go', 'about-oracle', 'oracle-family-scan', 'oracle-soul-sync-update', 'inbox', 'xray'],
+    include: ['forward', 'retrospective', 'rrr', 'recap', 'standup', 'go', 'about-oracle', 'oracle-family-scan', 'oracle-soul-sync-update', 'inbox', 'xray', 'dig'],
   },
   standard: {
     include: [

--- a/src/skills/dig/SKILL.md
+++ b/src/skills/dig/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: dig
+description: Mine Claude Code sessions — timeline, gaps, repo attribution, session history. Use when user says "dig", "sessions", "past sessions", "timeline", "what did I work on", or wants to see session history. Do NOT trigger for finding code/projects (use /trace), exploring repos (use /learn), or current session status (use /recap).
+argument-hint: "[N] | --all | --timeline"
+---
+
+# /dig - Session Goldminer
+
+Mine Claude Code session data for timelines, gaps, and repo attribution. No query needed.
+
+## Usage
+
+```
+/dig                    # Current repo, 10 most recent
+/dig [N]                # Current repo, N most recent
+/dig --all              # All repos, ALL sessions (auto-detect count)
+/dig --all [N]          # All repos, N most recent
+/dig --timeline         # Day-by-day grouped (current repo)
+/dig --all --timeline   # Day-by-day grouped (all repos, ALL sessions)
+```
+
+## Step 0: Timestamp
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+```
+
+---
+
+## Step 1: Discover Project Dirs
+
+**Default** (current repo only):
+```bash
+ENCODED_PWD=$(pwd | sed 's|^/|-|; s|/|-|g')
+PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
+export PROJECT_DIRS="$PROJECT_BASE"
+for wt in "$HOME/.claude/projects/${ENCODED_PWD}"-wt*; do [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"; done
+```
+
+Encodes `pwd` the same way Claude does (replace `/` with `-`, prepend `-`) to match the `.claude/projects/` directory naming. Also picks up worktree dirs (`-wt`, `-wt-1`, etc.).
+
+**With `--all`** (all repos):
+```bash
+export PROJECT_DIRS=$(ls -d "$HOME/.claude/projects/"*/ | tr '\n' ':')
+```
+
+## Step 2: Extract Session Data
+
+Run the dig script. Pass `0` for `--all` (no limit), or N if user specified a count, default 10:
+
+```bash
+python3 ~/.claude/skills/dig/scripts/dig.py [N]
+# N=10 (default), N=0 (scan all sessions), N=50 (50 most recent)
+```
+
+## Step 3: Display Timeline
+
+Read the JSON output and display as a table. Sessions are chronological (oldest first). Gap rows (`type: "gap"`) span the session column with `· · ·` prefix:
+
+```markdown
+## Session Timeline
+
+| # | Date | Session | Min | Repo | Msgs | Focus |
+|---|------|---------|-----|------|------|-------|
+|   |      | · · · sleeping / offline | | | | |
+| 1 | 02-21 | 08:40–09:08 | 28m | oracle-skills-cli | 5 | Wire /rrr to read pulse data |
+|   |      | · · · 45m gap | | | | |
+| 2 | 02-21 | 09:55–10:23 | 28m | homelab | 3 | oracle-pulse birth + CLI flag |
+|   |      | · · · no session yet | | | | |
+
+**Dirs scanned**: [list PROJECT_DIRS]
+**Total sessions found**: [count]
+```
+
+Column rendering rules:
+- **Gap rows**: `|   |      | · · · [label] | | | | |` — number + date empty, label in Session col
+- **Date**: `MM-DD` short format (strip year)
+- **Session**: `HH:MM–HH:MM` using `startGMT7` and `endGMT7` (strip date, keep time only)
+- **Min**: `[durationMin]m`
+- **Repo**: use `repoName` field from dig.py output (resolved via ghq)
+- **Msgs**: `realHumanMessages` count
+
+"Msgs" = real typed human messages (not tool approvals).
+
+---
+
+## With --timeline: Group by Date
+
+When `--timeline` flag is present, group sessions by date instead of a flat table. Use `--all` to see all repos (recommended for timeline).
+
+**Step 1**: Run dig.py with `0` for `--all` (scans all sessions), or user-specified count
+
+**Step 2**: Group sessions by date from `startGMT7`. Render each day as:
+
+```markdown
+## Feb 22 (Sun) — [vibe label]
+
+                  · · ·   sleeping / offline
+08:48–09:11    23m   homelab        Update Fleet Runbook + Explore black.local
+09:11–11:30   139m   homelab        Set Up KVM OpenClaw Node on black.local
+09:37–12:51   194m   Nat-s-Agents   /recap → supergateway → CF ZT → arra-oracle-v3 dig
+                  · · ·   45m gap
+12:51–13:03    12m   Nat-s-Agents   Dig All + Design arra-oracle-v3 ← current
+                  · · ·   no session yet
+
+## Feb 21 (Sat) — Long day: Fleet + Brewing + Skills
+
+06:19–08:38   139m   homelab        Moltworker Gateway + MBP Node
+08:40           (bg)  openclaw       ClawHub Build Script (idle long)
+09:23–16:08   405m   homelab        Debug MBP Node 401 — Gateway Token Auth
+```
+
+**Rendering rules**:
+- **Day header**: `## MMM DD (Day) — [vibe label]` — infer vibe from session summaries (e.g. "Infrastructure Day", "Brewing + Skills")
+- **Session rows**: `HH:MM–HH:MM  [N]m  REPO  Summary` — use `repoName` for repo, `summary` for focus
+- **Gap rows**: `· · ·  [label]` between sessions when gap > 30 min
+- **Sidechain**: prefix `(bg)` for sessions with `isSidechain: true`
+- **Current**: append `← current` marker on the last session of the current day (today only)
+- **Sort**: days newest-first, sessions within each day oldest-first (chronological)
+- **Date format**: `startGMT7` time portion only (HH:MM), `endGMT7` time portion (HH:MM)
+- **Repo width**: pad repo names to align columns
+
+**Step 3**: Show summary footer:
+```markdown
+**Days**: [count] | **Sessions**: [count] | **Total time**: [sum of durationMin]m
+```
+
+---
+
+## Trace Connection
+
+After displaying the timeline, log the discovery to Oracle so it's searchable later:
+
+```
+arra_trace({
+  query: "dig session [N]",
+  project: "[repo-name]",
+  foundFiles: [],
+  foundCommits: [list of commit hashes from timeline],
+  foundIssues: []
+})
+```
+
+This connects `/dig` discoveries to `/trace` — "When did we first work on X?" becomes answerable.
+
+---
+
+ARGUMENTS: $ARGUMENTS

--- a/src/skills/dig/scripts/dig.py
+++ b/src/skills/dig/scripts/dig.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Session goldminer — scan Claude Code .jsonl files for session timeline."""
+import json, os, glob, sys, subprocess, re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+project_dirs = [d for d in os.environ.get('PROJECT_DIRS', '').split(':') if d]
+count = int(sys.argv[1]) if len(sys.argv) > 1 else 10  # 0 = no limit (scan all)
+bkk = timedelta(hours=7)
+
+def build_repo_map():
+    mapping = {}
+    try:
+        r = subprocess.run(['ghq', 'list', '-p'], capture_output=True, text=True, timeout=5)
+        for path in r.stdout.strip().split('\n'):
+            if path:
+                mapping[path.replace('/', '-')] = path.split('/')[-1]
+    except: pass
+    return mapping
+
+def get_repo_name(project_dir, repo_map):
+    base = os.path.basename(project_dir.rstrip('/'))
+    clean = re.sub(r'-wt-\d+$', '', base)   # strip -wt-1, -wt-8 etc
+    return repo_map.get(clean) or clean.split('-')[-1] or clean
+
+repo_map = build_repo_map()
+
+# Get .jsonl files across all project dirs, deduplicate by basename, take N most recent
+seen = {}
+for d in project_dirs:
+    for f in glob.glob(os.path.join(d, '*.jsonl')):
+        base = os.path.basename(f)
+        if base not in seen or os.path.getmtime(f) > os.path.getmtime(seen[base][0]):
+            seen[base] = (f, d)   # store (filepath, project_dir) tuple
+all_files = [(fp, d) for fp, d in seen.values()]
+files = sorted(all_files, key=lambda x: os.path.getmtime(x[0]), reverse=True)
+if count > 0:
+    files = files[:count]
+
+# Load sessions-index from all dirs
+index_map = {}
+for d in project_dirs:
+    try:
+        with open(os.path.join(d, 'sessions-index.json')) as f:
+            for e in json.load(f).get('entries', []):
+                index_map[e['sessionId']] = e
+    except: pass
+
+sessions = []
+for fp, source_dir in files:
+    sid = os.path.basename(fp).replace('.jsonl', '')
+    first_ts = last_ts = None
+    branch = summary_text = None
+    is_sidechain = False
+    real_human = []
+    assistant_count = 0
+
+    with open(fp) as fh:
+        for line in fh:
+            try: obj = json.loads(line)
+            except: continue
+            ts = obj.get('timestamp')
+            if ts:
+                if not first_ts or ts < first_ts: first_ts = ts
+                if not last_ts or ts > last_ts: last_ts = ts
+            t = obj.get('type', '')
+            if t == 'summary':
+                summary_text = obj.get('summary', '')
+                branch = obj.get('gitBranch', '')
+                is_sidechain = obj.get('isSidechain', False)
+            elif t == 'assistant':
+                assistant_count += 1
+            elif t == 'user':
+                msg = obj.get('message', {})
+                content = msg.get('content', [])
+                text = ''
+                if isinstance(content, list):
+                    for c in content:
+                        if isinstance(c, dict) and c.get('type') == 'text':
+                            text = c.get('text', '').strip()
+                            break
+                elif isinstance(content, str):
+                    text = content.strip()
+                if text and len(text) > 5 and not text.startswith('[Request interrupted'):
+                    real_human.append(text[:80])
+
+    if not first_ts: continue
+
+    # Convert timestamps to GMT+7
+    def to_gmt7(iso):
+        try:
+            dt = datetime.fromisoformat(iso.replace('Z', '+00:00'))
+            return (dt + bkk).strftime('%Y-%m-%d %H:%M')
+        except: return iso
+
+    dur_min = 0
+    if first_ts and last_ts:
+        try:
+            t1 = datetime.fromisoformat(first_ts.replace('Z', '+00:00'))
+            t2 = datetime.fromisoformat(last_ts.replace('Z', '+00:00'))
+            dur_min = int((t2 - t1).total_seconds() / 60)
+        except: pass
+
+    # Prefer index summary over first prompt
+    idx = index_map.get(sid, {})
+    final_summary = idx.get('summary') or summary_text or (real_human[0] if real_human else 'No summary')
+    final_branch = branch or idx.get('gitBranch') or 'unknown'
+
+    sessions.append({
+        'sessionId': sid[:12],
+        'repoName': get_repo_name(source_dir, repo_map),
+        'startGMT7': to_gmt7(first_ts),
+        'endGMT7': to_gmt7(last_ts),
+        'durationMin': dur_min,
+        'realHumanMessages': len(real_human),
+        'assistantMessages': assistant_count,
+        'firstPrompt': real_human[0] if real_human else None,
+        'gitBranch': final_branch,
+        'summary': final_summary[:80],
+        'isSidechain': is_sidechain,
+    })
+
+sessions.sort(key=lambda s: s['startGMT7'])  # chronological (oldest first)
+
+GAP_THRESHOLD = 30  # minutes
+
+def parse_gmt7(s):
+    try: return datetime.strptime(s, '%Y-%m-%d %H:%M')
+    except: return None
+
+with_gaps = []
+for i, s in enumerate(sessions):
+    if i == 0:
+        with_gaps.append({"type": "gap", "label": "sleeping / offline"})
+    else:
+        prev_end = parse_gmt7(sessions[i-1]['endGMT7'])
+        curr_start = parse_gmt7(s['startGMT7'])
+        if prev_end and curr_start:
+            gap_min = int((curr_start - prev_end).total_seconds() / 60)
+            if gap_min > GAP_THRESHOLD:
+                with_gaps.append({"type": "gap", "gapMin": gap_min, "label": f"{gap_min}m gap"})
+    with_gaps.append(s)
+with_gaps.append({"type": "gap", "label": "no session yet"})
+
+print(json.dumps(with_gaps, indent=2))


### PR DESCRIPTION
## Summary
- Restored `/dig` skill (SKILL.md + scripts/dig.py) from before deletion in commit 01e44a8
- Added `dig` to the `seed` profile in profiles.ts — it's a core tool every Oracle needs
- Updated test expectations to reflect 12 skills in seed (was 11)

## Test plan
- [x] All 106 tests pass (0 failures)
- [x] Pre-commit hook (lefthook) passes
- [x] README auto-updated by hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)