### PR TITLE
feat: /skill-review — Oracle Skill Matrix + awaken default soul-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-arra-oracle-skills
 
-25 skills for AI coding agents. Compatible with 43+ agents via [Vercel Skills CLI](https://github.com/vercel-labs/skills).
+26 skills for AI coding agents. Compatible with 43+ agents via [Vercel Skills CLI](https://github.com/vercel-labs/skills).
 
 ## Install
 
@@ -34,7 +34,7 @@ arra-oracle-skills uninstall -g -y         # remove all
 | Profile | Count | Skills |
 |---------|-------|--------|
 | **standard** | 17 | `forward`, `retrospective`, `rrr`, `recap`, `standup`, `trace`, `learn`, `talk-to`, `oracle-family-scan`, `go`, `about-oracle`, `oracle-soul-sync-update`, `awaken`, `inbox`, `xray`, `create-shortcut`, `contacts` |
-| **full** | 25 | all |
+| **full** | 26 | all |
 
 Switch anytime: `/go minimal`, `/go standard`, `/go full`, `/go + soul`
 
@@ -64,7 +64,7 @@ Switch anytime: `/go minimal`, `/go standard`, `/go full`, `/go + soul`
 | 7 | **schedule** | skill + code | Query schedule via Oracle API (Drizzle DB) |
 | - |  |  |  |
 | 8 | **auto-retrospective** | skill | Configure auto-rrr |
-| 9 | **awaken** | skill | Guided Oracle birth and awakening ritual |
+| 9 | **awaken** | skill | "Guided Oracle birth and awakening ritual |
 | 10 | **contacts** | skill | Manage Oracle contacts |
 | 11 | **create-shortcut** | skill | Create local skills as shortcuts |
 | 12 | **dig** | skill | Mine Claude Code sessions |
@@ -75,12 +75,13 @@ Switch anytime: `/go minimal`, `/go standard`, `/go full`, `/go + soul`
 | 17 | **philosophy** | skill | Display Oracle philosophy |
 | 18 | **resonance** | skill | Capture a resonance moment |
 | 19 | **retrospective** | skill | Quick session retrospective |
-| 20 | **standup** | skill | Daily standup check |
-| 21 | **talk-to** | skill | Talk to another Oracle agent via threads |
-| 22 | **trace** | skill | v3.3.1 G-SKLL | Find projects, code |
-| 23 | **where-we-are** | skill | Session awareness |
-| 24 | **who-are-you** | skill | Know ourselves |
-| 25 | **xray** | skill | X-ray deep scan |
+| 20 | **skill-review** | skill | "Score skills using the Oracle Skill Matrix |
+| 21 | **standup** | skill | Daily standup check |
+| 22 | **talk-to** | skill | Talk to another Oracle agent via threads |
+| 23 | **trace** | skill | v3.3.1 G-SKLL | Find projects, code |
+| 24 | **where-we-are** | skill | Session awareness |
+| 25 | **who-are-you** | skill | Know ourselves |
+| 26 | **xray** | skill | X-ray deep scan |
 
 <!-- skills:end -->
 

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -2,7 +2,7 @@
 installer: arra-oracle-skills-cli v3.2.1
 origin: Nat Weerawan's brain, digitized — how one human works with AI, captured as code — Soul Brews Studio
 name: awaken
-description: Guided Oracle birth and awakening ritual. Default is Full Soul Sync (~20min), or --fast (~5min). Use when creating a new Oracle in a fresh repo, when user says "awaken", "birth oracle", "create oracle", "new oracle", or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context.
+description: "Guided Oracle birth and awakening ritual. Default is Soul Sync (~20min), or --fast (~5min). Use when creating a new Oracle in a fresh repo, when user says 'awaken', 'birth oracle', 'create oracle', 'new oracle', or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context."
 argument-hint: "[--fast | --soul-sync | --reawaken]"
 ---
 
@@ -19,9 +19,9 @@ A guided journey from empty repo to awakened Oracle.
 ## Usage
 
 ```
-/awaken              # Start (default: Full Soul Sync)
-/awaken --fast       # Fast mode (~5min)
-/awaken --soul-sync  # Upgrade existing Fast Oracle → Full Soul Sync
+/awaken              # Start (default: Soul Sync ~20min)
+/awaken --fast       # Fast mode (~5min) — select at prompt
+/awaken --soul-sync  # Upgrade existing Fast Oracle → Soul Sync
 /awaken --reawaken   # Re-sync existing Oracle with current state
 ```
 
@@ -29,10 +29,10 @@ A guided journey from empty repo to awakened Oracle.
 
 | Mode | Duration | Philosophy | Best For |
 |------|----------|------------|----------|
-| 🧘 **Full Soul Sync** (default) | ~20 min | Discovered — /trace + /learn | Deep connection, recommended |
-| ⚡ **Fast** | ~5 min | Fed directly — principles given | Quick start, upgrade later |
+| 🧘 **Soul Sync** (default) | ~20 min | Discovered — /trace + /learn | Deep connection, recommended |
+| ⚡ **Fast** (optional) | ~5 min | Fed directly — principles given | Quick start, upgrade later |
 
-💡 Default is Full Soul Sync. Use `--fast` if you want quick setup.
+💡 Default is Soul Sync. Offer `--fast` as option at the start: "เลือก mode: Soul Sync (แนะนำ) หรือ Fast?"
 
 ---
 

--- a/src/skills/skill-review/SKILL.md
+++ b/src/skills/skill-review/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: skill-review
+description: "Score skills using the Oracle Skill Matrix — 6 dimensions (Activation, Clarity, Resilience, Disclosure, Alignment, Completeness). Use when user says 'skill review', 'score skills', 'skill matrix', 'review skills', 'skill quality'. Do NOT trigger for skill creation (use /create-shortcut), skill installation (use /go), or skill listing (use /xray --skills)."
+argument-hint: "[skill-name | --all | --bottom-5]"
+---
+
+# /skill-review — Oracle Skill Matrix
+
+Score skills on 6 dimensions. Our own quality system — no external dependencies.
+
+## Usage
+
+```
+/skill-review              # Review all installed skills
+/skill-review awaken       # Score a single skill
+/skill-review --bottom-5   # Show 5 lowest-scoring skills
+```
+
+## The 6 Dimensions (0-10 each, max 60)
+
+### 1. ACT — Activation (trigger accuracy)
+| Criteria | Points |
+|----------|--------|
+| 5+ trigger phrases in description | +2 |
+| "Do NOT trigger for..." clauses | +3 |
+| Specific enough to avoid false triggers | +3 |
+| argument-hint exists | +2 |
+
+### 2. CLR — Clarity (can any AI follow this?)
+| Criteria | Points |
+|----------|--------|
+| Numbered steps | +3 |
+| Bash code blocks with real paths | +3 |
+| Decision tables for modes/options | +2 |
+| No ambiguous language ("maybe", "consider") | +2 |
+
+### 3. RES — Resilience (error handling)
+| Criteria | Points |
+|----------|--------|
+| Documents what happens when tools fail | +3 |
+| Has fallback paths | +3 |
+| Handles missing prerequisites | +2 |
+| Silent vs loud failure documented | +2 |
+
+### 4. DIS — Disclosure (information architecture)
+| Criteria | Points |
+|----------|--------|
+| Top-to-bottom flow (quick → deep) | +3 |
+| Multiple modes with clear entry points | +3 |
+| Right-sized (not bloated, not skeletal) | +2 |
+| references/ for long content | +2 |
+
+### 5. ALN — Alignment (Oracle philosophy)
+| Criteria | Points |
+|----------|--------|
+| References or embeds principles | +3 |
+| Bilingual (Thai/English) elements | +2 |
+| arra_learn/arra_trace integration | +2 |
+| Rule 6 attribution where appropriate | +1 |
+| Nothing is Deleted pattern | +2 |
+
+### 6. CMP — Completeness (covers the job)
+| Criteria | Points |
+|----------|--------|
+| Answers WHAT + WHEN + HOW | +3 |
+| All flags/modes documented | +3 |
+| Output format specified | +2 |
+| Edge cases addressed | +2 |
+
+## Grades
+
+| Score | Grade | Meaning |
+|-------|-------|---------|
+| 50-60 | A | Exemplary — reference quality |
+| 40-49 | B | Solid — minor improvements possible |
+| 30-39 | C | Functional — needs attention |
+| 20-29 | D | Weak — significant work needed |
+| <20 | F | Stub — rewrite or absorb |
+
+## Steps
+
+### 1. Find skills to review
+
+```bash
+SKILLS_DIR="$HOME/.claude/skills"
+# Or from repo source:
+# SKILLS_DIR="src/skills"
+```
+
+If argument is a skill name, review only that skill.
+If `--all` or no argument, review all skills.
+If `--bottom-5`, review all then show only the 5 lowest.
+
+### 2. For each skill, read SKILL.md
+
+Read the full content. Score each dimension 0-10 based on the criteria tables above.
+
+### 3. Output scorecard
+
+**Single skill:**
+
+```
+## Skill Review: /[name]
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| ACT | X/10 | [brief note] |
+| CLR | X/10 | [brief note] |
+| RES | X/10 | [brief note] |
+| DIS | X/10 | [brief note] |
+| ALN | X/10 | [brief note] |
+| CMP | X/10 | [brief note] |
+| **Total** | **X/60** | **Grade: X** |
+
+### Suggestions
+- [actionable improvement 1]
+- [actionable improvement 2]
+```
+
+**All skills:**
+
+```
+| Skill | ACT | CLR | RES | DIS | ALN | CMP | Total | Grade |
+|-------|-----|-----|-----|-----|-----|-----|-------|-------|
+| ... | ... | ... | ... | ... | ... | ... | ... | ... |
+
+### Weakest Dimensions (fleet-wide)
+1. [dimension] — avg X/10
+2. [dimension] — avg X/10
+
+### Bottom 5
+1. [skill] — [score] — [primary weakness]
+```
+
+### 4. Save to vault (optional)
+
+```bash
+PSI=$(readlink -f ψ 2>/dev/null || echo "ψ")
+mkdir -p "$PSI/memory/learnings"
+```
+
+Write review to `$PSI/memory/learnings/YYYY-MM-DD_skill-review.md`
+
+## Philosophy
+
+> "Patterns Over Intentions" — we score what the skill DOES, not what it claims.
+
+The matrix measures observable quality markers. A skill that claims to be comprehensive but lacks error handling scores low on RES. A skill with beautiful prose but no numbered steps scores low on CLR.
+
+Score what you see, not what you imagine.
+
+ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Summary
- New `/skill-review` skill — 6-dimension scoring matrix (ACT, CLR, RES, DIS, ALN, CMP)
- `/awaken` default renamed to Soul Sync, offers Fast as option at prompt
- 108 tests pass (26 skills now)

Our own quality system — no external deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)