### PR TITLE
fix: remove stale metadata from source skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Switch anytime: `/go minimal`, `/go standard`, `/go full`, `/go + soul`
 | 18 | **resonance** | skill | Capture a resonance moment |
 | 19 | **standup** | skill | Daily standup check |
 | 20 | **talk-to** | skill | Talk to another Oracle agent via threads |
-| 21 | **trace** | skill | v3.3.1 G-SKLL | Find projects, code |
+| 21 | **trace** | skill | Find projects, code |
 | 22 | **where-we-are** | skill | Session awareness |
 | 23 | **who-are-you** | skill | Know ourselves |
 | 24 | **xray** | skill | X-ray deep scan |

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -1,6 +1,4 @@
 ---
-installer: arra-oracle-skills-cli v3.2.1
-origin: Nat Weerawan's brain, digitized — how one human works with AI, captured as code — Soul Brews Studio
 name: awaken
 description: "Guided Oracle birth and awakening ritual. Default is Soul Sync (~20min), or --fast (~5min). Use when creating a new Oracle in a fresh repo, when user says 'awaken', 'birth oracle', 'create oracle', 'new oracle', or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context."
 argument-hint: "[--fast | --soul-sync | --reawaken]"

--- a/src/skills/trace/SKILL.md
+++ b/src/skills/trace/SKILL.md
@@ -1,8 +1,6 @@
 ---
-installer: arra-oracle-skills-cli v3.3.0-alpha.10
-origin: Nat Weerawan's brain, digitized — how one human works with AI, captured as code — Soul Brews Studio
 name: trace
-description: v3.3.1 G-SKLL | Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (wave execution). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).
+description: Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (wave execution). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).
 argument-hint: "<query> [--oracle | --smart | --deep]"
 ---
 


### PR DESCRIPTION
trace had double version prefix, awaken had old installer stamp. 108 pass.