### PR TITLE
chore: v3.5.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "3.4.12",
+  "version": "3.5.0-alpha.1",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v3.5.0-alpha.1

### Since v3.4.10
- /resonance restored — capture what clicks (heart, not head)
- /rrr full version restored — timeline, dig, deep modes
- /awaken stamped growth files — full/fast/soul-sync
- /awaken default soul-sync, fast optional
- /awaken always Issue, never Discussion
- /skill-review Oracle Skill Matrix (internal only)
- /retrospective removed (absorbed by /rrr)
- Vercel Skills CLI path removed
- _template → .template
- __SKILL_DIR__ fixed with readlink
- Stale metadata cleaned from source skills
- PR #155 merged (community: uninstall preserves external skills)
- 7 Oracles welcomed by Neo (first time)
- 108 tests pass