### PR TITLE
fix: uninstall preserves external skills

### DIFF
--- a/__tests__/e2e-install.test.ts
+++ b/__tests__/e2e-install.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { readdir, readFile, rm, mkdir } from "fs/promises";
+import { readdir, readFile, rm, mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 import { tmpdir } from "os";
@@ -197,6 +197,72 @@ describe("e2e: uninstall full", () => {
 
     const commands = await listCommandFiles(COMMANDS_DIR);
     expect(commands.length).toBe(0);
+  });
+});
+
+describe("e2e: uninstall preserves external skills", () => {
+  it("skips skills without installer marker", async () => {
+    // Install oracle skills normally
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "seed",
+      yes: true,
+    });
+
+    // Create an external skill (no installer marker)
+    const externalDir = join(SKILLS_DIR, "external-skill");
+    await mkdir(externalDir, { recursive: true });
+    await writeFile(
+      join(externalDir, "SKILL.md"),
+      "# External Skill\n\nInstalled by another tool."
+    );
+
+    // Uninstall (without -s flag = remove all)
+    const result = await uninstallSkills([TEST_AGENT], {
+      global: true,
+      yes: true,
+    });
+
+    // External skill should survive
+    expect(existsSync(externalDir)).toBe(true);
+    expect(existsSync(join(externalDir, "SKILL.md"))).toBe(true);
+
+    // Oracle skills should be removed
+    const remaining = await listSkillDirs(SKILLS_DIR);
+    expect(remaining).toEqual(["external-skill"]);
+
+    // Cleanup
+    await rm(externalDir, { recursive: true });
+  });
+
+  it("removes explicitly named external skills with -s flag", async () => {
+    // Install oracle skills
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "seed",
+      yes: true,
+    });
+
+    // Create an external skill
+    const externalDir = join(SKILLS_DIR, "my-custom-skill");
+    await mkdir(externalDir, { recursive: true });
+    await writeFile(
+      join(externalDir, "SKILL.md"),
+      "# Custom\n\nNo marker."
+    );
+
+    // Uninstall with explicit -s flag (should remove even without marker)
+    await uninstallSkills([TEST_AGENT], {
+      global: true,
+      skills: ["my-custom-skill"],
+      yes: true,
+    });
+
+    // Explicitly named skill should be removed
+    expect(existsSync(externalDir)).toBe(false);
+
+    // Cleanup remaining oracle skills
+    await uninstallSkills([TEST_AGENT], { global: true, yes: true });
   });
 });
 

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -509,8 +509,16 @@ export async function uninstallSkills(
     if (toRemove.length === 0) continue;
 
     // Remove skills
+    let skipped = 0;
     for (const skill of toRemove) {
       const skillPath = join(targetDir, skill);
+
+      // When removing all skills (no -s flag), only remove our own
+      if (!options.skills && !await isOurSkill(skillPath)) {
+        skipped++;
+        continue;
+      }
+
       await rmrf(skillPath, shellMode);
 
       // Clean up commands/ flat files (OpenCode, Claude Code, Gemini, etc.)
@@ -537,8 +545,11 @@ export async function uninstallSkills(
       totalRemoved++;
     }
 
+    if (skipped > 0) {
+      p.log.info(`${agent.displayName}: skipped ${skipped} external skills`);
+    }
     agentsProcessed++;
-    p.log.success(`${agent.displayName}: removed ${toRemove.length} skills`);
+    p.log.success(`${agent.displayName}: removed ${toRemove.length - skipped} skills`);
   }
 
   return { removed: totalRemoved, agents: agentsProcessed };


### PR DESCRIPTION
## Summary

- `uninstallSkills()` now checks `isOurSkill()` before removing skill directories
- Only skills with the `installer: arra-oracle-skills-cli` marker are removed during bulk uninstall (`-g -y`)
- Explicit `-s skill-name` still removes any named skill (respects user intent)

## Problem

Running `oracle-skills uninstall -g -y` deletes ALL skill directories — including those installed manually or by other tools. This caused 18 manually-installed skills to be permanently lost during a `/oracle-soul-sync-update` cleanup cycle.

The `isOurSkill()` guard already exists and is used in the **install** orphan cleanup (line 156), but was missing from the **uninstall** function.

## Changes

- `src/cli/installer.ts` — added `isOurSkill()` check in uninstall loop (5 lines)
- `__tests__/e2e-install.test.ts` — 2 new tests: external skill preservation + explicit `-s` override

## Test plan

- [x] `bun test __tests__/e2e-install.test.ts` — 14/14 pass
- [ ] CI full test suite

> **Note**: 3 pre-existing failures in `integration.test.ts` (OpenCode global install reads stale v2.0.10 data from `~/.config/opencode/skills/`) — unrelated to this change.