### PR TITLE
feat: /team-agents lab skill + auto-rrr silent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v3.7.2 (2026-04-10)
+
+### `/team-agents` lab skill + auto-retrospective silent mode
+
+**New skill:**
+- `/team-agents` — coordinated agent teams framework (lab). Reusable TeamCreate/SendMessage/TaskList pattern for any skill. 3 tiers: subagents (fire-and-forget), team agents (coordinated), cross-Oracle (persistent). Auto-designs teams from task description, named roles, graceful shutdown.
+
+**Changed:**
+- `/auto-retrospective` — now runs **silently** by default. No user prompts, no "should I run /rrr?" distractions. Auto means auto. Users discover controls only when they ask.
+- `/go` profile counts updated: lab=29 (was 28)
+- 29 skills, 124 tests
+
+---
+
 ## v3.7.1 (2026-04-10)
 
 ### `/go cleanup` + `/project incubate` redirect

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # arra-oracle-skills-cli
 
-28 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+29 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@3.7.1 install -g -y --agent claude-code
+npx arra-oracle-skills@3.7.2 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@3.7.1 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@3.7.2 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@3.7.1 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@3.7.2 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@3.7.1 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@3.7.2 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@3.7.1 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@3.7.1 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@3.7.1 install -g -y --agent cursor
-npx arra-oracle-skills@3.7.1 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@3.7.2 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@3.7.2 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@3.7.2 install -g -y --agent cursor
+npx arra-oracle-skills@3.7.2 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@3.7.1 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@3.7.2 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -60,11 +60,12 @@ npx arra-oracle-skills@3.7.1 install -g -y --agent claude-code codex opencode
 | 21 | **resonance** | skill | Capture a resonance moment |
 | 22 | **standup** | skill | Daily standup check |
 | 23 | **talk-to** | skill | Talk to another Oracle agent via threads |
