### PR TITLE
feat: /go cleanup + v3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v3.7.1 (2026-04-10)
+
+### `/go cleanup` + `/project incubate` redirect
+
+- `/go cleanup` — safe fresh install with full crosscheck table, usage mining via /dig, conflict detection + backup
+- `/go` profile counts updated: standard=14, full=21, lab=28
+- `/project incubate` now redirects to standalone `/incubate` (backward compat)
+
+---
+
 ## v3.7.0 (2026-04-10)
 
 ### Standalone /incubate + profile reorg

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@3.7.0 install -g -y --agent claude-code
+npx arra-oracle-skills@3.7.1 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@3.7.0 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@3.7.1 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@3.7.0 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@3.7.1 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@3.7.0 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@3.7.1 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@3.7.0 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@3.7.0 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@3.7.0 install -g -y --agent cursor
-npx arra-oracle-skills@3.7.0 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@3.7.1 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@3.7.1 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@3.7.1 install -g -y --agent cursor
+npx arra-oracle-skills@3.7.1 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@3.7.0 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@3.7.1 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -52,7 +52,7 @@ npx arra-oracle-skills@3.7.0 install -g -y --agent claude-code codex opencode
 | 13 | **dream** | skill | "Cross-repo pattern discovery |
 | 14 | **feel** | skill | "Capture how the system feels |
 | 15 | **forward** | skill | Create handoff + enter plan mode for next |
-| 16 | **go** | skill | 'Switch skill profiles |
+| 16 | **go** | skill | 'Switch skill profiles or fresh install |
 | 17 | **inbox** | skill | Read and write to Oracle inbox |
 | 18 | **incubate** | skill | Clone or create repos for active development |
 | 19 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/skills/go/SKILL.md
+++ b/src/skills/go/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go
-description: 'Switch skill profiles. Profiles: standard (16), full (all), lab (experimental). Use when user says "go", "go standard", "go full", "go lab", "switch profile", "enable skills", "disable skills".'
-argument-hint: "<standard|full|lab> | enable|disable <skill...>"
+description: 'Switch skill profiles or fresh install. Profiles: standard (14), full (21), lab (28). Use when user says "go", "go standard", "go full", "go lab", "go cleanup", "switch profile", "enable skills", "disable skills", "fresh install".'
+argument-hint: "<standard|full|lab|cleanup> | enable|disable <skill...>"
 ---
 
 # /go
@@ -12,9 +12,10 @@ argument-hint: "<standard|full|lab> | enable|disable <skill...>"
 
 ```
 /go                     # show installed skills
-/go standard            # switch to standard profile (16 skills)
-/go full                # enable everything
-/go lab                 # full + experimental skills
+/go standard            # switch to standard profile (14 skills)
+/go full                # all stable skills (21)
+/go lab                 # full + experimental (28)
+/go cleanup             # remove ALL skills → fetch latest → fresh install
 /go enable trace dig    # enable specific skills
 /go disable watch       # disable specific skills
 ```
@@ -43,6 +44,172 @@ Profiles: `standard`, `full`, `lab`
 - `/go full` → `arra-oracle-skills install -g --profile full -y`
 - `/go lab` → `arra-oracle-skills install -g --profile lab -y`
 
