### PR TITLE
chore: release v3.7.0 — profile reorg + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v3.7.0 (2026-04-10)
+
+### Standalone /incubate + profile reorg
+
+**New skill:**
+- `/incubate` — clone or create repos for active development. The right hand of `/learn`. Workflow modes: default (long-term dev), `--flash` (issue → PR → offload), `--contribute` (fork + multi-PR), `--status`, `--offload`
+
+**Profile changes:**
+
+| Profile | Count | Description |
+|---------|-------|-------------|
+| **standard** | 14 | Daily driver (default) |
+| **full** | 21 | All stable skills |
+| **lab** | 28 | Full + experimental |
+
+- `contacts`, `inbox` → moved to lab (experimental)
+- `schedule` → moved to lab (experimental)
+- `dream`, `feel`, `vault` → now visible in autocomplete (removed `hidden: true`)
+- `incubate` → added to full profile (same level as `/learn` and `/project`)
+
+**Other:**
+- `/project incubate` → graduation note pointing to standalone `/incubate`
+- `/learn` description updated: `/project incubate` → `/incubate`
+- Resolved 7 open issues (#199 #198 #193 #192 #180 #141 #72)
+- 28 skills, 124 tests
+
+---
+
 ## v3.6.1 (2026-04-05)
 
 **Bug fixes + issue cleanup**

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@3.6.1 install -g -y --agent claude-code
+npx arra-oracle-skills@3.7.0 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@3.6.1 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@3.7.0 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@3.6.1 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@3.7.0 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@3.6.1 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@3.7.0 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@3.6.1 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@3.6.1 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@3.6.1 install -g -y --agent cursor
-npx arra-oracle-skills@3.6.1 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@3.7.0 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@3.7.0 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@3.7.0 install -g -y --agent cursor
+npx arra-oracle-skills@3.7.0 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@3.6.1 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@3.7.0 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -74,7 +74,7 @@ npx arra-oracle-skills@3.6.1 install -g -y --agent claude-code codex opencode
 
 | Profile | Count | Skills |
 |---------|-------|--------|
-| **standard** | 16 | `about-oracle`, `awaken`, `contacts`, `dig`, `forward`, `go`, `inbox`, `learn`, `oracle-family-scan`, `oracle-soul-sync-update`, `recap`, `rrr`, `standup`, `talk-to`, `trace`, `xray` |
+| **standard** | 14 | `about-oracle`, `awaken`, `dig`, `forward`, `go`, `learn`, `oracle-family-scan`, `oracle-soul-sync-update`, `recap`, `rrr`, `standup`, `talk-to`, `trace`, `xray` |
 | **full** | 28 | all |
 | **lab** | 28 | all |
 

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -10,8 +10,8 @@ const ALL_SKILLS = [
 ];
 
 describe("profiles", () => {
-  it("standard has 16 skills", () => {
-    expect(profiles.standard.include).toHaveLength(16);
+  it("standard has 14 skills", () => {
+    expect(profiles.standard.include).toHaveLength(14);
   });
 
   it("full excludes lab-only skills", () => {
@@ -36,19 +36,21 @@ describe("profiles", () => {
     expect(profiles.standard.include).not.toContain("feel");
   });
 
-  it("labOnly contains create-shortcut, dream, feel, schedule, vault", () => {
+  it("labOnly contains contacts, create-shortcut, dream, feel, inbox, schedule, vault", () => {
+    expect(labOnly).toContain("contacts");
     expect(labOnly).toContain("create-shortcut");
     expect(labOnly).toContain("dream");
     expect(labOnly).toContain("feel");
+    expect(labOnly).toContain("inbox");
     expect(labOnly).toContain("schedule");
     expect(labOnly).toContain("vault");
   });
 });
 
 describe("resolveProfile", () => {
-  it("standard returns 16 skills", () => {
+  it("standard returns 14 skills", () => {
     const result = resolveProfile("standard", ALL_SKILLS);
-    expect(result).toHaveLength(16);
+    expect(result).toHaveLength(14);
   });
 
   it("full returns all minus lab-only", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,19 +1,19 @@
 /**
  * Skill profiles — 3 tiers, no features.
  *
- * standard: daily driver (default) — 16 essential skills
+ * standard: daily driver (default) — 14 essential skills
  * full: all stable skills (excludes lab-only experiments)
  * lab: everything including experimental / bleeding edge
  */
 
 // Skills that are lab-only (experimental, not in standard or full)
-export const labOnly = ['create-shortcut', 'dream', 'feel', 'schedule', 'vault'];
+export const labOnly = ['contacts', 'create-shortcut', 'dream', 'feel', 'inbox', 'schedule', 'vault'];
 
 export const profiles: Record<string, { include?: string[]; exclude?: string[] }> = {
   standard: {
     include: [
-      'about-oracle', 'awaken', 'contacts', 'dig', 'forward', 'go',
-      'inbox', 'learn', 'oracle-family-scan', 'oracle-soul-sync-update',
+      'about-oracle', 'awaken', 'dig', 'forward', 'go',
+      'learn', 'oracle-family-scan', 'oracle-soul-sync-update',
       'recap', 'rrr', 'standup', 'talk-to', 'trace', 'xray',
     ],
   },

--- a/src/skills/project/SKILL.md
+++ b/src/skills/project/SKILL.md
@@ -40,83 +40,11 @@ ln -sf "$GHQ_ROOT/github.com/owner/repo" ψ/learn/owner/repo
 
 **Output**: "✓ Linked [repo] to ψ/learn/owner/repo"
 
-> **Note**: For full development workflows (--flash, --contribute, --offload), use the standalone `/incubate` skill. This section is kept as plumbing reference.
+### incubate — REDIRECTS TO /incubate
 
-### incubate [url|slug] [--offload|--contribute|--flash]
-
-Clone repo for **active development** with optional workflow flags.
-
-```bash
-# Same flow, different target
-ghq get -u https://github.com/owner/repo
-GHQ_ROOT=$(ghq root)
-mkdir -p ψ/incubate/owner
-ln -sf "$GHQ_ROOT/github.com/owner/repo" ψ/incubate/owner/repo
-```
-
-**Output**: "✓ Linked [repo] to ψ/incubate/owner/repo"
-
-#### Workflow Flags
-
-| Flag | Scope | Duration | Cleanup |
-|------|-------|----------|---------|
-| (none) | Long-term dev | Weeks/months | Manual |
-| `--offload` | Manual trigger | — | Remove symlink (keep ghq) |
-| `--contribute` | Multi-feature | Days/weeks | Offload when all done (keep ghq for PR feedback) |
-| `--flash` | Single fix | Minutes | Issue → PR → offload → purge (one shot) |
-
-#### --offload
-
-Remove symlink after work is done (manual trigger):
-
-```bash
-unlink ψ/incubate/owner/repo
-rmdir ψ/incubate/owner 2>/dev/null
-# ghq clone preserved for future use
-```
-
-#### --contribute
-
-For multi-feature contributions over days/weeks. Offload when ALL features are done:
-
-```bash
-# 1. Work on multiple features/fixes over time
-git -C ψ/incubate/owner/repo checkout -b feat/feature-1
-# ... work, commit, push, PR ...
-git -C ψ/incubate/owner/repo checkout -b feat/feature-2
-# ... work, commit, push, PR ...
-
-# 2. When all done, offload (ghq kept for PR feedback)
-unlink ψ/incubate/owner/repo
-```
-
-**Use case**: Extended contribution period. Keep ghq for addressing PR reviews.
-
-#### --flash
-
-Complete contribution cycle with full cleanup:
-
-```
-/project incubate URL --flash
-    ↓
-1. gh issue create → #N (document intent)
-    ↓
-2. ghq get → symlink to ψ/incubate/
-    ↓
-3. git checkout -b issue-N-description
-    ↓
-4. Make changes, commit
-    ↓
-5. git push → gh pr create --body "Closes #N"
-    ↓
-6. cd back to main repo
-    ↓
-7. Auto-offload + purge ghq clone
-    ↓
-"✓ Issue #N → PR #M → Offloaded & Purged"
-```
-
-**Use case**: Quick external contributions without leaving traces.
+> **`/project incubate` is now `/incubate`.**
+> If the user says `/project incubate [args]`, run `/incubate [args]` instead.
+> Do NOT execute incubate logic here — invoke the standalone `/incubate` skill with the same arguments.
 
 ### find [query]
 
@@ -184,26 +112,13 @@ User: "I want to learn from https://github.com/SawyerHood/dev-browser"
 → mkdir -p ψ/learn/SawyerHood
 → ln -sf ~/Code/github.com/SawyerHood/dev-browser ψ/learn/SawyerHood/dev-browser
 
-# User wants to develop long-term
+# User wants to develop → redirect to /incubate
 User: "I want to work on claude-mem"
-→ /project incubate https://github.com/thedotmack/claude-mem
-→ Symlink created, work until done
+→ /incubate https://github.com/thedotmack/claude-mem
 
-# User wants to contribute (keep ghq for follow-up)
-User: "Fix a bug in arra-oracle-v3"
-→ /project incubate https://github.com/Soul-Brews-Studio/arra-oracle-v3 --contribute
-→ [edit, commit, push]
-→ Auto-offload, ghq kept for PR feedback
-
-# User wants quick flash contribution (full cleanup)
-User: "Quick README fix on arra-oracle-skills-cli"
-→ /project incubate https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli --flash
-→ Issue #17 created
-→ Branch: issue-17-fix-readme
-→ [edit, commit, push]
-→ PR #18 created (Closes #17)
-→ Auto-offload + purge
-→ "✓ Issue #17 → PR #18 → Offloaded & Purged"
+# User says "/project incubate" → redirect to /incubate
+User: "/project incubate https://github.com/Soul-Brews-Studio/arra-oracle-v3 --contribute"
+→ /incubate https://github.com/Soul-Brews-Studio/arra-oracle-v3 --contribute
 ```
 
 ## Anti-Patterns
@@ -221,28 +136,12 @@ User: "Quick README fix on arra-oracle-skills-cli"
 # Add to learn
 ghq get -u URL && mkdir -p ψ/learn/owner && ln -sf "$(ghq root)/github.com/owner/repo" ψ/learn/owner/repo
 
-# Add to incubate
-ghq get -u URL && mkdir -p ψ/incubate/owner && ln -sf "$(ghq root)/github.com/owner/repo" ψ/incubate/owner/repo
-
-# Offload (remove symlink only)
-unlink ψ/incubate/owner/repo && rmdir ψ/incubate/owner 2>/dev/null
-
-# Offload + purge (remove symlink AND ghq clone)
-unlink ψ/incubate/owner/repo && rm -rf "$(ghq root)/github.com/owner/repo"
+# Incubate (use standalone /incubate skill)
+/incubate URL [--flash | --contribute | --status | --offload]
 
 # Update source
 ghq get -u URL
 
 # Find repo
 ghq list | grep name
-```
-
-## Workflow Intensity Scale
-
-```
-incubate        → Long-term dev (manual cleanup)
-    ↓
---contribute    → Push → offload (keep ghq)
-    ↓
---flash         → Issue → Branch → PR → offload → purge (complete cycle)
 ```


### PR DESCRIPTION
## Summary

- **contacts, inbox → lab profile** (moved from standard)
- **Standard**: 14 skills | **Full**: 21 | **Lab**: 28 | **labOnly**: 7
- Version bump to v3.7.0 with CHANGELOG + README stamps

## What's in v3.7.0 (cumulative since v3.6.1)

- Standalone `/incubate` skill (PR #203 — merged)
- `dream`, `feel`, `vault` visible in autocomplete (removed `hidden: true`)
- `contacts`, `inbox`, `schedule` → lab profile
- 7 open issues resolved (#199 #198 #193 #192 #180 #141 #72)
- 28 skills, 124 tests passing

## Test plan

- [x] `bun test` — 124 pass, 0 fail
- [x] `bun run compile` — 28 skills compiled
- [x] Pre-commit hooks pass (lefthook: test + update-table)
- [ ] After merge: create GitHub Release v3.7.0 → triggers npm publish

---

**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)