-| 24 | **trace** | skill | Find projects, code |
-| 25 | **vault** | skill | Connect external knowledge bases (Obsidian |
-| 26 | **where-we-are** | skill | Session awareness |
-| 27 | **who-are-you** | skill | Know ourselves |
-| 28 | **xray** | skill | X-ray deep scan |
+| 24 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 25 | **trace** | skill | Find projects, code |
+| 26 | **vault** | skill | Connect external knowledge bases (Obsidian |
+| 27 | **where-we-are** | skill | Session awareness |
+| 28 | **who-are-you** | skill | Know ourselves |
+| 29 | **xray** | skill | X-ray deep scan |
 
 <!-- skills:end -->
 
@@ -75,8 +76,8 @@ npx arra-oracle-skills@3.7.1 install -g -y --agent claude-code codex opencode
 | Profile | Count | Skills |
 |---------|-------|--------|
 | **standard** | 14 | `about-oracle`, `awaken`, `dig`, `forward`, `go`, `learn`, `oracle-family-scan`, `oracle-soul-sync-update`, `recap`, `rrr`, `standup`, `talk-to`, `trace`, `xray` |
-| **full** | 28 | all |
-| **lab** | 28 | all |
+| **full** | 29 | all |
+| **lab** | 29 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -5,8 +5,8 @@ const ALL_SKILLS = [
   "about-oracle", "auto-retrospective", "awaken", "contacts", "create-shortcut",
   "dig", "dream", "feel", "forward", "go", "inbox", "incubate", "learn",
   "oracle-family-scan", "oracle-soul-sync-update", "philosophy", "project", "recap",
-  "resonance", "rrr", "schedule", "standup", "talk-to", "trace", "vault",
-  "where-we-are", "who-are-you", "xray",
+  "resonance", "rrr", "schedule", "standup", "talk-to", "team-agents", "trace",
+  "vault", "where-we-are", "who-are-you", "xray",
 ];
 
 describe("profiles", () => {
@@ -36,13 +36,14 @@ describe("profiles", () => {
     expect(profiles.standard.include).not.toContain("feel");
   });
 
-  it("labOnly contains contacts, create-shortcut, dream, feel, inbox, schedule, vault", () => {
+  it("labOnly contains contacts, create-shortcut, dream, feel, inbox, schedule, team-agents, vault", () => {
     expect(labOnly).toContain("contacts");
     expect(labOnly).toContain("create-shortcut");
     expect(labOnly).toContain("dream");
     expect(labOnly).toContain("feel");
     expect(labOnly).toContain("inbox");
     expect(labOnly).toContain("schedule");
+    expect(labOnly).toContain("team-agents");
     expect(labOnly).toContain("vault");
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -7,7 +7,7 @@
  */
 
 // Skills that are lab-only (experimental, not in standard or full)
-export const labOnly = ['contacts', 'create-shortcut', 'dream', 'feel', 'inbox', 'schedule', 'vault'];
+export const labOnly = ['contacts', 'create-shortcut', 'dream', 'feel', 'inbox', 'schedule', 'team-agents', 'vault'];
 
 export const profiles: Record<string, { include?: string[]; exclude?: string[] }> = {
   standard: {

--- a/src/skills/auto-retrospective/SKILL.md
+++ b/src/skills/auto-retrospective/SKILL.md
@@ -9,6 +9,18 @@ argument-hint: "[on | off | status | rrr:<interval>k | fwd:<interval>k]"
 
 Manage the auto-scale hook that triggers /rrr and /forward based on context window usage.
 
+## CRITICAL: Auto = Silent
+
+**When auto-triggered, run /rrr and /forward SILENTLY.**
+
+- Do NOT ask the user "should I run /rrr?" — just do it
+- Do NOT announce "I'm about to run /rrr" — just do it
+- Do NOT prompt for confirmation — the user already opted in by having auto enabled
+- Write the retro files quietly, then continue with whatever the user was doing
+- If the user notices and asks "why did you do that?" → explain: "Auto-retrospective is enabled. You can disable it with `/auto-rrr off`"
+
+**The whole point is zero distraction.** Auto means auto.
+
 ## Usage
 
 ```
@@ -26,7 +38,7 @@ Manage the auto-scale hook that triggers /rrr and /forward based on context wind
 Auto-scale hook (`~/.claude/hooks/auto-scale.sh`) runs on every `UserPromptSubmit`:
 1. Reads context usage from `/tmp/statusline-raw.json`
 2. Shows status line: `10:20 | 46k (rrr:100k fwd:195k) | white.local | auto:on`
-3. At threshold: injects message telling AI to run /rrr or /forward
+3. At threshold: injects system message to run /rrr or /forward **silently**
 4. Uses flag files per session to avoid re-triggering
 
 ## Steps
@@ -99,5 +111,28 @@ Show updated status after any change.
 `~/.claude/hooks/auto-scale.sh` — registered in `~/.claude/settings.json` under `UserPromptSubmit`.
 
 If hook doesn't exist, tell user to create it or run the setup.
+
+## When User Asks "Why Did You Do That?"
+
+If the user notices a retro was written automatically and asks about it:
+
+```
+Auto-retrospective is enabled — it runs /rrr silently when context
+reaches the threshold (default: every 100k tokens).
+
+  /auto-rrr off          # disable auto-triggers
+  /auto-rrr on           # re-enable
+  /auto-rrr rrr:150k     # change threshold
+  /auto-rrr status       # see current settings
+```
+
+Never be defensive. Just explain and show the controls.
+
+## Default Behavior
+
+- **Default**: ON (auto, silent)
+- **Memory consent = auto** (from /awaken): auto-rrr is expected
+- **Memory consent = manual** (from /awaken): auto-rrr is OFF until user enables it
+- Check CLAUDE.md Demographics table for Memory field
 
 ARGUMENTS: $ARGUMENTS

--- a/src/skills/go/SKILL.md
+++ b/src/skills/go/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go
-description: 'Switch skill profiles or fresh install. Profiles: standard (14), full (21), lab (28). Use when user says "go", "go standard", "go full", "go lab", "go cleanup", "switch profile", "enable skills", "disable skills", "fresh install".'
+description: 'Switch skill profiles or fresh install. Profiles: standard (14), full (21), lab (29). Use when user says "go", "go standard", "go full", "go lab", "go cleanup", "switch profile", "enable skills", "disable skills", "fresh install".'
 argument-hint: "<standard|full|lab|cleanup> | enable|disable <skill...>"
 ---
 
@@ -74,10 +74,10 @@ for dir in "$SKILLS_DIR"/*/; do
 done
 ```
 
-**Step 2: Show full table** — display ALL 28 arra skills with status:
+**Step 2: Show full table** — display ALL 29 arra skills with status:
 
 ```
-📋 Skills Overview (28 arra + N external):
+📋 Skills Overview (29 arra + N external):
 
   #  Skill                    Profile    Installed  Version   Status
   ── ──────────────────────── ────────── ────────── ───────── ──────
@@ -104,11 +104,12 @@ done
   21 schedule                 lab        ✗          —         —
   22 standup                  standard   ✓          v3.7.0    ✓ ok
   23 talk-to                  standard   ✓          v3.7.0    ✓ ok
-  24 trace                    standard   ✓          v3.7.0    ✓ ok
-  25 vault                    lab        ✗          —         —
-  26 where-we-are             full       ✗          —         —
-  27 who-are-you              full       ✓          v1.0.22   ⚠️ conflict
-  28 xray                     standard   ✓          v3.7.0    ✓ ok
+  24 team-agents              lab        ✗          —         —
+  25 trace                    standard   ✓          v3.7.0    ✓ ok
+  26 vault                    lab        ✗          —         —
+  27 where-we-are             full       ✗          —         —
+  28 who-are-you              full       ✓          v1.0.22   ⚠️ conflict
+  29 xray                     standard   ✓          v3.7.0    ✓ ok
 
   External (will keep):
   ○ drink, mawjs, mawjs-local, ultrathink
@@ -234,7 +235,7 @@ arra-oracle-skills uninstall -g -s <skill...> -y
 |---------|-------|-------------|
 | **standard** | 14 | Daily driver — essential Oracle skills (default) |
 | **full** | 21 | All stable skills (excludes lab-only) |
-| **lab** | 28 | Everything including experimental |
+| **lab** | 29 | Everything including experimental |
 
 ---
 

--- a/src/skills/team-agents/SKILL.md
+++ b/src/skills/team-agents/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: team-agents
+description: Spin up coordinated agent teams for any task. Reusable framework for TeamCreate/SendMessage/TaskList patterns. Use when user says "team-agents", "spin up a team", "use teammates", "parallel agents", "coordinate agents", "fan out", or wants multiple agents working together with coordination. Do NOT trigger for simple subagent work (use Agent tool directly) or inter-Oracle messaging (use /talk-to).
+argument-hint: "<task-description> [--roles N] [--model sonnet|opus|haiku] [--plan]"
+---
+
+# /team-agents — Coordinated Agent Teams
+
+> "Many hands, one mind."
+
+Spin up a coordinated team of agents for any task. Generalizes the TeamCreate/SendMessage/TaskList pattern into a reusable framework that any skill or workflow can leverage.
+
+## Prerequisites
+
+Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+Without this flag, TeamCreate/SendMessage/TaskList tools don't exist. Fall back to parallel subagents (fire-and-forget) if unavailable.
+
+## Usage
+
+```
+/team-agents "review this PR for security, perf, and tests"
+/team-agents "refactor auth module" --roles 3
+/team-agents "research X" --model haiku
+/team-agents "implement feature Y" --plan
+/team-agents status                    # show running team
+/team-agents shutdown                  # graceful shutdown
+```
+
+---
+
+## How It Works
+
+### 3 Tiers — Choose the Right One
+
+| Tier | When | Tools | Coordination |
+|------|------|-------|-------------|
+| **Subagents** | Simple parallel work, < 3 agents | Agent tool only | None — fire-and-forget |
+| **Team Agents** | Coordinated work, 3-5 agents | TeamCreate + SendMessage + TaskList | Full — named roles, shared tasks, reports |
+| **Cross-Oracle** | Inter-session, multi-repo | /talk-to + contacts | Persistent — maw/thread/inbox |
+
+**Rule**: If the task can be done with 2 independent subagents, DON'T use team-agents. Use this for tasks that need coordination — where Agent B's work depends on Agent A's findings, or where a lead needs to compile structured reports.
+
+---
+
+## Step 0: Parse Task + Auto-Design Team
+
+From the user's task description, the lead (you) designs the team:
+
+### Role Archetypes
+
+Pick 2-5 roles that cover the task. Common patterns:
+
+| Pattern | Roles | Best For |
+|---------|-------|----------|
+| **Review** | security, performance, testing | Code review, PR review |
+| **Research** | codebase, docs, community | Investigation, trace-like work |
+| **Analysis** | timeline, patterns, memory | Retrospectives, audits |
+| **Build** | architect, implementer, tester | Feature development |
+| **Explore** | deep-dig, cross-repo, history | Discovery, /dream-like work |
+
+### Auto-Design Logic
+
+1. Parse the task description
+2. Identify 2-5 dimensions of work
+3. Assign each dimension a named role
+4. Show the user the proposed team:
+
+```
+Team: pr-review (3 agents)
+
+  Role         Focus                          Model
+  ────────── ──────────────────────────────── ────────
+  security     Auth flows, injection, OWASP    sonnet
+  performance  N+1 queries, memory, latency    sonnet
+  testing      Coverage gaps, edge cases       sonnet
+
+  Lead: you (compile + write final report)
+
+Spin up? [Y/n]
+```
+
+If `--plan` flag: show plan, wait for approval.
+If no flag: show plan briefly, proceed immediately.
+
+---
+
+## Step 1: Create Team
+
+```
+TeamCreate("team-name")
+```
+
+Team name: slugified from task (e.g., "review this PR" → `pr-review`).
+
+---
+
+## Step 2: Register Tasks
+
+Create one task per role:
+
+```
+TaskCreate({
+  subject: "Security review",
+  description: "Review auth flows, check for injection, OWASP top 10"
+})
+
+TaskCreate({
+  subject: "Performance review",
+  description: "Check N+1 queries, memory leaks, latency bottlenecks"
+})
+
+TaskCreate({
+  subject: "Test coverage review",
+  description: "Find coverage gaps, missing edge cases, flaky tests"
+})
+```
+
+---
+
+## Step 3: Spawn Teammates
+
+Spawn all teammates in parallel. Each gets:
+
+```
+Agent({
+  name: "security",
+  team_name: "pr-review",
+  model: "sonnet",
+  prompt: `You are the SECURITY reviewer on team "pr-review".
+
+REPO: [ABSOLUTE_PATH]
+TASK: Review auth flows, check for injection vulnerabilities, OWASP top 10.
+
+Instructions:
+1. Read the relevant files
+2. Do your analysis
+3. Update your task: TaskUpdate({ taskId: [ID], status: "completed" })
+4. Report to lead: SendMessage({
+     to: "team-lead@pr-review",
+     summary: "Security review complete — [findings count] issues",
+     message: "[structured findings, max 500 words]"
+   })
+
+Rules:
+- ONLY report via SendMessage — do NOT write files
+- Max 500 words in your report
+- Include severity (critical/high/medium/low) for each finding
+- Be specific — file paths, line numbers, code snippets`
+})
+```
+
+### Prompt Template (every teammate gets this)
+
+```
+You are the [ROLE] specialist on team "[TEAM_NAME]".
+
+REPO: [ABSOLUTE_PATH_TO_REPO]
+TASK: [TASK_DESCRIPTION]
+
+Instructions:
+1. Do your work (read files, run commands, analyze)
+2. Mark task done: TaskUpdate({ taskId: [ID], status: "completed" })
+3. Report to lead: SendMessage({
+     to: "team-lead@[TEAM_NAME]",
+     summary: "[5-10 word summary]",
+     message: "[findings, max 500 words]"
+   })
+
+Rules:
+- Report via SendMessage ONLY — do NOT write files
+- Max 500 words in report
+- Be specific — paths, lines, evidence
+- If you need info from another agent, ask lead via SendMessage
+```
+
+**Critical**: Always include:
+- `REPO:` with literal absolute path (never shell variables)
+- `team-lead@[TEAM_NAME]` for SendMessage addressing
+- 500-word limit to prevent context waste
+- "do NOT write files" — only lead writes
+
+---
+
+## Step 4: Wait for Reports
+
+Lead waits for SendMessage reports from all teammates. Expected time: 60-120 seconds.
+
+**While waiting**:
+- Idle notifications are normal — teammates are working
+- Real content arrives via SendMessage with summary field
+- Check TaskList periodically if reports seem slow
+
+**If a teammate crashes**:
+1. Check TaskList — is their task still `in_progress`?
+2. SendMessage to the agent: "status check — are you still working?"
+3. If no response after 30s: lead does the work manually
+4. Note in final output: "Agent [role] crashed — lead completed manually"
+
+---
+
+## Step 5: Compile Results
+
+Lead receives all SendMessage reports and compiles into a single output.
+
+### Compilation Template
+
+```markdown
+# [Task Title] — Team Report
+
+**Team**: [team-name] | **Agents**: [N] | **Duration**: ~[N]min
+**Date**: [timestamp]
+
+## [Role 1]: [Summary]
+[Compiled findings from agent 1]
+
+## [Role 2]: [Summary]
+[Compiled findings from agent 2]
+
+## [Role 3]: [Summary]
+[Compiled findings from agent 3]
+
+## Synthesis
+[Lead's cross-cutting observations — patterns across agents' findings]
+
+## Action Items
+- [ ] [Specific action from findings]
+- [ ] [Specific action from findings]
+```
+
+### Where to Write
+
+- If task is review/analysis → display to user (don't write file)
+- If task is retrospective → write to `ψ/memory/retrospectives/`
+- If task is research → write to `ψ/memory/traces/`
+- If task is implementation → agents write code (lead reviews)
+
+---
+
+## Step 6: Shutdown
+
+Graceful shutdown sequence:
+
+```
+# 1. Send shutdown request to each teammate
+SendMessage({
+  to: "security",
+  message: { type: "shutdown_request" }
+})
+
+SendMessage({
+  to: "performance",
+  message: { type: "shutdown_request" }
+})
+
+SendMessage({
+  to: "testing",
+  message: { type: "shutdown_request" }
+})
+
+# 2. Wait for shutdown_response from each (~5-10s)
+
+# 3. Clean up
+TeamDelete()
+```
+
+**Never skip shutdown** — TeamDelete fails if agents are still active.
+
+---
+
+## /team-agents status
+
+Show current team state:
+
+```
+Team: pr-review (active)
+
+  Agent        Status       Task                     Last Report
+  ──────────── ──────────── ──────────────────────── ────────────
+  security     completed    Security review           2 issues found
+  performance  in_progress  Performance review        —
+  testing      completed    Test coverage review      3 gaps found
+
+  Duration: 45s | Tasks: 2/3 complete
+```
+
+Uses TaskList to get current state.
+
+---
+
+## /team-agents shutdown
+
+Force graceful shutdown of current team:
+
+```
+SendMessage shutdown_request → all agents
+Wait for responses (10s timeout)
+TeamDelete()
+```
+
+---
+
+## Fallback: No Agent Teams Available
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is not set, the TeamCreate tool won't exist.
+
+**Fallback to Tier 1 (subagents)**:
+
+```
+Team tools not available. Falling back to parallel subagents.
+  (Enable with: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in settings.json)
+
+Spawning 3 independent agents...
+```
+
+Spawn agents via the regular Agent tool without team_name. Results come back as tool results instead of SendMessage. Lead still compiles.
+
+**Differences in fallback mode**:
+- No SendMessage — agents return text directly
+- No TaskList — no shared task tracking
+- No named addressing — agents can't message each other
+- Still works for most parallel tasks — just less coordinated
+
+---
+
+## Gotchas
+
+1. **Context is isolated** — teammates don't see lead's conversation history
+2. **One team per session** — no nested teams
+3. **~3-7x token usage** vs single agent — use wisely
+4. **Two agents editing same file = overwrites** — only lead should write
+5. **Task status can lag** — agents sometimes forget TaskUpdate
+6. **No session resumption** — /resume doesn't restore teammates
+7. **Teammates inherit lead's permissions** — can't restrict per-agent
+8. **Recommended**: 3-5 agents, 5-6 tasks per agent max
+9. **Don't use for small tasks** — if it takes < 5 minutes solo, don't team it
+
+---
+
+## Integration with Other Skills
+
+| Skill | How /team-agents helps |
+|-------|----------------------|
+| `/rrr --deep --teammate` | Already uses this pattern (TEAMMATE.md) |
+| `/dream` | Could upgrade from subagents to coordinated team |
+| `/trace --deep` | Wave 2 agents could coordinate findings |
+| `/learn --deep` | Doc agents could build on each other's output |
+| Any new skill | Import the pattern instead of reinventing |
+
+---
+
+## Philosophy
+
+> Subagents are arrows. Team agents are a squad.
+
+Arrows fly independently — you aim them and hope they hit. A squad communicates, coordinates, adapts. Use arrows for quick shots. Use a squad when the mission is complex.
+
+The cost is real (~3-7x tokens). The benefit is real (structured coordination, named roles, shared tasks, crash resilience). Choose based on the task, not the novelty.
+
+---
+
+ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Summary

- **New skill**: `/team-agents` (lab) — reusable coordinated agent teams framework. Generalizes the TeamCreate/SendMessage/TaskList pattern from `/rrr --teammate` into a standalone skill any workflow can use. Auto-designs teams from task descriptions, supports 3 tiers (subagents → team agents → cross-Oracle), graceful shutdown, crash recovery.
- **Auto-retrospective fix**: now runs **silently** by default. No "should I run /rrr?" prompts — auto means auto. Users discover controls only when they ask.
- Profile counts: lab=29 (was 28)
- 29 skills, 124 tests, 0 failures

## Changes

| File | What |
|------|------|
| `src/skills/team-agents/SKILL.md` | New lab skill (~300 lines) |
| `src/skills/auto-retrospective/SKILL.md` | Silent mode + "when user asks" guidance |
| `src/profiles.ts` | labOnly: +team-agents |
| `__tests__/profiles.test.ts` | ALL_SKILLS + labOnly assertions updated |
| `src/skills/go/SKILL.md` | Profile counts: lab=29 |
| `package.json` | v3.7.2 |
| `CHANGELOG.md` | v3.7.2 entry |

## Test plan

- [x] `bun test` — 124 tests pass
- [x] `bun run compile` — 29 skills compile at v3.7.2
- [x] Profile math: standard=14, full=21, lab=29
- [ ] Install with `--profile lab` and verify team-agents appears
- [ ] Test `/team-agents` with agent teams enabled

---

**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)