+### `/go cleanup` — fresh install (safe)
+
+Crosscheck installed skills, remove stale arra-managed ones, fetch latest, reinstall. External skills are never touched.
+
+**Step 1: Crosscheck** — list all installed skills, classify each:
+
+```bash
+SKILLS_DIR="$HOME/.claude/skills"
+# Arra's known skill names (from the CLI)
+ARRA_SKILLS=$(arra-oracle-skills list --all --json 2>/dev/null | jq -r '.[].name' || echo "")
+
+echo "📋 Crosscheck:"
+for dir in "$SKILLS_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  name=$(basename "$dir")
+  version=$(grep -o 'v[0-9.]*' "$dir/SKILL.md" 2>/dev/null | head -1)
+  installer=$(grep -o 'installer: .*' "$dir/SKILL.md" 2>/dev/null | head -1)
+
+  if echo "$ARRA_SKILLS" | grep -qx "$name"; then
+    if [ -n "$installer" ]; then
+      echo "  ✓ arra: $name ($version)"
+    else
+      echo "  ⚠️ conflict: $name ($version) — same name as arra skill but installed separately"
+    fi
+  else
+    echo "  ○ external: $name (not in arra — will keep)"
+  fi
+done
+```
+
+**Step 2: Show full table** — display ALL 28 arra skills with status:
+
+```
+📋 Skills Overview (28 arra + N external):
+
+  #  Skill                    Profile    Installed  Version   Status
+  ── ──────────────────────── ────────── ────────── ───────── ──────
+  1  about-oracle             standard   ✓          v3.7.0    ✓ ok
+  2  auto-retrospective       full       ✓          v3.7.0    ✓ ok
+  3  awaken                   standard   ✓          v3.7.0    ✓ ok
+  4  contacts                 lab        ✓          v3.7.0    ✓ ok
+  5  create-shortcut          lab        ✗          —         —
+  6  dig                      standard   ✓          v3.7.0    ✓ ok
+  7  dream                    lab        ✗          —         —
+  8  feel                     lab        ✗          —         —
+  9  forward                  standard   ✓          v3.7.0    ✓ ok
+  10 go                       standard   ✓          v3.7.0    ✓ ok
+  11 inbox                    lab        ✓          v3.7.0    ✓ ok
+  12 incubate                 full       ✓          v3.7.0    ✓ ok
+  13 learn                    standard   ✓          v3.7.0    ✓ ok
+  14 oracle-family-scan       standard   ✓          v3.7.0    ✓ ok
+  15 oracle-soul-sync-update  standard   ✓          v3.7.0    ✓ ok
+  16 philosophy               full       ✗          —         —
+  17 project                  full       ✗          —         —
+  18 recap                    standard   ✓          v3.7.0    ✓ ok
+  19 resonance                full       ✗          —         —
+  20 rrr                      standard   ✓          v3.7.0    ✓ ok
+  21 schedule                 lab        ✗          —         —
+  22 standup                  standard   ✓          v3.7.0    ✓ ok
+  23 talk-to                  standard   ✓          v3.7.0    ✓ ok
+  24 trace                    standard   ✓          v3.7.0    ✓ ok
+  25 vault                    lab        ✗          —         —
+  26 where-we-are             full       ✗          —         —
+  27 who-are-you              full       ✓          v1.0.22   ⚠️ conflict
+  28 xray                     standard   ✓          v3.7.0    ✓ ok
+
+  External (will keep):
+  ○ drink, mawjs, mawjs-local, ultrathink
+```
+
+Status legend:
+- `✓ ok` — arra-managed, correct version
+- `⚠️ conflict` — same name as arra skill but installed separately or wrong version
+- `⚠️ stale` — arra-managed but outdated version
+
+**Step 2.5: Ask about usage data** — before confirming, offer insight:
+
+```
+📊 Want to see which skills you use most? (mines session history via /dig)
+   This helps choose the right profile after cleanup.
+   [Y/n]
+```
+
+If yes, mine all session JSONL files for skill invocations:
+
+```bash
+# Scan all sessions for skill triggers
+echo "📊 Skill Usage (mining sessions...):"
+TOTAL=0
+for jsonl in ~/.claude/projects/*/*.jsonl; do
+  [ -f "$jsonl" ] || continue
+  TOTAL=$((TOTAL + 1))
+done
+echo "  Scanned: $TOTAL sessions"
+echo ""
+
+# Count skill invocations (look for /skill-name patterns in user messages)
+# Display as table sorted by usage count (descending)
+for skill in about-oracle auto-retrospective awaken contacts create-shortcut \
+  dig dream feel forward go inbox incubate learn oracle-family-scan \
+  oracle-soul-sync-update philosophy project recap resonance rrr \
+  schedule standup talk-to trace vault where-we-are who-are-you xray; do
+
+  count=$(grep -l "\"/$skill\"\\|\"/$skill " ~/.claude/projects/*/*.jsonl 2>/dev/null | wc -l)
+  echo "$count $skill"
+done | sort -rn | awk '{printf "  %-3s %-28s %s sessions\n", NR".", $2, $1}'
+```
+
+Output:
+```
+📊 Skill Usage (74 sessions):
+
+  #   Skill                        Sessions
+  ──  ────────────────────────────  ────────
+  1.  rrr                          42 sessions
+  2.  trace                        38 sessions
+  3.  recap                        35 sessions
+  4.  learn                        28 sessions
+  5.  dig                          22 sessions
+  ...
+  27. schedule                     0 sessions
+  28. create-shortcut              0 sessions
+
+  💡 Skills with 0 usage might not need to be in your profile.
+```
+
+**Step 3: Confirm** — now with full context:
+
+```
+Proceed with cleanup?
+  - Conflicts will be replaced (backed up to .bak)
+  - External skills kept untouched
+  - Which profile? [standard / full / lab]
+```
+
+**Step 4: Clean + reinstall** (only after user confirms):
+
+```bash
+# Uninstall arra-managed via CLI
+arra-oracle-skills uninstall -g -y
+
+# For each conflict skill: rename to .bak (Nothing is Deleted)
+for name in [conflicting skills]; do
+  mv "$SKILLS_DIR/$name" "$SKILLS_DIR/${name}.bak.$(date +%s)"
+done
+
+# Fresh install at latest
+LATEST=$(curl -s https://api.github.com/repos/Soul-Brews-Studio/arra-oracle-skills-cli/tags | grep -m1 '"name"' | cut -d'"' -f4)
+~/.bun/bin/bunx --bun arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli#$LATEST install -g -y
+```
+
+**Output:**
+```
+🧹 Cleanup complete!
+  Kept: [N] external skills
+  Replaced: [N] conflicts (backed up to .bak)
+  Installed: [N] fresh at $LATEST
+  Restart required.
+```
+
+**When to use:**
+- Stale skills from old versions mixed with new
+- `[hidden]` flags persisting after unhide
+- Version mismatch (some v3.6.1, some v3.7.0)
+- Want a clean slate without losing personal skills
+
 ### `/go enable <skill...>` — enable specific skills
 
 ```bash
@@ -65,9 +232,9 @@ arra-oracle-skills uninstall -g -s <skill...> -y
 
 | Profile | Count | Description |
 |---------|-------|-------------|
-| **standard** | 16 | Daily driver — essential Oracle skills (default) |
-| **full** | all | Everything |
-| **lab** | all+ | Full + experimental / bleeding edge |
+| **standard** | 14 | Daily driver — essential Oracle skills (default) |
+| **full** | 21 | All stable skills (excludes lab-only) |
+| **lab** | 28 | Everything including experimental |
 
 ---
 


### PR DESCRIPTION
## Summary

- `/go cleanup` — safe fresh install with crosscheck table, optional usage mining via /dig, conflict backup
- `/go` profile counts updated (standard=14, full=21, lab=28)
- `/project incubate` → redirects to standalone `/incubate`
- Bump v3.7.1

## `/go cleanup` flow

1. **Full table** — all 28 skills with profile tier, installed version, status (ok/conflict/stale)
2. **Ask** — "Want to see which skills you use most?" → mines sessions via /dig
3. **Usage table** — skills ranked by session count
4. **Confirm** — user picks profile with data in hand
5. **Clean** — uninstall, backup conflicts (.bak), fresh install at latest

No `rm -rf`. Conflicts backed up, not deleted. External skills never touched.

## Test plan

- [x] `bun test` — 124 pass, 0 fail
- [x] `bun run compile` — 28 skills at v3.7.1
- [x] Pre-commit hooks pass

---

**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)