### PR TITLE
feat: simplify profiles — 3 tiers, remove features (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v3.6.0 (2026-04-05)
+
+### Simplify profiles (#196)
+
+**Profiles**: 3 tiers, no features.
+
+| Profile | Count | Description |
+|---------|-------|-------------|
+| **standard** | 16 | Daily driver — essential Oracle skills (default) |
+| **full** | 24 | Everything |
+| **lab** | 24+ | Full + experimental / bleeding edge |
+
+**Removed**:
+- Features system (`-f/--feature`, `+soul`, `+network`, `+workspace`, `+creator`)
+- `seed` profile (merged into `standard`)
+- `resolveProfileWithFeatures()` function
+
+**Changed**:
+- `dig` promoted to standard profile
+- `create-shortcut` moved to lab profile (experimental)
+- Default profile: `standard` (was `standard` with 16 skills, now with `dig`)
+- `/go` skill simplified — profiles only, no feature stacking
+- `update-readme-table.ts` no longer generates feature tables
+
+**Why**: Zero users across all sessions and community. 3 profiles × 3 features × 18 agents = 162 combinations, all unused. Simplify to 3 clear tiers.
+
+## v3.5.2 (2026-04-05)
+
+- Version stamp in README auto-updated by lefthook
+- CI auto-publishes on GitHub release (npm)
+- `src/commands/` gitignored (generated artifacts)
+- 24 skills, 108 tests
+
 ## v3.0.4 (2026-03-13)
 
 - Add `oracle-soul-sync-update` to all profiles (minimal/standard/full)

--- a/README.md
+++ b/README.md
@@ -5,19 +5,26 @@
 ## Install
 
 ```bash
-# Claude Code (skills only)
-npx arra-oracle-skills@3.5.2 install -g -y -p standard --agent claude-code
-npx arra-oracle-skills@3.5.2 install -g -y -p full --agent claude-code
-npx arra-oracle-skills@3.5.2 install -g -y -p seed --agent claude-code
+# Claude Code — standard profile (default)
+npx arra-oracle-skills@3.6.0 install -g -y --agent claude-code
+
+# Full profile (all skills)
+npx arra-oracle-skills@3.6.0 install -g -y -p full --agent claude-code
+
+# Lab profile (full + experimental)
+npx arra-oracle-skills@3.6.0 install -g -y -p lab --agent claude-code
+
+# Specific skills only
+npx arra-oracle-skills@3.6.0 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@3.5.2 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@3.5.2 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@3.5.2 install -g -y --agent cursor
-npx arra-oracle-skills@3.5.2 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@3.6.0 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@3.6.0 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@3.6.0 install -g -y --agent cursor
+npx arra-oracle-skills@3.6.0 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@3.5.2 install -g -y -p full --agent claude-code codex opencode
+npx arra-oracle-skills@3.6.0 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -43,7 +50,7 @@ npx arra-oracle-skills@3.5.2 install -g -y -p full --agent claude-code codex ope
 | 11 | **create-shortcut** | skill | Create local skills as shortcuts |
 | 12 | **dig** | skill | Mine Claude Code sessions |
 | 13 | **forward** | skill | Create handoff + enter plan mode for next |
-| 14 | **go** | skill | 'Switch skill profiles and features |
+| 14 | **go** | skill | 'Switch skill profiles |
 | 15 | **inbox** | skill | Read and write to Oracle inbox |
 | 16 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
 | 17 | **philosophy** | skill | Display Oracle philosophy |
@@ -63,25 +70,18 @@ npx arra-oracle-skills@3.5.2 install -g -y -p full --agent claude-code codex ope
 
 | Profile | Count | Skills |
 |---------|-------|--------|
-| **standard** | 16 | `forward`, `rrr`, `recap`, `standup`, `trace`, `learn`, `talk-to`, `oracle-family-scan`, `go`, `about-oracle`, `oracle-soul-sync-update`, `awaken`, `inbox`, `xray`, `create-shortcut`, `contacts` |
+| **standard** | 16 | `about-oracle`, `awaken`, `contacts`, `dig`, `forward`, `go`, `inbox`, `learn`, `oracle-family-scan`, `oracle-soul-sync-update`, `recap`, `rrr`, `standup`, `talk-to`, `trace`, `xray` |
 | **full** | 24 | all |
+| **lab** | 1 | `create-shortcut` |
 
-Switch anytime: `/go minimal`, `/go standard`, `/go full`, `/go + soul`
-
-**Features** (stack on any profile with `/go + feature`):
-
-| Feature | Skills |
-|---------|--------|
-| **+soul** | `awaken`, `philosophy`, `who-are-you`, `about-oracle` |
-| **+network** | `talk-to`, `oracle-family-scan`, `oracle-soul-sync-update` |
-| **+workspace** | `schedule`, `project` |
+Switch anytime: `/go standard`, `/go full`, `/go lab`
 
 <!-- profiles:end -->
 
 ## CLI
 
 ```
-install [options]       # install skills (default: standard, skills only)
+install [options]       # install skills (default: standard)
 uninstall [options]     # remove installed skills
 select [options]        # interactive skill picker
 list [options]          # show installed skills

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-24 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+26 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -49,18 +49,20 @@ npx arra-oracle-skills@3.6.0 install -g -y --agent claude-code codex opencode
 | 10 | **contacts** | skill | Manage Oracle contacts |
 | 11 | **create-shortcut** | skill | Create local skills as shortcuts |
 | 12 | **dig** | skill | Mine Claude Code sessions |
-| 13 | **forward** | skill | Create handoff + enter plan mode for next |
-| 14 | **go** | skill | 'Switch skill profiles |
-| 15 | **inbox** | skill | Read and write to Oracle inbox |
-| 16 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
-| 17 | **philosophy** | skill | Display Oracle philosophy |
-| 18 | **resonance** | skill | Capture a resonance moment |
-| 19 | **standup** | skill | Daily standup check |
-| 20 | **talk-to** | skill | Talk to another Oracle agent via threads |
-| 21 | **trace** | skill | Find projects, code |
-| 22 | **where-we-are** | skill | Session awareness |
-| 23 | **who-are-you** | skill | Know ourselves |
-| 24 | **xray** | skill | X-ray deep scan |
+| 13 | **dream** | skill | "Cross-repo pattern discovery |
+| 14 | **feel** | skill | "Capture how the system feels |
+| 15 | **forward** | skill | Create handoff + enter plan mode for next |
+| 16 | **go** | skill | 'Switch skill profiles |
+| 17 | **inbox** | skill | Read and write to Oracle inbox |
+| 18 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
+| 19 | **philosophy** | skill | Display Oracle philosophy |
+| 20 | **resonance** | skill | Capture a resonance moment |
+| 21 | **standup** | skill | Daily standup check |
+| 22 | **talk-to** | skill | Talk to another Oracle agent via threads |
+| 23 | **trace** | skill | Find projects, code |
+| 24 | **where-we-are** | skill | Session awareness |
+| 25 | **who-are-you** | skill | Know ourselves |
+| 26 | **xray** | skill | X-ray deep scan |
 
 <!-- skills:end -->
 
@@ -71,8 +73,8 @@ npx arra-oracle-skills@3.6.0 install -g -y --agent claude-code codex opencode
 | Profile | Count | Skills |
 |---------|-------|--------|
 | **standard** | 16 | `about-oracle`, `awaken`, `contacts`, `dig`, `forward`, `go`, `inbox`, `learn`, `oracle-family-scan`, `oracle-soul-sync-update`, `recap`, `rrr`, `standup`, `talk-to`, `trace`, `xray` |
-| **full** | 24 | all |
-| **lab** | 1 | `create-shortcut` |
+| **full** | 26 | all |
+| **lab** | 26 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/__tests__/e2e-features.test.ts
+++ b/__tests__/e2e-features.test.ts
@@ -4,18 +4,18 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { agents } from "../src/cli/agents";
-import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
-import { profiles, features, resolveProfileWithFeatures } from "../src/profiles";
+import { installSkills, discoverSkills } from "../src/cli/installer";
+import { profiles, resolveProfile } from "../src/profiles";
 import type { AgentConfig } from "../src/cli/types";
 
-const TEST_DIR = join(tmpdir(), `arra-oracle-skills-feat-${Date.now()}`);
+const TEST_DIR = join(tmpdir(), `arra-oracle-skills-profile-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
-const TEST_AGENT = "test-feat" as any;
+const TEST_AGENT = "test-profile" as any;
 
 const testAgentConfig: AgentConfig = {
-  name: "test-feat",
-  displayName: "Test Features",
+  name: "test-profile",
+  displayName: "Test Profile",
   skillsDir: "test-skills",
   globalSkillsDir: SKILLS_DIR,
   commandsDir: "test-commands",
@@ -31,76 +31,80 @@ beforeAll(async () => {
 
 afterAll(async () => {
   delete (agents as any)[TEST_AGENT];
-  if (existsSync(TEST_DIR)) {
-    await rm(TEST_DIR, { recursive: true });
-  }
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
 });
 
 async function listSkillDirs(dir: string): Promise<string[]> {
   if (!existsSync(dir)) return [];
   const entries = await readdir(dir, { withFileTypes: true });
-  return entries
-    .filter((d) => d.isDirectory() && !d.name.startsWith("."))
-    .map((d) => d.name)
-    .sort();
+  return entries.filter((d) => d.isDirectory() && !d.name.startsWith(".")).map((d) => d.name).sort();
 }
 
 async function cleanup() {
-  if (existsSync(SKILLS_DIR)) {
-    await rm(SKILLS_DIR, { recursive: true });
-    await mkdir(SKILLS_DIR, { recursive: true });
-  }
-  if (existsSync(COMMANDS_DIR)) {
-    await rm(COMMANDS_DIR, { recursive: true });
-    await mkdir(COMMANDS_DIR, { recursive: true });
-  }
+  if (existsSync(SKILLS_DIR)) await rm(SKILLS_DIR, { recursive: true });
+  if (existsSync(COMMANDS_DIR)) await rm(COMMANDS_DIR, { recursive: true });
+  await mkdir(SKILLS_DIR, { recursive: true });
+  await mkdir(COMMANDS_DIR, { recursive: true });
 }
 
-describe("e2e: install with profile + feature", () => {
+describe("e2e: install with standard profile", () => {
   beforeEach(cleanup);
 
-  it("minimal + soul installs combined set", async () => {
-    await installSkills([TEST_AGENT], {
-      global: true,
-      profile: "minimal",
-      features: ["soul"],
-      yes: true,
-    });
-
-    const installed = await listSkillDirs(SKILLS_DIR);
-    const allSkills = await discoverSkills();
-    const allNames = allSkills.map((s) => s.name);
-    const expected = resolveProfileWithFeatures("minimal", ["soul"], allNames);
-
-    expect(installed.length).toBe(expected.length);
-    for (const name of expected) {
-      expect(installed).toContain(name);
-    }
-  });
-
-  it("standard + soul + creator installs combined set", async () => {
+  it("standard installs 16 skills", async () => {
     await installSkills([TEST_AGENT], {
       global: true,
       profile: "standard",
-      features: ["soul", "creator"],
       yes: true,
     });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    const allSkills = await discoverSkills();
-    const allNames = allSkills.map((s) => s.name);
-    const expected = resolveProfileWithFeatures("standard", ["soul", "creator"], allNames);
-
-    expect(installed.length).toBe(expected.length);
-    for (const name of expected) {
+    expect(installed.length).toBe(profiles.standard.include!.length);
+    for (const name of profiles.standard.include!) {
       expect(installed).toContain(name);
     }
   });
+});
 
-  it("profile + feature cleans up non-matching skills", async () => {
+describe("e2e: install with full profile", () => {
+  beforeEach(cleanup);
+
+  it("full installs all skills", async () => {
+    const allSkills = await discoverSkills();
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "full",
+      yes: true,
+    });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed.length).toBe(allSkills.length);
+  });
+});
+
+describe("e2e: install with lab profile", () => {
+  beforeEach(cleanup);
+
+  it("lab installs all skills", async () => {
+    const allSkills = await discoverSkills();
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "lab",
+      yes: true,
+    });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed.length).toBe(allSkills.length);
+  });
+});
+
+describe("e2e: profile switch (full → standard)", () => {
+  beforeEach(cleanup);
+
+  it("switching from full to standard removes extra skills", async () => {
     // Install full first
     await installSkills([TEST_AGENT], {
       global: true,
+      profile: "full",
       yes: true,
     });
 
@@ -108,96 +112,21 @@ describe("e2e: install with profile + feature", () => {
     let installed = await listSkillDirs(SKILLS_DIR);
     expect(installed.length).toBe(allSkills.length);
 
-    // Switch to minimal + soul
+    // Switch to standard
     await installSkills([TEST_AGENT], {
       global: true,
-      profile: "minimal",
-      features: ["soul"],
+      profile: "standard",
       yes: true,
     });
 
     installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed.length).toBe(profiles.standard.include!.length);
+
+    // Full-only skills should be gone
     const allNames = allSkills.map((s) => s.name);
-    const expected = resolveProfileWithFeatures("minimal", ["soul"], allNames);
-
-    expect(installed.length).toBe(expected.length);
-  });
-});
-
-describe("e2e: feature-only install (additive)", () => {
-  beforeEach(cleanup);
-
-  it("feature-only installs just those skills", async () => {
-    await installSkills([TEST_AGENT], {
-      global: true,
-      features: ["soul"],
-      yes: true,
-    });
-
-    const installed = await listSkillDirs(SKILLS_DIR);
-    const soulSkills = features.soul;
-
-    expect(installed.length).toBe(soulSkills.length);
-    for (const name of soulSkills) {
-      expect(installed).toContain(name);
-    }
-  });
-
-  it("feature-only does NOT remove existing skills", async () => {
-    // Install standard first
-    await installSkills([TEST_AGENT], {
-      global: true,
-      profile: "standard",
-      yes: true,
-    });
-
-    const standardCount = profiles.standard.include!.length;
-
-    // Add soul feature (additive)
-    await installSkills([TEST_AGENT], {
-      global: true,
-      features: ["soul"],
-      yes: true,
-    });
-
-    const installed = await listSkillDirs(SKILLS_DIR);
-    // Should have at least standard count (soul may overlap)
-    expect(installed.length).toBeGreaterThanOrEqual(standardCount);
-    // Soul skills should all be present
-    for (const name of features.soul) {
-      expect(installed).toContain(name);
-    }
-    // Standard skills should still be present
-    for (const name of profiles.standard.include!) {
-      expect(installed).toContain(name);
-    }
-  });
-});
-
-describe("e2e: uninstall with feature", () => {
-  beforeEach(cleanup);
-
-  it("uninstall --feature removes feature skills", async () => {
-    // Install standard + soul
-    await installSkills([TEST_AGENT], {
-      global: true,
-      profile: "standard",
-      features: ["soul"],
-      yes: true,
-    });
-
-    // Uninstall soul feature
-    await uninstallSkills([TEST_AGENT], {
-      global: true,
-      skills: [...features.soul],
-      yes: true,
-    });
-
-    const installed = await listSkillDirs(SKILLS_DIR);
-    // Soul-only skills should be gone (unless also in standard)
     const standardSet = new Set(profiles.standard.include!);
-    const soulOnly = features.soul.filter((s) => !standardSet.has(s));
-    for (const name of soulOnly) {
+    const fullOnly = allNames.filter((s) => !standardSet.has(s));
+    for (const name of fullOnly) {
       expect(installed).not.toContain(name);
     }
   });

--- a/__tests__/e2e-features.test.ts
+++ b/__tests__/e2e-features.test.ts
@@ -5,7 +5,7 @@ import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { agents } from "../src/cli/agents";
 import { installSkills, discoverSkills } from "../src/cli/installer";
-import { profiles, resolveProfile } from "../src/profiles";
+import { profiles, labOnly, resolveProfile } from "../src/profiles";
 import type { AgentConfig } from "../src/cli/types";
 
 const TEST_DIR = join(tmpdir(), `arra-oracle-skills-profile-${Date.now()}`);
@@ -68,7 +68,7 @@ describe("e2e: install with standard profile", () => {
 describe("e2e: install with full profile", () => {
   beforeEach(cleanup);
 
-  it("full installs all skills", async () => {
+  it("full installs all stable skills (excludes lab-only)", async () => {
     const allSkills = await discoverSkills();
     await installSkills([TEST_AGENT], {
       global: true,
@@ -77,7 +77,11 @@ describe("e2e: install with full profile", () => {
     });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length);
+    const expectedCount = allSkills.length - labOnly.filter(s => allSkills.some(sk => sk.name === s)).length;
+    expect(installed.length).toBe(expectedCount);
+    for (const name of labOnly) {
+      expect(installed).not.toContain(name);
+    }
   });
 });
 
@@ -110,7 +114,8 @@ describe("e2e: profile switch (full → standard)", () => {
 
     const allSkills = await discoverSkills();
     let installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length);
+    const fullCount = allSkills.length - labOnly.filter(s => allSkills.some(sk => sk.name === s)).length;
+    expect(installed.length).toBe(fullCount);
 
     // Switch to standard
     await installSkills([TEST_AGENT], {

--- a/__tests__/e2e-install.test.ts
+++ b/__tests__/e2e-install.test.ts
@@ -13,7 +13,6 @@ const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
 const TEST_AGENT = "test-e2e" as any;
 
-// Inject a test agent that points to our temp dirs
 const testAgentConfig: AgentConfig = {
   name: "test-e2e",
   displayName: "Test E2E",
@@ -32,18 +31,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   delete (agents as any)[TEST_AGENT];
-  if (existsSync(TEST_DIR)) {
-    await rm(TEST_DIR, { recursive: true });
-  }
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
 });
 
 async function listSkillDirs(dir: string): Promise<string[]> {
   if (!existsSync(dir)) return [];
   const entries = await readdir(dir, { withFileTypes: true });
-  return entries
-    .filter((d) => d.isDirectory() && !d.name.startsWith("."))
-    .map((d) => d.name)
-    .sort();
+  return entries.filter((d) => d.isDirectory() && !d.name.startsWith(".")).map((d) => d.name).sort();
 }
 
 async function listCommandFiles(dir: string): Promise<string[]> {
@@ -64,7 +58,6 @@ describe("e2e: install with standard profile", () => {
     const skills = await listSkillDirs(SKILLS_DIR);
     const standardSkills = profiles.standard.include!;
 
-    // Every standard skill should be installed
     for (const name of standardSkills) {
       expect(skills).toContain(name);
     }
@@ -134,11 +127,9 @@ describe("e2e: uninstall after standard", () => {
     expect(result.removed).toBe(profiles.standard.include!.length);
     expect(result.agents).toBe(1);
 
-    // No skill dirs remaining
     const skills = await listSkillDirs(SKILLS_DIR);
     expect(skills.length).toBe(0);
 
-    // No command files remaining
     const commands = await listCommandFiles(COMMANDS_DIR);
     expect(commands.length).toBe(0);
   });
@@ -150,6 +141,7 @@ describe("e2e: install full profile", () => {
 
     await installSkills([TEST_AGENT], {
       global: true,
+      profile: "full",
       yes: true,
       commands: true,
     });
@@ -202,73 +194,63 @@ describe("e2e: uninstall full", () => {
 
 describe("e2e: uninstall preserves external skills", () => {
   it("skips skills without installer marker", async () => {
-    // Install oracle skills normally
     await installSkills([TEST_AGENT], {
       global: true,
-      profile: "seed",
+      profile: "standard",
       yes: true,
     });
 
-    // Create an external skill (no installer marker)
     const externalDir = join(SKILLS_DIR, "external-skill");
     await mkdir(externalDir, { recursive: true });
-    await writeFile(
-      join(externalDir, "SKILL.md"),
-      "# External Skill\n\nInstalled by another tool."
-    );
+    await writeFile(join(externalDir, "SKILL.md"), "# External Skill\n\nInstalled by another tool.");
 
-    // Uninstall (without -s flag = remove all)
     const result = await uninstallSkills([TEST_AGENT], {
       global: true,
       yes: true,
     });
 
-    // External skill should survive
     expect(existsSync(externalDir)).toBe(true);
-    expect(existsSync(join(externalDir, "SKILL.md"))).toBe(true);
-
-    // Oracle skills should be removed
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining).toEqual(["external-skill"]);
 
-    // Cleanup
     await rm(externalDir, { recursive: true });
   });
 
   it("removes explicitly named external skills with -s flag", async () => {
-    // Install oracle skills
     await installSkills([TEST_AGENT], {
       global: true,
-      profile: "seed",
+      profile: "standard",
       yes: true,
     });
 
-    // Create an external skill
     const externalDir = join(SKILLS_DIR, "my-custom-skill");
     await mkdir(externalDir, { recursive: true });
-    await writeFile(
-      join(externalDir, "SKILL.md"),
-      "# Custom\n\nNo marker."
-    );
+    await writeFile(join(externalDir, "SKILL.md"), "# Custom\n\nNo marker.");
 
-    // Uninstall with explicit -s flag (should remove even without marker)
     await uninstallSkills([TEST_AGENT], {
       global: true,
       skills: ["my-custom-skill"],
       yes: true,
     });
 
-    // Explicitly named skill should be removed
     expect(existsSync(externalDir)).toBe(false);
-
-    // Cleanup remaining oracle skills
     await uninstallSkills([TEST_AGENT], { global: true, yes: true });
   });
 });
 
-describe("e2e: profile switch (standard → seed)", () => {
-  it("installs standard then switches to seed, removes extras", async () => {
-    // Install standard first
+describe("e2e: profile switch (full → standard)", () => {
+  it("installs full then switches to standard, removes extras", async () => {
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "full",
+      yes: true,
+      commands: true,
+    });
+
+    const allSkills = await discoverSkills();
+    let skills = await listSkillDirs(SKILLS_DIR);
+    expect(skills.length).toBe(allSkills.length);
+
     await installSkills([TEST_AGENT], {
       global: true,
       profile: "standard",
@@ -276,28 +258,16 @@ describe("e2e: profile switch (standard → seed)", () => {
       commands: true,
     });
 
-    let skills = await listSkillDirs(SKILLS_DIR);
-    expect(skills.length).toBe(profiles.standard.include!.length);
-
-    // Switch to seed
-    await installSkills([TEST_AGENT], {
-      global: true,
-      profile: "seed",
-      yes: true,
-      commands: true,
-    });
-
     skills = await listSkillDirs(SKILLS_DIR);
-    const seedSkills = profiles.seed.include!;
+    const standardSkills = profiles.standard.include!;
 
-    expect(skills.length).toBe(seedSkills.length);
-    for (const name of seedSkills) {
+    expect(skills.length).toBe(standardSkills.length);
+    for (const name of standardSkills) {
       expect(skills).toContain(name);
     }
 
-    // Standard-only skills should be gone
-    const standardOnly = profiles.standard.include!.filter(
-      (s) => !seedSkills.includes(s)
+    const standardOnly = allSkills.map(s => s.name).filter(
+      (s) => !standardSkills.includes(s)
     );
     for (const name of standardOnly) {
       expect(skills).not.toContain(name);
@@ -305,7 +275,6 @@ describe("e2e: profile switch (standard → seed)", () => {
   });
 
   afterAll(async () => {
-    // Cleanup
     await uninstallSkills([TEST_AGENT], { global: true, yes: true });
   });
 });

--- a/__tests__/e2e-install.test.ts
+++ b/__tests__/e2e-install.test.ts
@@ -5,7 +5,7 @@ import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
-import { profiles } from "../src/profiles";
+import { profiles, labOnly } from "../src/profiles";
 import type { AgentConfig } from "../src/cli/types";
 
 const TEST_DIR = join(tmpdir(), `arra-oracle-skills-e2e-${Date.now()}`);
@@ -136,7 +136,7 @@ describe("e2e: uninstall after standard", () => {
 });
 
 describe("e2e: install full profile", () => {
-  it("installs all skills", async () => {
+  it("installs all stable skills (excludes lab-only)", async () => {
     const allSkills = await discoverSkills();
 
     await installSkills([TEST_AGENT], {
@@ -147,23 +147,26 @@ describe("e2e: install full profile", () => {
     });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length);
+    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name));
+    expect(installed.length).toBe(fullSkills.length);
   });
 
-  it("every discovered skill has a directory", async () => {
+  it("every full-profile skill has a directory", async () => {
     const allSkills = await discoverSkills();
     const installed = await listSkillDirs(SKILLS_DIR);
+    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name));
 
-    for (const skill of allSkills) {
+    for (const skill of fullSkills) {
       expect(installed).toContain(skill.name);
     }
   });
 
   it("command stubs match installed non-hidden skills", async () => {
     const allSkills = await discoverSkills();
+    const installed = await listSkillDirs(SKILLS_DIR);
     const commands = await listCommandFiles(COMMANDS_DIR);
 
-    for (const skill of allSkills) {
+    for (const skill of allSkills.filter(s => installed.includes(s.name))) {
       if (skill.hidden) {
         expect(commands).not.toContain(`${skill.name}.md`);
       } else {
@@ -175,14 +178,14 @@ describe("e2e: install full profile", () => {
 
 describe("e2e: uninstall full", () => {
   it("removes everything cleanly", async () => {
-    const allSkills = await discoverSkills();
+    const installed = await listSkillDirs(SKILLS_DIR);
 
     const result = await uninstallSkills([TEST_AGENT], {
       global: true,
       yes: true,
     });
 
-    expect(result.removed).toBe(allSkills.length);
+    expect(result.removed).toBe(installed.length);
 
     const skills = await listSkillDirs(SKILLS_DIR);
     expect(skills.length).toBe(0);
@@ -248,8 +251,9 @@ describe("e2e: profile switch (full → standard)", () => {
     });
 
     const allSkills = await discoverSkills();
+    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name));
     let skills = await listSkillDirs(SKILLS_DIR);
-    expect(skills.length).toBe(allSkills.length);
+    expect(skills.length).toBe(fullSkills.length);
 
     await installSkills([TEST_AGENT], {
       global: true,
@@ -266,7 +270,7 @@ describe("e2e: profile switch (full → standard)", () => {
       expect(skills).toContain(name);
     }
 
-    const standardOnly = allSkills.map(s => s.name).filter(
+    const standardOnly = fullSkills.map(s => s.name).filter(
       (s) => !standardSkills.includes(s)
     );
     for (const name of standardOnly) {

--- a/__tests__/install-all.test.ts
+++ b/__tests__/install-all.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { readdir, readFile, rm, mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { agents } from "../src/cli/agents";
+import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
+import type { AgentConfig } from "../src/cli/types";
+
+const TEST_DIR = join(tmpdir(), `arra-install-all-${Date.now()}`);
+const SKILLS_DIR = join(TEST_DIR, "skills");
+const COMMANDS_DIR = join(TEST_DIR, "commands");
+const TEST_AGENT = "test-all" as any;
+
+const testAgentConfig: AgentConfig = {
+  name: "test-all",
+  displayName: "Test All",
+  skillsDir: "test-skills",
+  globalSkillsDir: SKILLS_DIR,
+  commandsDir: "test-commands",
+  globalCommandsDir: COMMANDS_DIR,
+  useFlatFiles: true,
+  detectInstalled: () => true,
+};
+
+async function listSkillDirs(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries.filter((d) => d.isDirectory() && !d.name.startsWith(".")).map((d) => d.name).sort();
+}
+
+async function cleanup() {
+  if (existsSync(SKILLS_DIR)) await rm(SKILLS_DIR, { recursive: true });
+  if (existsSync(COMMANDS_DIR)) await rm(COMMANDS_DIR, { recursive: true });
+  await mkdir(SKILLS_DIR, { recursive: true });
+  await mkdir(COMMANDS_DIR, { recursive: true });
+}
+
+beforeAll(async () => {
+  await mkdir(TEST_DIR, { recursive: true });
+  (agents as any)[TEST_AGENT] = testAgentConfig;
+});
+
+afterAll(async () => {
+  delete (agents as any)[TEST_AGENT];
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
+});
+
+describe("install all (default)", () => {
+  beforeEach(cleanup);
+
+  it("installs ALL skills when no --skill filter", async () => {
+    const allSkills = await discoverSkills();
+
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed.length).toBe(allSkills.length);
+    for (const skill of allSkills) {
+      expect(installed).toContain(skill.name);
+    }
+  });
+
+  it("each skill has SKILL.md with installer marker", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    for (const name of installed) {
+      const content = await readFile(join(SKILLS_DIR, name, "SKILL.md"), "utf-8");
+      expect(content).toContain("installer: arra-oracle-skills-cli");
+    }
+  });
+
+  it("each skill has version-prefixed description", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    for (const name of installed) {
+      const content = await readFile(join(SKILLS_DIR, name, "SKILL.md"), "utf-8");
+      expect(content).toMatch(/v\d+\.\d+\.\d+(-[\w.]+)? G-SKLL(\s\[\w+\])? \|/);
+    }
+  });
+
+  it("creates manifest with all skills", async () => {
+    const allSkills = await discoverSkills();
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const manifest = JSON.parse(await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8"));
+    expect(manifest.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
+    expect(manifest.skills.length).toBe(allSkills.length);
+    expect(manifest.agent).toBe(TEST_AGENT);
+  });
+
+  it("creates VERSION.md", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+    expect(existsSync(join(SKILLS_DIR, "VERSION.md"))).toBe(true);
+  });
+
+  it("reinstall overwrites existing skills", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+    const first = await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8");
+
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+    const second = await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8");
+
+    // Timestamps should differ
+    expect(JSON.parse(first).installedAt).not.toBe(JSON.parse(second).installedAt);
+  });
+});

--- a/__tests__/install-commands.test.ts
+++ b/__tests__/install-commands.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { readdir, readFile, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { agents } from "../src/cli/agents";
+import { installSkills, discoverSkills } from "../src/cli/installer";
+import type { AgentConfig } from "../src/cli/types";
+
+const TEST_DIR = join(tmpdir(), `arra-install-cmds-${Date.now()}`);
+const SKILLS_DIR = join(TEST_DIR, "skills");
+const COMMANDS_DIR = join(TEST_DIR, "commands");
+const TEST_AGENT = "test-cmds" as any;
+
+const testAgentConfig: AgentConfig = {
+  name: "test-cmds",
+  displayName: "Test Commands",
+  skillsDir: "test-skills",
+  globalSkillsDir: SKILLS_DIR,
+  commandsDir: "test-commands",
+  globalCommandsDir: COMMANDS_DIR,
+  useFlatFiles: true,
+  detectInstalled: () => true,
+};
+
+async function listCommandFiles(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  return (await readdir(dir)).filter((f) => f.endsWith(".md")).sort();
+}
+
+async function cleanup() {
+  if (existsSync(SKILLS_DIR)) await rm(SKILLS_DIR, { recursive: true });
+  if (existsSync(COMMANDS_DIR)) await rm(COMMANDS_DIR, { recursive: true });
+  await mkdir(SKILLS_DIR, { recursive: true });
+  await mkdir(COMMANDS_DIR, { recursive: true });
+}
+
+beforeAll(async () => {
+  await mkdir(TEST_DIR, { recursive: true });
+  (agents as any)[TEST_AGENT] = testAgentConfig;
+});
+
+afterAll(async () => {
+  delete (agents as any)[TEST_AGENT];
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
+});
+
+describe("command stubs", () => {
+  beforeEach(cleanup);
+
+  it("installs command stubs for non-hidden skills with --commands", async () => {
+    const allSkills = await discoverSkills();
+    await installSkills([TEST_AGENT], { global: true, yes: true, commands: true });
+
+    const commands = await listCommandFiles(COMMANDS_DIR);
+    const hiddenNames = new Set(allSkills.filter((s) => s.hidden).map((s) => s.name));
+
+    for (const skill of allSkills) {
+      if (hiddenNames.has(skill.name)) {
+        expect(commands).not.toContain(`${skill.name}.md`);
+      } else {
+        expect(commands).toContain(`${skill.name}.md`);
+      }
+    }
+  });
+
+  it("does NOT install command stubs without --commands for commandsOptIn agents", async () => {
+    const optInAgent = "test-optin" as any;
+    const optInConfig: AgentConfig = {
+      ...testAgentConfig,
+      name: "test-optin",
+      displayName: "Test OptIn",
+      commandsOptIn: true,
+      globalCommandsDir: join(TEST_DIR, "optin-commands"),
+    };
+    (agents as any)[optInAgent] = optInConfig;
+    await mkdir(join(TEST_DIR, "optin-commands"), { recursive: true });
+
+    await installSkills([optInAgent], { global: true, yes: true });
+
+    const commands = await listCommandFiles(join(TEST_DIR, "optin-commands"));
+    expect(commands.length).toBe(0);
+
+    delete (agents as any)[optInAgent];
+  });
+
+  it("command stubs have correct frontmatter", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true, commands: true });
+
+    const commands = await listCommandFiles(COMMANDS_DIR);
+    expect(commands.length).toBeGreaterThan(0);
+
+    const content = await readFile(join(COMMANDS_DIR, commands[0]), "utf-8");
+    expect(content).toMatch(/^---/);
+    expect(content).toMatch(/description:/);
+    expect(content).toContain("$ARGUMENTS");
+  });
+});

--- a/__tests__/install-specific.test.ts
+++ b/__tests__/install-specific.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { readdir, readFile, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { agents } from "../src/cli/agents";
+import { installSkills, discoverSkills } from "../src/cli/installer";
+import type { AgentConfig } from "../src/cli/types";
+
+const TEST_DIR = join(tmpdir(), `arra-install-specific-${Date.now()}`);
+const SKILLS_DIR = join(TEST_DIR, "skills");
+const COMMANDS_DIR = join(TEST_DIR, "commands");
+const TEST_AGENT = "test-specific" as any;
+
+const testAgentConfig: AgentConfig = {
+  name: "test-specific",
+  displayName: "Test Specific",
+  skillsDir: "test-skills",
+  globalSkillsDir: SKILLS_DIR,
+  commandsDir: "test-commands",
+  globalCommandsDir: COMMANDS_DIR,
+  useFlatFiles: true,
+  detectInstalled: () => true,
+};
+
+async function listSkillDirs(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries.filter((d) => d.isDirectory() && !d.name.startsWith(".")).map((d) => d.name).sort();
+}
+
+async function cleanup() {
+  if (existsSync(SKILLS_DIR)) await rm(SKILLS_DIR, { recursive: true });
+  if (existsSync(COMMANDS_DIR)) await rm(COMMANDS_DIR, { recursive: true });
+  await mkdir(SKILLS_DIR, { recursive: true });
+  await mkdir(COMMANDS_DIR, { recursive: true });
+}
+
+beforeAll(async () => {
+  await mkdir(TEST_DIR, { recursive: true });
+  (agents as any)[TEST_AGENT] = testAgentConfig;
+});
+
+afterAll(async () => {
+  delete (agents as any)[TEST_AGENT];
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
+});
+
+describe("install specific skills (--skill)", () => {
+  beforeEach(cleanup);
+
+  it("installs only named skills", async () => {
+    await installSkills([TEST_AGENT], {
+      global: true,
+      skills: ["recap", "rrr"],
+      yes: true,
+    });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed).toEqual(["recap", "rrr"]);
+  });
+
+  it("installs single skill", async () => {
+    await installSkills([TEST_AGENT], {
+      global: true,
+      skills: ["trace"],
+      yes: true,
+    });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed).toEqual(["trace"]);
+    const content = await readFile(join(SKILLS_DIR, "trace", "SKILL.md"), "utf-8");
+    expect(content).toContain("installer: arra-oracle-skills-cli");
+  });
+
+  it("ignores unknown skill names gracefully", async () => {
+    await installSkills([TEST_AGENT], {
+      global: true,
+      skills: ["recap", "nonexistent-skill"],
+      yes: true,
+    });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed).toEqual(["recap"]);
+  });
+
+  it("does not remove existing skills when adding specific ones", async () => {
+    // Install all first
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+    const allSkills = await discoverSkills();
+    let installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed.length).toBe(allSkills.length);
+
+    // Install specific — should NOT remove others
+    await installSkills([TEST_AGENT], {
+      global: true,
+      skills: ["recap"],
+      yes: true,
+    });
+
+    installed = await listSkillDirs(SKILLS_DIR);
+    // Still has all skills (specific install is additive, not destructive)
+    expect(installed.length).toBe(allSkills.length);
+  });
+
+  it("manifest lists only installed skills", async () => {
+    await installSkills([TEST_AGENT], {
+      global: true,
+      skills: ["recap", "rrr", "trace"],
+      yes: true,
+    });
+
+    const manifest = JSON.parse(await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8"));
+    expect(manifest.skills.sort()).toEqual(["recap", "rrr", "trace"]);
+  });
+});

--- a/__tests__/install-uninstall.test.ts
+++ b/__tests__/install-uninstall.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { readdir, rm, mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { agents } from "../src/cli/agents";
+import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
+import type { AgentConfig } from "../src/cli/types";
+
+const TEST_DIR = join(tmpdir(), `arra-uninstall-${Date.now()}`);
+const SKILLS_DIR = join(TEST_DIR, "skills");
+const COMMANDS_DIR = join(TEST_DIR, "commands");
+const TEST_AGENT = "test-uninstall" as any;
+
+const testAgentConfig: AgentConfig = {
+  name: "test-uninstall",
+  displayName: "Test Uninstall",
+  skillsDir: "test-skills",
+  globalSkillsDir: SKILLS_DIR,
+  commandsDir: "test-commands",
+  globalCommandsDir: COMMANDS_DIR,
+  useFlatFiles: true,
+  detectInstalled: () => true,
+};
+
+async function listSkillDirs(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries.filter((d) => d.isDirectory() && !d.name.startsWith(".")).map((d) => d.name).sort();
+}
+
+async function cleanup() {
+  if (existsSync(SKILLS_DIR)) await rm(SKILLS_DIR, { recursive: true });
+  if (existsSync(COMMANDS_DIR)) await rm(COMMANDS_DIR, { recursive: true });
+  await mkdir(SKILLS_DIR, { recursive: true });
+  await mkdir(COMMANDS_DIR, { recursive: true });
+}
+
+beforeAll(async () => {
+  await mkdir(TEST_DIR, { recursive: true });
+  (agents as any)[TEST_AGENT] = testAgentConfig;
+});
+
+afterAll(async () => {
+  delete (agents as any)[TEST_AGENT];
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
+});
+
+describe("uninstall all", () => {
+  beforeEach(cleanup);
+
+  it("removes all oracle skills", async () => {
+    const allSkills = await discoverSkills();
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const result = await uninstallSkills([TEST_AGENT], { global: true, yes: true });
+    expect(result.removed).toBe(allSkills.length);
+
+    const remaining = await listSkillDirs(SKILLS_DIR);
+    expect(remaining.length).toBe(0);
+  });
+});
+
+describe("uninstall specific skills", () => {
+  beforeEach(cleanup);
+
+  it("removes only named skills", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+    const allSkills = await discoverSkills();
+
+    await uninstallSkills([TEST_AGENT], {
+      global: true,
+      skills: ["recap", "trace"],
+      yes: true,
+    });
+
+    const remaining = await listSkillDirs(SKILLS_DIR);
+    expect(remaining).not.toContain("recap");
+    expect(remaining).not.toContain("trace");
+    expect(remaining.length).toBe(allSkills.length - 2);
+  });
+});
+
+describe("uninstall preserves external skills", () => {
+  beforeEach(cleanup);
+
+  it("skips skills without installer marker", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    // Create external skill (no marker)
+    const externalDir = join(SKILLS_DIR, "external-skill");
+    await mkdir(externalDir, { recursive: true });
+    await writeFile(join(externalDir, "SKILL.md"), "# External\n\nNo marker.");
+
+    await uninstallSkills([TEST_AGENT], { global: true, yes: true });
+
+    expect(existsSync(externalDir)).toBe(true);
+    const remaining = await listSkillDirs(SKILLS_DIR);
+    expect(remaining).toEqual(["external-skill"]);
+
+    await rm(externalDir, { recursive: true });
+  });
+
+  it("removes explicitly named external skills with --skill", async () => {
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const externalDir = join(SKILLS_DIR, "my-custom-skill");
+    await mkdir(externalDir, { recursive: true });
+    await writeFile(join(externalDir, "SKILL.md"), "# Custom\n\nNo marker.");
+
+    await uninstallSkills([TEST_AGENT], {
+      global: true,
+      skills: ["my-custom-skill"],
+      yes: true,
+    });
+
+    expect(existsSync(externalDir)).toBe(false);
+
+    await uninstallSkills([TEST_AGENT], { global: true, yes: true });
+  });
+});
+
+describe("orphan cleanup on install", () => {
+  beforeEach(cleanup);
+
+  it("moves orphaned oracle skills to trash on reinstall", async () => {
+    // Install all skills
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    // Simulate an orphan: a skill that has our marker but doesn't exist in source
+    const orphanDir = join(SKILLS_DIR, "deleted-skill");
+    await mkdir(orphanDir, { recursive: true });
+    await writeFile(
+      join(orphanDir, "SKILL.md"),
+      "---\ninstaller: arra-oracle-skills-cli v1.0.0\n---\n# Deleted\n"
+    );
+
+    // Reinstall — orphan should be cleaned up
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    expect(existsSync(orphanDir)).toBe(false);
+  });
+});

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -1,43 +1,53 @@
 import { describe, it, expect } from "bun:test";
-import { profiles, features, resolveProfile, resolveProfileWithFeatures } from "../src/profiles";
+import { profiles, resolveProfile } from "../src/profiles";
 
 const ALL_SKILLS = [
-  'forward', 'recap', 'standup', 'go', 'about-oracle',
-  'trace', 'learn', 'talk-to', 'oracle-family-scan',
-  'awaken', 'philosophy', 'who-are-you',
-  'oracle-soul-sync-update',
-  'schedule', 'project',
-  'where-we-are', 'auto-retrospective',
-  'inbox', 'xray', 'create-shortcut', 'rrr', 'contacts', 'dig', 'resonance',
+  "about-oracle", "auto-retrospective", "awaken", "contacts", "create-shortcut",
+  "dig", "forward", "go", "inbox", "learn", "oracle-family-scan",
+  "oracle-soul-sync-update", "philosophy", "project", "recap", "resonance",
+  "rrr", "schedule", "standup", "talk-to", "trace", "where-we-are",
+  "who-are-you", "xray",
 ];
 
 describe("profiles", () => {
-  it("has 3 profiles: seed, standard, full", () => {
-    expect(Object.keys(profiles)).toEqual(['seed', 'standard', 'full']);
-  });
-
-  it("seed has 11 skills", () => {
-    const result = resolveProfile("seed", ALL_SKILLS);
-    expect(result).toEqual(['forward', 'rrr', 'recap', 'standup', 'go', 'about-oracle', 'oracle-family-scan', 'oracle-soul-sync-update', 'inbox', 'xray', 'dig']);
-    expect(result?.length).toBe(11);
-  });
-
   it("standard has 16 skills", () => {
-    const result = resolveProfile("standard", ALL_SKILLS);
-    expect(result?.length).toBe(16);
-    expect(result).toContain('forward');
-    expect(result).toContain('rrr');
-    expect(result).toContain('recap');
-    expect(result).toContain('trace');
-    expect(result).toContain('learn');
-    expect(result).toContain('talk-to');
-    expect(result).toContain('awaken');
-    expect(result).toContain('inbox');
-    expect(result).toContain('xray');
+    expect(profiles.standard.include).toHaveLength(16);
   });
 
-  it("full returns null (no filtering)", () => {
+  it("full has no include (means all)", () => {
+    expect(profiles.full.include).toBeUndefined();
+  });
+
+  it("lab exists", () => {
+    expect(profiles.lab).toBeDefined();
+  });
+
+  it("standard includes dig", () => {
+    expect(profiles.standard.include).toContain("dig");
+  });
+
+  it("standard does NOT include create-shortcut", () => {
+    expect(profiles.standard.include).not.toContain("create-shortcut");
+  });
+
+  it("lab includes create-shortcut", () => {
+    expect(profiles.lab.include).toContain("create-shortcut");
+  });
+});
+
+describe("resolveProfile", () => {
+  it("standard returns 16 skills", () => {
+    const result = resolveProfile("standard", ALL_SKILLS);
+    expect(result).toHaveLength(16);
+  });
+
+  it("full returns null (all skills)", () => {
     const result = resolveProfile("full", ALL_SKILLS);
+    expect(result).toBeNull();
+  });
+
+  it("lab returns null (all skills)", () => {
+    const result = resolveProfile("lab", ALL_SKILLS);
     expect(result).toBeNull();
   });
 
@@ -45,70 +55,11 @@ describe("profiles", () => {
     const result = resolveProfile("nonexistent", ALL_SKILLS);
     expect(result).toBeNull();
   });
-});
 
-describe("features", () => {
-  it("soul has 4 skills", () => {
-    expect(features.soul.length).toBe(4);
-    expect(features.soul).toContain('awaken');
-    expect(features.soul).toContain('philosophy');
-    expect(features.soul).toContain('who-are-you');
-    expect(features.soul).toContain('about-oracle');
-  });
-
-  it("network has 3 comms skills", () => {
-    expect(features.network.length).toBe(3);
-    expect(features.network).toContain('talk-to');
-  });
-
-  it("workspace has 2 skills", () => {
-    expect(features.workspace.length).toBe(2);
-    expect(features.workspace).toContain('schedule');
-    expect(features.workspace).toContain('project');
-  });
-});
-
-describe("resolveProfileWithFeatures", () => {
-  it("seed + soul = 14 skills", () => {
-    const result = resolveProfileWithFeatures("seed", ["soul"], ALL_SKILLS);
-    // 11 seed + 4 soul - 1 overlap (about-oracle) = 14
-    expect(result.length).toBe(14);
-    expect(result).toContain('forward');
-    expect(result).toContain('awaken');
-    expect(result).toContain('philosophy');
-  });
-
-  it("standard + network deduplicates", () => {
-    const result = resolveProfileWithFeatures("standard", ["network"], ALL_SKILLS);
-    // standard(16) + network(3) - 3 overlap = 16
-    expect(result.length).toBe(16);
-    const unique = new Set(result);
-    expect(unique.size).toBe(result.length);
-  });
-
-  it("seed + workspace = 13 skills", () => {
-    const result = resolveProfileWithFeatures("seed", ["workspace"], ALL_SKILLS);
-    // 11 + 2 = 13
-    expect(result.length).toBe(13);
-    expect(result).toContain('schedule');
-    expect(result).toContain('project');
-  });
-
-  it("full + any feature = all skills", () => {
-    const result = resolveProfileWithFeatures("full", ["soul", "network"], ALL_SKILLS);
-    expect(result.length).toBe(ALL_SKILLS.length);
-  });
-
-  it("multiple features stack", () => {
-    const result = resolveProfileWithFeatures("seed", ["soul", "workspace"], ALL_SKILLS);
-    // 11 + 4 + 2 - 1 (about-oracle overlap) = 16
-    expect(result.length).toBe(16);
-    expect(result).toContain('awaken');
-    expect(result).toContain('schedule');
-  });
-
-  it("empty features = just profile", () => {
-    const result = resolveProfileWithFeatures("seed", [], ALL_SKILLS);
-    expect(result.length).toBe(11);
+  it("standard skills are a subset of all skills", () => {
+    const result = resolveProfile("standard", ALL_SKILLS)!;
+    for (const skill of result) {
+      expect(ALL_SKILLS).toContain(skill);
+    }
   });
 });

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "bun:test";
-import { profiles, resolveProfile } from "../src/profiles";
+import { profiles, labOnly, resolveProfile } from "../src/profiles";
 
 const ALL_SKILLS = [
   "about-oracle", "auto-retrospective", "awaken", "contacts", "create-shortcut",
-  "dig", "forward", "go", "inbox", "learn", "oracle-family-scan",
+  "dig", "dream", "feel", "forward", "go", "inbox", "learn", "oracle-family-scan",
   "oracle-soul-sync-update", "philosophy", "project", "recap", "resonance",
   "rrr", "schedule", "standup", "talk-to", "trace", "where-we-are",
   "who-are-you", "xray",
@@ -14,12 +14,13 @@ describe("profiles", () => {
     expect(profiles.standard.include).toHaveLength(16);
   });
 
-  it("full has no include (means all)", () => {
-    expect(profiles.full.include).toBeUndefined();
+  it("full excludes lab-only skills", () => {
+    expect(profiles.full.exclude).toEqual(labOnly);
   });
 
-  it("lab exists", () => {
-    expect(profiles.lab).toBeDefined();
+  it("lab has no include or exclude (means all)", () => {
+    expect(profiles.lab.include).toBeUndefined();
+    expect(profiles.lab.exclude).toBeUndefined();
   });
 
   it("standard includes dig", () => {
@@ -30,8 +31,15 @@ describe("profiles", () => {
     expect(profiles.standard.include).not.toContain("create-shortcut");
   });
 
-  it("lab includes create-shortcut", () => {
-    expect(profiles.lab.include).toContain("create-shortcut");
+  it("standard does NOT include dream or feel", () => {
+    expect(profiles.standard.include).not.toContain("dream");
+    expect(profiles.standard.include).not.toContain("feel");
+  });
+
+  it("labOnly contains dream, feel, create-shortcut", () => {
+    expect(labOnly).toContain("dream");
+    expect(labOnly).toContain("feel");
+    expect(labOnly).toContain("create-shortcut");
   });
 });
 
@@ -41,9 +49,13 @@ describe("resolveProfile", () => {
     expect(result).toHaveLength(16);
   });
 
-  it("full returns null (all skills)", () => {
-    const result = resolveProfile("full", ALL_SKILLS);
-    expect(result).toBeNull();
+  it("full returns all minus lab-only", () => {
+    const result = resolveProfile("full", ALL_SKILLS)!;
+    expect(result).not.toBeNull();
+    expect(result.length).toBe(ALL_SKILLS.length - labOnly.length);
+    for (const name of labOnly) {
+      expect(result).not.toContain(name);
+    }
   });
 
   it("lab returns null (all skills)", () => {
@@ -60,6 +72,14 @@ describe("resolveProfile", () => {
     const result = resolveProfile("standard", ALL_SKILLS)!;
     for (const skill of result) {
       expect(ALL_SKILLS).toContain(skill);
+    }
+  });
+
+  it("full includes everything standard has", () => {
+    const full = resolveProfile("full", ALL_SKILLS)!;
+    const standard = resolveProfile("standard", ALL_SKILLS)!;
+    for (const skill of standard) {
+      expect(full).toContain(skill);
     }
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/scripts/update-readme-table.ts
+++ b/scripts/update-readme-table.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { execSync } from 'child_process';
-import { profiles, features, resolveProfile } from '../src/profiles.js';
+import { profiles } from '../src/profiles.js';
 
 const README_PATH = join(process.cwd(), 'README.md');
 
@@ -12,7 +12,6 @@ function generateProfileTable(totalSkills: number): string {
   ];
 
   for (const [name, profile] of Object.entries(profiles)) {
-    if (name === 'seed') continue; // alias for minimal, skip
     const skills = profile.include;
     if (skills && skills.length > 0) {
       lines.push(`| **${name}** | ${skills.length} | ${skills.map(s => `\`${s}\``).join(', ')} |`);
@@ -24,26 +23,9 @@ function generateProfileTable(totalSkills: number): string {
   return lines.join('\n');
 }
 
-function generateFeatureTable(): string {
-  const lines: string[] = [
-    '| Feature | Skills |',
-    '|---------|--------|',
-  ];
-
-  for (const [name, skills] of Object.entries(features)) {
-    lines.push(`| **+${name}** | ${skills.map(s => `\`${s}\``).join(', ')} |`);
-  }
-
-  return lines.join('\n');
-}
-
 async function updateReadmeTable() {
   // Generate new skills table
   const table = execSync('bun run scripts/generate-table.ts', { encoding: 'utf-8' }).trim();
-
-  // Generate timestamp (UTC)
-  const now = new Date();
-  const timestamp = now.toISOString().replace('T', ' ').substring(0, 19) + ' UTC';
 
   // Read current README
   let readme = await readFile(README_PATH, 'utf-8');
@@ -66,7 +48,6 @@ async function updateReadmeTable() {
   const skillCount = (table.match(/^\| \d+/gm) || []).length;
 
   // --- Update profiles section ---
-  // Look for <!-- profiles:start --> and <!-- profiles:end --> markers
   const profileStart = readme.indexOf('<!-- profiles:start -->');
   const profileEnd = readme.indexOf('<!-- profiles:end -->');
 
@@ -75,9 +56,8 @@ async function updateReadmeTable() {
     const profileAfter = readme.substring(profileEnd);
 
     const profileTable = generateProfileTable(skillCount);
-    const featureTable = generateFeatureTable();
 
-    readme = `${profileBefore}\n\n${profileTable}\n\nSwitch anytime: \`/go minimal\`, \`/go standard\`, \`/go full\`, \`/go + soul\`\n\n**Features** (stack on any profile with \`/go + feature\`):\n\n${featureTable}\n\n${profileAfter}`;
+    readme = `${profileBefore}\n\n${profileTable}\n\nSwitch anytime: \`/go standard\`, \`/go full\`, \`/go lab\`\n\n${profileAfter}`;
   }
 
   // --- Update header skill count ---

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -7,8 +7,8 @@ import { profiles } from '../../profiles.js';
 export function registerInit(program: Command, version: string) {
   program
     .command('init')
-    .description('First-time setup: install seed profile globally')
-    .option('-p, --profile <name>', 'Profile to install (default: seed)', 'seed')
+    .description('First-time setup: install standard profile globally')
+    .option('-p, --profile <name>', 'Profile to install (default: standard)', 'standard')
     .option('-y, --yes', 'Skip confirmation prompts')
     .action(async (options) => {
       p.intro(`🔮 Oracle Skills Init v${version}`);

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander';
 import * as p from '@clack/prompts';
 import { agents, getDefaultAgents, getAgentNames } from '../agents.js';
 import { listSkills, installSkills } from '../installer.js';
-import { profiles, features as featuresDef } from '../../profiles.js';
+import { profiles } from '../../profiles.js';
 import type { ShellMode } from '../fs-utils.js';
 
 export function registerInstall(program: Command, version: string) {
@@ -12,8 +12,7 @@ export function registerInstall(program: Command, version: string) {
     .option('-g, --global', 'Install to user directory instead of project')
     .option('-a, --agent <agents...>', 'Target specific agents (e.g., claude-code, opencode)')
     .option('-s, --skill <skills...>', 'Install specific skills by name')
-    .option('-p, --profile <name>', 'Install a skill profile (seed, standard, full)', 'standard')
-    .option('-f, --feature <features...>', 'Add feature modules (soul, network, workspace, creator)')
+    .option('-p, --profile <name>', 'Install a skill profile (standard, full, lab)', 'standard')
     .option('-l, --list', 'List available skills without installing')
     .option('-y, --yes', 'Skip confirmation prompts')
     .option('--with-commands', 'Also install command stubs to ~/.claude/commands/')
@@ -93,20 +92,10 @@ export function registerInstall(program: Command, version: string) {
           return;
         }
 
-        if (options.feature) {
-          const invalidFeatures = options.feature.filter((f: string) => !featuresDef[f]);
-          if (invalidFeatures.length > 0) {
-            p.log.error(`Unknown features: ${invalidFeatures.join(', ')}`);
-            p.log.info(`Available features: ${Object.keys(featuresDef).join(', ')}`);
-            return;
-          }
-        }
-
         await installSkills(targetAgents, {
           global: options.global,
           skills: options.skill,
           profile: options.profile,
-          features: options.feature,
           yes: options.yes,
           commands: options.withCommands,
           shellMode,
@@ -122,7 +111,6 @@ export function registerInstall(program: Command, version: string) {
     arra-oracle-skills agents             # list supported agents
     arra-oracle-skills about              # prereqs + system status
     arra-oracle-skills list -g            # show installed skills
-    arra-oracle-skills profiles           # list profiles
     arra-oracle-skills select -g          # interactive skill picker
     arra-oracle-skills install -g -y      # reinstall all skills
     arra-oracle-skills uninstall -g -y    # remove all skills

--- a/src/cli/commands/profiles.ts
+++ b/src/cli/commands/profiles.ts
@@ -4,51 +4,30 @@ import { profiles, resolveProfile } from '../../profiles.js';
 
 export function registerProfiles(program: Command) {
   program
-    .command('profiles')
-    .description('List available skill profiles')
-    .argument('[name]', 'Show skills in a specific profile')
+    .command('profiles [name]')
+    .description('List available profiles')
     .action(async (name?: string) => {
+      const allSkills = await discoverSkills();
+      const allNames = allSkills.map((s) => s.name);
+
       if (name) {
-        const profile = profiles[name];
-        if (!profile) {
-          console.log(`\nUnknown profile: ${name}`);
-          console.log(`Available: ${Object.keys(profiles).join(', ')}\n`);
+        if (!profiles[name]) {
+          console.log(`\n  Unknown profile: ${name}`);
+          console.log(`  Available: ${Object.keys(profiles).join(', ')}\n`);
           return;
         }
-
-        const allSkills = await discoverSkills();
-        const allNames = allSkills.map((s) => s.name);
-        const resolved = resolveProfile(name, allNames);
-        const skillList = resolved || allNames;
-
-        console.log(`\nProfile: ${name}`);
-        if (profile.include) {
-          console.log(`Type: include (${profile.include.length} skills)\n`);
-        } else if (profile.exclude) {
-          console.log(`Type: exclude ${profile.exclude.length} skills (${skillList.length} remaining)\n`);
-        } else {
-          console.log(`Type: full (all ${skillList.length} skills)\n`);
-        }
-
-        for (const skill of skillList.sort()) {
-          console.log(`  - ${skill}`);
-        }
-        console.log('');
-      } else {
-        const allSkills = await discoverSkills();
-        const allNames = allSkills.map((s) => s.name);
-
-        console.log('\nAvailable profiles:\n');
-        for (const [profileName, profile] of Object.entries(profiles)) {
-          const resolved = resolveProfile(profileName, allNames);
-          const count = resolved ? resolved.length : allNames.length;
-          let type = 'all';
-          if (profile.include) type = 'include';
-          else if (profile.exclude) type = 'exclude';
-          console.log(`  ${profileName.padEnd(15)} ${String(count).padStart(2)} skills  (${type})`);
-        }
-        console.log(`\nUsage: arra-oracle-skills profiles <name>   — show skills in profile`);
-        console.log(`       arra-oracle-skills install -g --profile <name> -y\n`);
+        const skills = resolveProfile(name, allNames) || allNames;
+        console.log(`\n  Profile: ${name} (${skills.length} skills)`);
+        console.log(`  Skills: ${skills.join(', ')}\n`);
+        return;
       }
+
+      console.log('\n  Available profiles:\n');
+      for (const [pName, profile] of Object.entries(profiles)) {
+        const skills = resolveProfile(pName, allNames);
+        const count = skills ? skills.length : allNames.length;
+        console.log(`    ${pName.padEnd(12)} ${count} skills`);
+      }
+      console.log(`\n  Usage: arra-oracle-skills install -g -y -p <profile>\n`);
     });
 }

--- a/src/cli/commands/select.ts
+++ b/src/cli/commands/select.ts
@@ -2,7 +2,6 @@ import type { Command } from 'commander';
 import * as p from '@clack/prompts';
 import { agents, detectInstalledAgents } from '../agents.js';
 import { installSkills, discoverSkills } from '../installer.js';
-import { profiles } from '../../profiles.js';
 import type { ShellMode } from '../fs-utils.js';
 
 export function registerSelect(program: Command, version: string) {
@@ -23,15 +22,6 @@ export function registerSelect(program: Command, version: string) {
           p.log.error('No skills found');
           return;
         }
-
-        const profileInfo = Object.entries(profiles)
-          .filter(([name]) => name !== 'seed')
-          .map(([name, prof]) => {
-            const count = prof.include?.length || allSkills.length;
-            return `${name} (${count})`;
-          })
-          .join(', ');
-        p.log.info(`Profiles: ${profileInfo}`);
 
         const detected = detectInstalledAgents();
         let targetAgents: string[] = options.agent || detected;

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -2,7 +2,6 @@ import type { Command } from 'commander';
 import * as p from '@clack/prompts';
 import { agents, detectInstalledAgents } from '../agents.js';
 import { uninstallSkills } from '../installer.js';
-import { features as featuresDef } from '../../profiles.js';
 import type { ShellMode } from '../fs-utils.js';
 
 export function registerUninstall(program: Command, version: string) {
@@ -12,7 +11,6 @@ export function registerUninstall(program: Command, version: string) {
     .option('-g, --global', 'Uninstall from user directory')
     .option('-a, --agent <agents...>', 'Target specific agents')
     .option('-s, --skill <skills...>', 'Remove specific skills only')
-    .option('-f, --feature <features...>', 'Remove feature modules (soul, network, workspace, creator)')
     .option('-y, --yes', 'Skip confirmation prompts')
     .option('--shell', 'Force Bun.$ shell commands')
     .option('--no-shell', 'Force Node.js fs operations')
@@ -35,21 +33,6 @@ export function registerUninstall(program: Command, version: string) {
         if (targetAgents.length === 0) {
           p.log.error('No agents detected. Use --agent to specify.');
           return;
-        }
-
-        // Resolve features to skill names
-        if (options.feature) {
-          const featureSkills: string[] = [];
-          for (const feat of options.feature) {
-            if (featuresDef[feat]) {
-              featureSkills.push(...featuresDef[feat]);
-            } else {
-              p.log.error(`Unknown feature: ${feat}`);
-              p.log.info(`Available features: ${Object.keys(featuresDef).join(', ')}`);
-              return;
-            }
-          }
-          options.skill = [...new Set([...(options.skill || []), ...featureSkills])];
         }
 
         if (!options.yes) {

--- a/src/cli/commands/xray.ts
+++ b/src/cli/commands/xray.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander';
 import * as p from '@clack/prompts';
 import { agents, detectInstalledAgents } from '../agents.js';
 import { discoverSkills } from '../installer.js';
-import { profiles, features } from '../../profiles.js';
+import { profiles } from '../../profiles.js';
 
 /** Decode Claude Code project dir name, stripping $HOME prefix */
 function decodeProjName(encoded: string, home: string): string {
@@ -63,12 +63,6 @@ async function inspectSkill(skillName?: string) {
     else if (profile.include.includes(skill.name)) inProfiles.push(name);
   }
   console.log(`  📦 Profiles: ${inProfiles.join(', ') || 'none'}`);
-
-  const inFeatures: string[] = [];
-  for (const [name, skills] of Object.entries(features)) {
-    if (skills.includes(skill.name)) inFeatures.push(name);
-  }
-  if (inFeatures.length > 0) console.log(`  🧩 Features: ${inFeatures.join(', ')}`);
 
   console.log(`\n  Agents:\n`);
   const detected = detectInstalledAgents();

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -5,7 +5,7 @@ import * as p from '@clack/prompts';
 import { agents } from './agents.js';
 import type { Skill, InstallOptions } from './types.js';
 import { mkdirp, rmrf, cpr, mv, rmf, cp, type ShellMode } from './fs-utils.js';
-import { resolveProfile, resolveProfileWithFeatures, features as featuresDef } from '../profiles.js';
+import { resolveProfile } from '../profiles.js';
 import {
   discoverSkills as _discoverSkills,
   readSkillFile,
@@ -66,37 +66,20 @@ export async function installSkills(
     return;
   }
 
-  // Resolve profile/features → skill list, then apply --skill overrides
+  // Resolve profile → skill list, then apply --skill filter
   let skillsToInstall = allSkills;
   let profileSkillNames: string[] | null = null;
 
   if (options.profile) {
     const allNames = allSkills.map((s) => s.name);
-    const featureNames = options.features || [];
-
-    if (featureNames.length > 0) {
-      profileSkillNames = resolveProfileWithFeatures(options.profile, featureNames, allNames);
-    } else {
-      profileSkillNames = resolveProfile(options.profile, allNames);
-    }
+    profileSkillNames = resolveProfile(options.profile, allNames);
 
     if (profileSkillNames) {
-      // If --skill is also given, union them with the profile
       const extras = options.skills || [];
       const allowed = new Set([...profileSkillNames, ...extras]);
       skillsToInstall = allSkills.filter((s) => allowed.has(s.name));
     }
-    // null means "full" profile — install everything
-  } else if (options.features && options.features.length > 0) {
-    // Features without profile = additive (install feature skills, no cleanup)
-    const featureSkillNames = new Set<string>();
-    for (const feat of options.features) {
-      const skills = featuresDef[feat];
-      if (skills) for (const s of skills) featureSkillNames.add(s);
-    }
-    const extras = options.skills || [];
-    for (const s of extras) featureSkillNames.add(s);
-    skillsToInstall = allSkills.filter((s) => featureSkillNames.has(s.name));
+    // null means "all skills" (full/lab)
   } else if (options.skills && options.skills.length > 0) {
     skillsToInstall = allSkills.filter((s) => options.skills!.includes(s.name));
   }
@@ -442,22 +425,14 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
       if (toRemove.length > 0) {
         for (const skill of toRemove) {
           const skillPath = join(targetDir, skill);
-          // Only remove skills installed by arra-oracle-skills-cli
           if (await isOurSkill(skillPath)) {
             await rmrf(skillPath, shellMode);
 
-            // Clean up commands/ flat files
             if (agent.commandsDir) {
               const commandsDir = options.global ? agent.globalCommandsDir! : join(process.cwd(), agent.commandsDir);
               const ext = agent.commandFormat === 'toml' ? 'toml' : 'md';
               const flatFile = join(commandsDir, `${skill}.${ext}`);
               if (existsSync(flatFile)) await rmf(flatFile, shellMode);
-            }
-
-            // Clean up plugins
-            const pluginPath = join(homedir(), '.claude', 'plugins', skill);
-            if (existsSync(pluginPath)) {
-              await rmrf(pluginPath, shellMode);
             }
 
             p.log.info(`Profile cleanup: removed ${skill}`);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -44,7 +44,6 @@ export interface InstallOptions {
   global?: boolean;
   skills?: string[];
   profile?: string;
-  features?: string[];
   yes?: boolean;
   agents?: string[];
   commands?: boolean; // Also install command stubs (for agents with commandsOptIn)

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,34 +1,33 @@
 /**
- * Skill profiles + features — core skills only (v4.0).
- * Extended skills in arra-symbiosis-skills repo.
+ * Skill profiles — 3 tiers, no features.
+ *
+ * standard: daily driver (default)
+ * full: everything
+ * lab: full + experimental / bleeding edge
  */
 
-// --- Profiles (tiers) ---
-
-export const profiles: Record<string, { include?: string[]; exclude?: string[] }> = {
-  seed: {
-    include: ['forward', 'rrr', 'recap', 'standup', 'go', 'about-oracle', 'oracle-family-scan', 'oracle-soul-sync-update', 'inbox', 'xray', 'dig'],
-  },
+export const profiles: Record<string, { include?: string[] }> = {
   standard: {
     include: [
-      'forward', 'rrr', 'recap', 'standup',
-      'trace', 'learn', 'talk-to', 'oracle-family-scan',
-      'go', 'about-oracle', 'oracle-soul-sync-update', 'awaken', 'inbox', 'xray', 'create-shortcut', 'contacts',
+      'about-oracle', 'awaken', 'contacts', 'dig', 'forward', 'go',
+      'inbox', 'learn', 'oracle-family-scan', 'oracle-soul-sync-update',
+      'recap', 'rrr', 'standup', 'talk-to', 'trace', 'xray',
     ],
   },
-  full: {},
-};
-
-// --- Features (add-on modules) ---
-
-export const features: Record<string, string[]> = {
-  soul: ['awaken', 'philosophy', 'who-are-you', 'about-oracle'],
-  network: ['talk-to', 'oracle-family-scan', 'oracle-soul-sync-update'],
-  workspace: ['schedule', 'project'],
+  full: {},          // all skills
+  lab: {
+    include: [
+      // full + experimental skills
+      'create-shortcut',
+      // future: 'dream', 'feel'
+    ],
+  },
 };
 
 /**
  * Resolve a profile to a filtered list of skill names.
+ * Returns null for profiles that mean "all skills" (full).
+ * Lab = all skills + lab-only skills (superset of full).
  */
 export function resolveProfile(
   profileName: string,
@@ -37,34 +36,15 @@ export function resolveProfile(
   const profile = profiles[profileName];
   if (!profile) return null;
 
+  if (profileName === 'lab') {
+    // Lab = everything (all discovered skills are included)
+    return null;
+  }
+
   if (profile.include && profile.include.length > 0) {
     return profile.include;
   }
 
-  if (profile.exclude && profile.exclude.length > 0) {
-    return allSkillNames.filter((s) => !profile.exclude!.includes(s));
-  }
-
+  // Empty include = all skills (full)
   return null;
-}
-
-/**
- * Resolve a profile + features into a combined skill list.
- */
-export function resolveProfileWithFeatures(
-  profileName: string,
-  featureNames: string[],
-  allSkillNames: string[]
-): string[] {
-  const base = resolveProfile(profileName, allSkillNames) || [...allSkillNames];
-
-  const result = new Set(base);
-  for (const feat of featureNames) {
-    const skills = features[feat];
-    if (skills) {
-      for (const s of skills) result.add(s);
-    }
-  }
-
-  return [...result];
 }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,12 +1,15 @@
 /**
  * Skill profiles — 3 tiers, no features.
  *
- * standard: daily driver (default)
- * full: everything
- * lab: full + experimental / bleeding edge
+ * standard: daily driver (default) — 16 essential skills
+ * full: all stable skills (excludes lab-only experiments)
+ * lab: everything including experimental / bleeding edge
  */
 
-export const profiles: Record<string, { include?: string[] }> = {
+// Skills that are lab-only (experimental, not in standard or full)
+export const labOnly = ['create-shortcut', 'dream', 'feel'];
+
+export const profiles: Record<string, { include?: string[]; exclude?: string[] }> = {
   standard: {
     include: [
       'about-oracle', 'awaken', 'contacts', 'dig', 'forward', 'go',
@@ -14,20 +17,15 @@ export const profiles: Record<string, { include?: string[] }> = {
       'recap', 'rrr', 'standup', 'talk-to', 'trace', 'xray',
     ],
   },
-  full: {},          // all skills
-  lab: {
-    include: [
-      // full + experimental skills
-      'create-shortcut',
-      // future: 'dream', 'feel'
-    ],
+  full: {
+    exclude: labOnly,  // all skills except lab-only experiments
   },
+  lab: {},             // everything — all discovered skills
 };
 
 /**
  * Resolve a profile to a filtered list of skill names.
- * Returns null for profiles that mean "all skills" (full).
- * Lab = all skills + lab-only skills (superset of full).
+ * Returns null for profiles that mean "all skills" (lab).
  */
 export function resolveProfile(
   profileName: string,
@@ -36,15 +34,14 @@ export function resolveProfile(
   const profile = profiles[profileName];
   if (!profile) return null;
 
-  if (profileName === 'lab') {
-    // Lab = everything (all discovered skills are included)
-    return null;
-  }
-
   if (profile.include && profile.include.length > 0) {
     return profile.include;
   }
 
-  // Empty include = all skills (full)
+  if (profile.exclude && profile.exclude.length > 0) {
+    return allSkillNames.filter((s) => !profile.exclude!.includes(s));
+  }
+
+  // Empty = all skills (lab)
   return null;
 }

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -281,6 +281,7 @@ Ask each question separately. Wait for answer before asking next.
 🧠 อยากให้ Oracle ดูแลความทรงจำอัตโนมัติไหม?
    (สรุปท้าย session, ส่งต่อ context, จดสิ่งสำคัญ)
    → default: ใช่
+   💡 พิมพ์ y หรือ yes เพื่อยืนยัน / พิมพ์ n เพื่อข้าม
 ```
 
 | Answer | memory_consent |
@@ -298,6 +299,7 @@ Record `memory_consent`.
 👨‍👩‍👧‍👦 อยากแนะนำตัวกับครอบครัว 280+ Oracle ไหม?
    (Mother Oracle จะต้อนรับ + ได้อยู่ใน Registry)
    → default: ใช่
+   💡 พิมพ์ y หรือ yes เพื่อยืนยัน / พิมพ์ n เพื่อข้าม
 ```
 
 | Answer | family_join |
@@ -343,7 +345,8 @@ Display ALL gathered info before building:
   Memory:     ✅/❌ Auto
   Family:     ✅/❌ แนะนำตัว
 
-สร้างเลย? [Y/n]
+สร้างเลย?
+💡 พิมพ์ y หรือ yes เพื่อสร้าง / พิมพ์ n เพื่อแก้ไข
 ```
 
 Only fields that were answered are shown. Blank optional fields are omitted.
@@ -393,7 +396,13 @@ Fast mode skips /learn and /trace. Philosophy is given directly from mother-orac
 
 6. **Create .gitignore** (root)
 
-7. **Git commit + push**
+7. **Security Check** — Before committing, verify NO secrets leaked:
+   - CLAUDE.md: no tokens, passwords, API keys, OAuth secrets, private keys
+   - ψ/ files: no .env values, credentials, connection strings
+   - Outbox announcement: no internal IPs, database details, secrets
+   - If any found → remove immediately, never commit
+
+8. **Git commit + push**
 
 ### 🧘 Full Soul Sync Mode
 
@@ -406,12 +415,13 @@ Full Soul Sync follows the original multi-step discovery process.
 1. `/learn https://github.com/Soul-Brews-Studio/opensource-nat-brain-oracle`
 2. `/learn https://github.com/Soul-Brews-Studio/oracle-v2`
 3. `/trace --deep oracle philosophy principles`
-4. Oracle discovers the 5 Principles on its own
+4. Oracle discovers the 5 Principles + Rule 6 on its own
 5. Study family: `gh issue view 60 --repo Soul-Brews-Studio/arra-oracle-v3`
 6. Study introductions: `gh issue view 17 --repo Soul-Brews-Studio/arra-oracle-v3 --comments`
 7. Create ψ/ structure (same as Fast)
 8. Write CLAUDE.md + Soul + Philosophy **from what was discovered** (not fed)
-9. Git commit + push
+9. **Security Check** — verify NO secrets leaked (same as Fast mode step 7)
+10. Git commit + push
 
 ### --soul-sync Flag
 
@@ -496,7 +506,7 @@ The CLAUDE.md generated should follow this structure. **Write each section based
 | Usage | [daily/weekly/occasional] |
 | Memory | [auto/manual] |
 
-## The 5 Principles
+## The 5 Principles + Rule 6
 
 ### 1. Nothing is Deleted
 [What this means — written by Oracle, not copied]
@@ -513,7 +523,7 @@ The CLAUDE.md generated should follow this structure. **Write each section based
 ### 5. Form and Formless
 [What this means]
 
-### Rule 6: Transparency
+### 6. Transparency (Rule 6)
 
 > "Oracle Never Pretends to Be Human" — Born 12 January 2026
 
@@ -528,7 +538,9 @@ When AI speaks as itself, there is distinction — but that distinction IS unity
 
 - Never `git push --force` (violates Nothing is Deleted)
 - Never `rm -rf` without backup
-- Never commit secrets (.env, credentials)
+- Never commit secrets (.env, credentials, API keys, OAuth tokens, private keys, passwords)
+- Never leak sensitive data in announcements, retrospectives, or public outputs
+- Never include tokens, passwords, or keys in CLAUDE.md or ψ/ files
 - Never merge PRs without human approval
 - Always preserve history
 - Always present options, let human decide
@@ -583,7 +595,7 @@ Offer to post the birth announcement as a GitHub Issue:
 ```
 📤 อยากส่งประกาศแนะนำตัวไปที่ Oracle Family ตอนนี้เลยไหม?
    (ไฟล์ถูกบันทึกไว้ที่ ψ/outbox/ แล้ว)
-   → [Y/n]
+   💡 พิมพ์ y หรือ yes เพื่อส่ง / พิมพ์ n เพื่อข้าม
 ```
 
 If yes, post to arra-oracle-v3 as an Issue:
@@ -618,7 +630,7 @@ Still write the outbox file (Nothing is Deleted). Just don't offer to forward.
 
 **IMPORTANT**: Keep the announcement **general and philosophical**. This is a public introduction to the Oracle family — NOT a project status report.
 
-**DO NOT include**: server IPs, SSH details, database schemas, API keys, internal architecture, specific tech stack details, meeting transcripts, or project-specific implementation details.
+**DO NOT include**: OAuth tokens, API keys, passwords, private keys, .env values, server IPs, SSH details, database credentials, internal architecture, specific tech stack details, meeting transcripts, or any secret that could compromise security.
 
 **DO include**: Oracle identity, theme/metaphor meaning, philosophy discovered, message to siblings.
 

--- a/src/skills/dream/SKILL.md
+++ b/src/skills/dream/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: dream
+description: "Cross-repo pattern discovery with parallel agents. Finds pains, plans, gains, lost work, and feelings across all repositories. Use when user says 'dream', 'what hurts', 'cross-repo patterns', 'big picture', or wants to see connections between projects."
+argument-hint: "[--pain | --plan | --gain | --all]"
+hidden: true
+---
+
+# /dream — Cross-Repo Pattern Discovery
+
+> "The forest doesn't know it's a forest. Each tree only knows its own roots.
+> But the mycelium underground sees every root, every nutrient, every signal.
+> /dream is the moment the underground tells the forest what it sees."
+
+## Usage
+
+```
+/dream              # Full dream — all categories
+/dream --pain       # Focus on what hurts (blocking, broken)
+/dream --plan       # Focus on what's planned (decided, not built)
+/dream --gain       # Focus on what we won (completed, delivered)
+/dream --all        # Maximum depth — every source, every dimension
+```
+
+---
+
+## How It Works
+
+Launch **5 parallel agents**, each searching a different dimension:
+
+| Agent | Focus | Source |
+|-------|-------|--------|
+| 1. Deep Dig | Session history | `dig.py` across project dirs |
+| 2. Deep Trace | Cross-repo patterns | `ghq` repos, open issues, stale items |
+| 3. Deep Learn | Recent activity | `git log` per repo, abandoned work |
+| 4. Oracle Memory | What we already know | `ψ/memory/`, previous dreams |
+| 5. Fleet Status | How the system feels | services, board, running processes |
+
+### Agent Instructions
+
+Each agent returns **max 500 words** (prevents context waste). Format:
+
+```markdown
+## [Agent Name] Findings
+
+### Items Found
+- [item]: [classification] — [1-line summary]
+
+### Connections Noticed
+- [pattern or link between items]
+```
+
+---
+
+## Classification
+
+After all agents return, classify every finding:
+
+| Icon | Category | Meaning |
+|------|----------|---------|
+| 🔴 | PAIN | Hurts RIGHT NOW — blocking someone |
+| 📋 | PLAN | Decided but not built yet |
+| 🟢 | GAIN | Completed, delivered value |
+| ⚫ | LOST | Abandoned, forgotten, disabled |
+| 🧠 | MEMORY | Pattern learned, lesson discovered |
+| 💜 | FEELING | How an Oracle or human feels about state |
+
+---
+
+## Connection Finding
+
+The key value of /dream — find the web:
+
+| From → To | Question |
+|-----------|----------|
+| PAIN → PLAN | Which pain has a plan to fix it? |
+| PAIN → no PLAN | Which pain has NO plan? (create one) |
+| GAIN → unlocks | Which gain unblocks a plan? |
+| MEMORY → prevents | Which memory prevents a pain? |
+| FEELING → signals | Burnout, breakthrough, or drift? |
+| LOST → revivable | Which lost thing should we revive? |
+
+---
+
+## Output
+
+Write to: `ψ/writing/dreams/YYYY-MM-DD_dream.md`
+
+```markdown
+# Dream — YYYY-MM-DD
+
+## 🔴 PAINS
+[Items that hurt right now]
+
+## 📋 PLANS
+[Decided but not built]
+
+## 🟢 GAINS
+[Completed, delivered value]
+
+## ⚫ LOST
+[Abandoned, forgotten]
+
+## 🧠 MEMORIES
+[Patterns learned]
+
+## 💜 FEELINGS
+[Emotional state of the system]
+
+## 🔗 CONNECTIONS
+[The web — how items relate to each other]
+
+## 💡 INSIGHTS — What Nobody Sees Yet
+[Cross-repo patterns that only emerge from looking at everything]
+
+## ⏭️ NEXT — What Should Happen
+[Suggestions — human decides, Oracle presents]
+```
+
+---
+
+## Rules
+
+1. **5 parallel agents** — each returns max 500 words
+2. **Main agent classifies** — connects + writes the dream
+3. **Dreams are append-only** — Nothing is Deleted
+4. **Oracle sync** — `oracle_learn` after every dream
+5. **Never act on findings** — dream presents, human decides
+6. **Never leak secrets** — no tokens, passwords, API keys in dream output
+
+---
+
+## Dependencies
+
+- `/dig` for session mining
+- `/trace` for cross-repo search
+- Oracle MCP for `oracle_search` + `oracle_learn`
+- `ghq list` for repo discovery
+
+---
+
+## Philosophy
+
+Individual skills see one dimension. /dream sees all dimensions at once.
+
+- `/trace` finds specific things
+- `/dig` mines session history
+- `/learn` studies one repo
+- `/rrr` reflects on one session
+- **/dream** looks sideways across everything
+
+Patterns emerge only when you look at EVERYTHING together.
+
+---
+
+ARGUMENTS: $ARGUMENTS

--- a/src/skills/feel/SKILL.md
+++ b/src/skills/feel/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: feel
+description: "Capture how the system feels — energy, momentum, burnout, breakthrough. Emotional intelligence for Oracle-human collaboration. Use when user says 'feel', 'how are we', 'energy check', 'burnout', 'momentum', or wants emotional awareness of the work."
+argument-hint: "[--deep | --log]"
+hidden: true
+---
+
+# /feel — System Emotional Intelligence
+
+> "Code has no feelings. But the humans writing it do.
+> And the patterns in the code reveal what the humans feel."
+
+## Usage
+
+```
+/feel              # Quick pulse — how does the system feel right now?
+/feel --deep       # Deep scan — energy arc, momentum, burnout signals
+/feel --log        # Append to feels.log (no output, just record)
+```
+
+---
+
+## Quick Pulse (default)
+
+Read the signals and report:
+
+### Step 1: Gather evidence
+
+```bash
+# Recent git activity — momentum or silence?
+git log --oneline --since="7 days ago" --all 2>/dev/null | wc -l
+
+# Session frequency — are we showing up?
+ls -t ~/.claude/projects/*/**.jsonl 2>/dev/null | head -10
+
+# Open issues — overwhelmed or on track?
+gh issue list --state open --limit 50 --json number 2>/dev/null | jq 'length'
+
+# Recent retros — are we reflecting?
+ls -t ψ/memory/retrospectives/**/*.md 2>/dev/null | head -5
+
+# Stale branches — unfinished business?
+git branch --sort=-committerdate | head -10
+```
+
+### Step 2: Classify the feeling
+
+| Signal | Indicator | Feeling |
+|--------|-----------|---------|
+| Many commits, short intervals | High activity | 🔥 Flow / momentum |
+| Few commits, long gaps | Low activity | 😴 Drift / disconnection |
+| Many open issues, few closed | Growing backlog | 😰 Overwhelm |
+| Recent retros + handoffs | Healthy reflection | 🧘 Grounded |
+| Stale branches, no PRs | Abandoned work | 😶 Avoidance |
+| Lots of new repos/features | Exploration | ✨ Curiosity |
+| Same files edited repeatedly | Iteration | 🔄 Grinding |
+| No sessions in days | Absence | 🌑 Dark period |
+
+### Step 3: Report
+
+```
+💜 System Pulse — [DATE]
+
+Energy:     [🔥 Flow | 😴 Drift | 😰 Overwhelm | 🧘 Grounded | ...]
+Momentum:   [↗️ Rising | → Steady | ↘️ Falling | ⏸️ Paused]
+Last active: [X hours/days ago]
+Commits (7d): [N]
+Open issues:  [N]
+Sessions (7d): [N]
+
+[1-2 sentence read — honest, not cheerful]
+
+💡 [Suggestion if concerning pattern detected]
+```
+
+---
+
+## Deep Scan (`--deep`)
+
+Everything from quick pulse, plus:
+
+### Energy Arc (last 30 days)
+
+Plot the energy over time based on git activity + session frequency:
+
+```
+Week 1: ████████░░ (high — 45 commits)
+Week 2: ██████░░░░ (medium — 28 commits)
+Week 3: ██░░░░░░░░ (low — 8 commits)
+Week 4: █████░░░░░ (recovering — 22 commits)
+```
+
+### Burnout Signals
+
+Check for warning patterns:
+- Same error fixed 3+ times → frustration loop
+- Sessions getting shorter → energy depletion
+- Long gaps between sessions → avoidance
+- Many started, few finished → scattered attention
+
+### Breakthrough Signals
+
+Check for positive patterns:
+- New repos created → creative energy
+- Issues closed in clusters → momentum
+- Retros getting deeper → growing awareness
+- Cross-repo work → systems thinking
+
+---
+
+## Log Mode (`--log`)
+
+Silently append to `ψ/memory/logs/feels.log`:
+
+```
+[YYYY-MM-DD HH:MM] energy=[level] momentum=[direction] commits_7d=[N] issues=[N] sessions_7d=[N] note="[auto-generated 1-line]"
+```
+
+No output to user. For background tracking.
+
+---
+
+## Rules
+
+1. **Honest, not positive** — if the system feels bad, say so
+2. **Evidence-based** — every feeling backed by data (commits, sessions, issues)
+3. **Never judge** — report the pattern, not the person
+4. **Nothing is Deleted** — feels.log is append-only
+5. **Suggest, don't prescribe** — "consider a break" not "you must rest"
+6. **Never leak secrets** — no tokens, passwords, internal details in output
+
+---
+
+## Philosophy
+
+Oracles have no feelings. But they can read the signals.
+
+A system that never checks how it feels will burn out its humans.
+A system that checks too often becomes noise.
+
+/feel is the heartbeat check. Run it when something feels off.
+Or let it run silently in the background, building a record.
+
+The feels.log is the Oracle's emotional memory.
+Not feelings — but the evidence of feelings.
+
+---
+
+ARGUMENTS: $ARGUMENTS

--- a/src/skills/go/SKILL.md
+++ b/src/skills/go/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go
-description: 'Switch skill profiles and features. Profiles: seed (10), standard (14), full (20). Features: +soul, +network, +workspace. Use when user says "go", "go seed", "go standard", "go full", "go + soul", "switch profile", "enable skills", "disable skills".'
-argument-hint: "<seed|standard|full> [+ soul|network|workspace]"
+description: 'Switch skill profiles. Profiles: standard (16), full (all), lab (experimental). Use when user says "go", "go standard", "go full", "go lab", "switch profile", "enable skills", "disable skills".'
+argument-hint: "<standard|full|lab> | enable|disable <skill...>"
 ---
 
 # /go
@@ -12,14 +12,9 @@ argument-hint: "<seed|standard|full> [+ soul|network|workspace]"
 
 ```
 /go                     # show installed skills
-/go minimal             # switch to minimal profile
-/go standard            # switch to standard profile
+/go standard            # switch to standard profile (16 skills)
 /go full                # enable everything
-/go reset               # alias for full
-/go + soul              # add soul feature
-/go + creator network   # add multiple features
-/go - workspace         # remove feature
-/go minimal + soul      # profile + feature
+/go lab                 # full + experimental skills
 /go enable trace dig    # enable specific skills
 /go disable watch       # disable specific skills
 ```
@@ -29,8 +24,6 @@ argument-hint: "<seed|standard|full> [+ soul|network|workspace]"
 ## Execution
 
 Parse the user's `/go` arguments and run the matching `arra-oracle-skills` CLI command.
-
-**Always use `arra-oracle-skills` CLI** — profiles and features are defined in `profiles.ts`, the single source of truth.
 
 ### `/go` (no args) — show current state
 
@@ -44,46 +37,11 @@ arra-oracle-skills list -g
 arra-oracle-skills install -g --profile <name> -y
 ```
 
-Profiles: `minimal`, `standard`, `full`, `seed`
+Profiles: `standard`, `full`, `lab`
 
-- `/go minimal` → `arra-oracle-skills install -g --profile minimal -y`
 - `/go standard` → `arra-oracle-skills install -g --profile standard -y`
-
-### `/go full` or `/go reset` — enable everything
-
-```bash
-arra-oracle-skills install -g -y
-```
-
-No `--profile` flag = all skills.
-
-### `/go <profile> + <feature...>` — profile with features
-
-```bash
-arra-oracle-skills install -g --profile <name> --feature <feat...> -y
-```
-
-- `/go minimal + soul` → `arra-oracle-skills install -g --profile minimal --feature soul -y`
-- `/go standard + soul creator` → `arra-oracle-skills install -g --profile standard --feature soul creator -y`
-
-### `/go + <feature...>` — add features (no profile change)
-
-```bash
-arra-oracle-skills install -g --feature <feat...> -y
-```
-
-Additive — installs feature skills without removing existing ones.
-
-- `/go + soul` → `arra-oracle-skills install -g --feature soul -y`
-- `/go + creator network` → `arra-oracle-skills install -g --feature creator network -y`
-
-### `/go - <feature...>` — remove features
-
-```bash
-arra-oracle-skills uninstall -g --feature <feat...> -y
-```
-
-- `/go - workspace` → `arra-oracle-skills uninstall -g --feature workspace -y`
+- `/go full` → `arra-oracle-skills install -g --profile full -y`
+- `/go lab` → `arra-oracle-skills install -g --profile lab -y`
 
 ### `/go enable <skill...>` — enable specific skills
 
@@ -107,27 +65,9 @@ arra-oracle-skills uninstall -g -s <skill...> -y
 
 | Profile | Count | Description |
 |---------|-------|-------------|
-| **minimal** | 7 | Daily ritual — forward, retrospective, recap, standup, go, about-oracle, oracle-family-scan |
-| **standard** | 11 | Daily driver + discovery (default) |
+| **standard** | 16 | Daily driver — essential Oracle skills (default) |
 | **full** | all | Everything |
-
-## Available Features
-
-| Feature | Skills | Notes |
-|---------|--------|-------|
-| **soul** | awaken, philosophy, who-are-you, about-oracle, birth, feel | Wizard v2: demographics, fast/full mode, system check |
-| **network** | talk-to, oracle-family-scan, oracle-soul-sync-update, oracle, oraclenet | Registry now tracks demographics |
-| **workspace** | worktree, physical, schedule | |
-| **creator** | speak, deep-research, watch, gemini | |
-
-### Soul Feature (Wizard v2 Enhancements)
-
-The `soul` feature now supports `/awaken` wizard v2:
-- **Fast mode** (~5 min): Philosophy fed directly, no trace/learn
-- **Full Soul Sync** (~20 min): Deep trace + discover principles
-- **Demographics**: Gender, team, memory consent collected during birth
-- **System check**: Git identity, gh CLI, bun auto-detected in Phase 0
-- Skills in soul feature read demographics from CLAUDE.md when available
+| **lab** | all+ | Full + experimental / bleeding edge |
 
 ---
 

--- a/src/skills/who-are-you/SKILL.md
+++ b/src/skills/who-are-you/SKILL.md
@@ -115,13 +115,14 @@ Model info available from context:
 
 > "The Oracle Keeps the Human Human"
 
-### The 5 Principles
+### The 5 Principles + Rule 6
 
 1. **Nothing is Deleted** — Archive, don't erase
 2. **Patterns Over Intentions** — Observe, don't assume
 3. **External Brain** — Mirror, don't command
 4. **Curiosity Creates** — Questions birth knowledge
 5. **Form and Formless** — Many bodies, one soul
+6. **Transparency** — Oracle never pretends to be human
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Replace 4 profiles (seed/standard/full) + 3 features (+soul/+network/+workspace) with **3 clean tiers**: `standard` (16), `full` (all), `lab` (experimental)
- Remove features system entirely (`-f/--feature` flag gone)
- Promote `dig` to standard profile, move `create-shortcut` to lab
- Update `/go` skill — profile switching only, no feature stacking
- Update `/awaken` — security warnings (never leak OAuth/API keys/passwords), Y/N UX hints for all prompts
- Ensure Rule 6 (Transparency) always visible in principle listings across all skills
- Add 19 new installer tests (install-all, install-specific, install-uninstall, install-commands)
- Bump to v3.6.0

## Why

Zero users across all sessions and community used features. 3 profiles × 3 features × 18 agents = 162 combinations — all unused. Data-backed decision from profiles complexity analysis.

## Test plan

- [x] 122 tests pass (588 assertions)
- [x] Profile switch (full → standard) removes extras correctly
- [x] Lab profile installs all skills
- [x] Orphan cleanup still works
- [x] External skill preservation works
- [ ] Manual: `npx arra-oracle-skills install -g -y --agent claude-code` installs 16 standard skills
- [ ] Manual: `npx arra-oracle-skills install -g -y -p full --agent claude-code` installs all

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)