### PR TITLE
feat(recap): add INDEX reconcile to recap-rich

### DIFF
--- a/src/skills/recap/SKILL.md
+++ b/src/skills/recap/SKILL.md
@@ -28,7 +28,7 @@ trigger: /recap
 bun ~/.claude/skills/recap/recap-rich.ts
 ```
 
-Script reads retro summaries, handoff content, tracks, git state. Then LLM adds:
+Script reads retro summaries, handoff content, tracks, git state, and INDEX reconcile. Then LLM adds:
 - **What's next?** (2-3 options based on context)
 
 ### Step 2: Git context
@@ -71,6 +71,15 @@ Include in recap:
 ```
 
 Need more? `/dig 5` or `/dig --timeline`.
+
+### INDEX Reconcile (auto)
+
+The rich script auto-detects `ψ/inbox/tracks/INDEX.md`. If present, it:
+- Counts pending vs done items
+- Cross-checks latest handoff pending items against INDEX
+- Reports items from handoff not yet in INDEX (new pending to add)
+
+This surfaces reconcile gaps at session start so the LLM can suggest adding missing items.
 
 **Total**: 1 bash call + LLM analysis
 

--- a/src/skills/recap/recap-rich.ts
+++ b/src/skills/recap/recap-rich.ts
@@ -97,6 +97,45 @@ if (existsSync(tracksDir)) {
   }
 }
 
+// INDEX reconcile — cross-check INDEX.md with latest handoff
+const indexFile = join(ROOT, "ψ/inbox/tracks/INDEX.md");
+if (existsSync(indexFile)) {
+  console.log("\n## INDEX RECONCILE");
+  const indexContent = await Bun.file(indexFile).text();
+  const indexLines = indexContent.split("\n");
+
+  // Count pending and done items
+  const pendingItems = indexLines.filter((l) => l.match(/^- \[ \]/));
+  const doneItems = indexLines.filter((l) => l.match(/^- \[x\]/));
+
+  // Read latest handoff pending items
+  const hDir = join(ROOT, "ψ/inbox/handoff");
+  let handoffPending: string[] = [];
+  if (existsSync(hDir)) {
+    const hFiles = readdirSync(hDir).filter((f) => f.endsWith(".md") && !f.includes("CLAUDE")).sort().reverse();
+    if (hFiles.length) {
+      const hContent = await Bun.file(join(hDir, hFiles[0])).text();
+      handoffPending = hContent.split("\n").filter((l) => l.match(/^- \[ \]/));
+    }
+  }
+
+  // Find handoff items not in INDEX (new pending)
+  const missing: string[] = [];
+  for (const hp of handoffPending) {
+    const hpText = hp.replace(/^- \[ \] /, "").replace(/\*\*/g, "").toLowerCase().slice(0, 40);
+    const found = indexLines.some((il) => il.toLowerCase().includes(hpText.slice(0, 20)));
+    if (!found) missing.push(hp.trim());
+  }
+
+  console.log(`Pending: ${pendingItems.length} | Done: ${doneItems.length}`);
+  if (missing.length) {
+    console.log(`\n**Not in INDEX** (${missing.length} from handoff):`);
+    for (const m of missing.slice(0, 5)) console.log(`  ${m}`);
+  } else if (handoffPending.length) {
+    console.log("Handoff items all in INDEX");
+  }
+}
+
 // Latest retro
 console.log("\n---\n\n## LAST SESSION");
 const retroDir = join(ROOT, `ψ/memory/retrospectives/${month}`);


### PR DESCRIPTION
## Summary
- Add INDEX reconcile section to `recap-rich.ts` — auto cross-checks `ψ/inbox/tracks/INDEX.md` with latest handoff pending items at session start
- Reports pending/done counts and surfaces items from handoff not yet in INDEX
- Helps teams catch reconcile gaps early without manual checking
- Updated SKILL.md documentation

## How it works
1. Reads `ψ/inbox/tracks/INDEX.md` if present (skips silently if not)
2. Reads latest handoff file and extracts `- [ ]` pending items
3. Cross-references: reports items in handoff not found in INDEX
4. Output appears between TRACKS and LAST SESSION sections

## Test plan
- [x] Tested with repo that has INDEX.md (friday-oracle) — correctly found 12 missing items
- [x] Tested with repo without INDEX.md (monday-oracle) — skips silently
- [x] Pre-existing test failure (cal command in schedule/calendar.ts) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>