### PR TITLE
release: v3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "3.5.0-alpha.4",
+  "version": "3.5.0",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v3.5.0

15 commits since v3.4.12. 108 tests pass.

### Highlights
- Default profile: standard (16 skills)
- Skills only by default, `--with-commands` opt-in
- Auto-publish to npm on GitHub release
- Generalized awaken announcements (no project internals)
- Birth Timeline in announcements
- Per-agent install (`--agent codex`)
- Removed Vercel Skills CLI path
- Removed generated command stubs from git
- Fixed stale metadata in source skills
- Fixed `__SKILL_DIR__` with readlink
- Renamed `_template` → `.template`
- /resonance restored
- /rrr full version restored
- /retrospective absorbed by /rrr (no dupes)
- /skill-review (internal only)
- 7 Oracles welcomed by Neo
- Repo name refs fixed
- README simplified