### PR TITLE
feat(team-agents): sweep agent worktrees on shutdown (#336)

### DIFF
--- a/src/skills/team-agents/SKILL.md
+++ b/src/skills/team-agents/SKILL.md
@@ -336,7 +336,7 @@ SendMessage({ to: "testing", message: { type: "shutdown_request" } })
 TeamDelete()
 ```
 
-**After shutdown, archive agent findings to persistent mailbox + skills to /tmp:**
+**After shutdown, archive agent findings to persistent mailbox + skills to /tmp + sweep worktrees:**
 
 ```bash
 # 1. Archive each agent's findings to persistent mailbox (ψ/memory/mailbox/)
@@ -346,7 +346,17 @@ done
 
 # 2. Archive ephemeral skills to /tmp (Nothing is Deleted)
 bash ~/.claude/skills/team-agents/scripts/shutdown-skills.sh pr-review security performance testing
+
+# 3. Sweep agent worktrees (#336 — root-cause fix)
+#    TeamDelete usually removes worktrees, but crashes / killed sessions
+#    leave them behind and they pollute subsequent test runs.
+#    ALWAYS run unconditionally — no-op when there's nothing to clean.
+bash ~/.claude/skills/team-agents/scripts/shutdown-worktrees.sh "$REPO_PATH"
 ```
+
+The sweeper matches both worktree patterns used by this skill:
+- `agents/<name>/` — Mode 1 (`--worktree` flag)
+- `.claude/worktrees/<name>/` — Mode 2 (Agent tool `isolation: "worktree"`)
 
 Next time you spawn the same agent name, their mailbox context is auto-loaded into the prompt.
 
@@ -359,6 +369,7 @@ bash ~/.claude/skills/team-agents/scripts/killshot.sh    # nuclear — all panes
 
 **Never skip shutdown** — TeamDelete fails if agents are still active (`isActive !== false` check).
 **Never broadcast shutdown** — structured messages CANNOT broadcast (`to: "*"` returns error). Use sequential sends.
+**Always sweep worktrees** — even if shutdown looked clean, run `shutdown-worktrees.sh`. Previously stale agent worktrees polluted maw-js `bun test` with ~1700 ghost tests (#336).
 **Session cleanup** — Teams created THIS session auto-clean on exit (gh-32730). Teams from PRIOR sessions persist and can resume. TeamDelete before exit preserves the team for future resume (counterintuitive but correct).
 
 ### What Happens During Shutdown (from source)
@@ -912,7 +923,10 @@ Force graceful shutdown of current team:
 SendMessage shutdown_request → all agents
 Wait for responses (10s timeout)
 TeamDelete()
+bash ~/.claude/skills/team-agents/scripts/shutdown-worktrees.sh "$REPO_PATH"  # #336
 ```
+
+The final worktree sweep is defensive — TeamDelete's own cleanup misses crashed/killed sessions.
 
 ---
 

--- a/src/skills/team-agents/scripts/doctor.sh
+++ b/src/skills/team-agents/scripts/doctor.sh
@@ -78,23 +78,33 @@ else
 fi
 
 # 2. Check orphaned worktrees
+# Uses `git worktree list --porcelain` as source of truth — catches stale
+# registrations even if the directory was manually deleted. Covers both
+# team-agents worktree patterns: agents/* and .claude/worktrees/* (#336).
 echo "  Worktrees:"
 ORPHAN_WTS=0
 for repo in ~/Code/github.com/Soul-Brews-Studio/*/; do
-  WT_DIR="$repo/.claude/worktrees"
-  if [ -d "$WT_DIR" ]; then
-    for wt in "$WT_DIR"/*/; do
-      [ -d "$wt" ] || continue
-      name=$(basename "$wt")
-      echo "    ⚠️ Orphaned: $(basename "$repo")/.claude/worktrees/$name"
-      ORPHAN_WTS=$((ORPHAN_WTS + 1))
+  [ -d "$repo/.git" ] || [ -f "$repo/.git" ] || continue
+  REPO_ROOT=$(git -C "$repo" rev-parse --show-toplevel 2>/dev/null) || continue
+  MAIN_WT="$REPO_ROOT"
 
-      if [ "$FIX" = true ]; then
-        cd "$repo" && git worktree remove "$wt" --force 2>/dev/null
-        echo "       → Removed worktree"
-      fi
-    done
-  fi
+  while IFS= read -r line; do
+    [ "${line:0:9}" = "worktree " ] || continue
+    WT_PATH="${line:9}"
+    [ "$WT_PATH" = "$MAIN_WT" ] && continue
+    REL="${WT_PATH#$MAIN_WT/}"
+    case "$REL" in
+      agents/*|.claude/worktrees/*)
+        echo "    ⚠️ Orphaned: $(basename "$REPO_ROOT")/$REL"
+        ORPHAN_WTS=$((ORPHAN_WTS + 1))
+        if [ "$FIX" = true ]; then
+          git -C "$REPO_ROOT" worktree remove --force "$WT_PATH" 2>/dev/null \
+            && echo "       → Removed worktree" \
+            || echo "       → Failed to remove (try manually)"
+        fi
+        ;;
+    esac
+  done < <(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null)
 done
 [ "$ORPHAN_WTS" -eq 0 ] && echo "    ✅ No orphaned worktrees"
 

--- a/src/skills/team-agents/scripts/shutdown-worktrees.sh
+++ b/src/skills/team-agents/scripts/shutdown-worktrees.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Remove team-agent git worktrees on shutdown — root-cause fix for #336
+# Usage: bash shutdown-worktrees.sh [repo-path] [--dry-run]
+#
+# TeamDelete() claims to clean worktrees, but agents that crash or sessions
+# that die without calling TeamDelete leave stale worktrees behind. Those
+# worktrees pollute test runs (e.g., maw-js picked up ~1700 extra tests from
+# agents/engine-isolator, agents/fail-debugger, agents/mock-builder).
+#
+# This script sweeps both worktree patterns used by /team-agents:
+#   1. `agents/<name>/`            ← Mode 1: --worktree flag
+#   2. `.claude/worktrees/<name>/` ← Mode 2: Agent tool isolation:"worktree"
+#
+# Safe to call unconditionally at shutdown — no-op if nothing matches.
+
+set -euo pipefail
+
+REPO_PATH="${1:-$(pwd)}"
+DRY_RUN=false
+[ "${2:-}" = "--dry-run" ] && DRY_RUN=true
+[ "${1:-}" = "--dry-run" ] && { DRY_RUN=true; REPO_PATH="$(pwd)"; }
+
+# Resolve to repo root
+if ! REPO_ROOT=$(git -C "$REPO_PATH" rev-parse --show-toplevel 2>/dev/null); then
+  echo "⚠️  Not a git repo: $REPO_PATH"
+  exit 0
+fi
+
+echo ""
+echo "🧹 Worktree sweep — $REPO_ROOT"
+echo ""
+
+REMOVED=0
+SKIPPED=0
+
+# git worktree list --porcelain emits blocks of:
+#   worktree /abs/path
+#   HEAD <sha>
+#   branch <ref>
+# Extract only worktree paths, skip the main worktree (first entry).
+MAIN_WT=$(git -C "$REPO_ROOT" rev-parse --show-toplevel)
+
+while IFS= read -r line; do
+  [ "${line:0:9}" = "worktree " ] || continue
+  WT_PATH="${line:9}"
+  [ "$WT_PATH" = "$MAIN_WT" ] && continue
+
+  # Match our two patterns: agents/<name> or .claude/worktrees/<name>
+  REL="${WT_PATH#$MAIN_WT/}"
+  case "$REL" in
+    agents/*|.claude/worktrees/*)
+      if [ "$DRY_RUN" = true ]; then
+        echo "  🔍 would remove: $REL"
+      else
+        if git -C "$REPO_ROOT" worktree remove --force "$WT_PATH" 2>/dev/null; then
+          echo "  ✓ removed: $REL"
+          REMOVED=$((REMOVED + 1))
+        else
+          echo "  ⚠️  failed: $REL (try: git worktree remove --force $WT_PATH)"
+          SKIPPED=$((SKIPPED + 1))
+        fi
+      fi
+      ;;
+    *)
+      # Not ours — leave alone
+      ;;
+  esac
+done < <(git -C "$REPO_ROOT" worktree list --porcelain)
+
+# Also prune any stale worktree metadata
+git -C "$REPO_ROOT" worktree prune 2>/dev/null || true
+
+echo ""
+if [ "$DRY_RUN" = true ]; then
+  echo "  Dry run — re-run without --dry-run to execute"
+elif [ "$REMOVED" -eq 0 ] && [ "$SKIPPED" -eq 0 ]; then
+  echo "  ✅ No agent worktrees found — clean"
+else
+  echo "  Removed: $REMOVED | Failed: $SKIPPED"
+fi
+echo ""

--- a/src/skills/team-agents/scripts/team-ops.sh
+++ b/src/skills/team-agents/scripts/team-ops.sh
@@ -35,6 +35,10 @@ case "$CMD" in
     bash "$SCRIPT_DIR/shutdown-skills.sh" "$@"
     ;;
 
+  shutdown-worktrees|sweep-worktrees)
+    bash "$SCRIPT_DIR/shutdown-worktrees.sh" "$@"
+    ;;
+
   cleanup|sweep)
     bash "$SCRIPT_DIR/cleanup.sh" "$@"
     ;;
@@ -129,6 +133,7 @@ print(', '.join(m['name'] for m in config.get('members', [])))
     echo "    panes [team]                  👁 Peek at tmux panes"
     echo "    spawn-skills <team> <agents>  🔧 Create /agent skills"
     echo "    shutdown-skills <team> <agents> 📦 Archive skills to /tmp"
+    echo "    shutdown-worktrees [repo]     🌳 Remove agent worktrees (#336)"
     echo "    cleanup [--dry-run]           🧹 Kill idle panes (safe)"
     echo "    killshot                      💀 Kill ALL non-lead panes"
     echo "    doctor [--fix]                🩺 Detect ghosts + orphans"


### PR DESCRIPTION
## What

Ports the #336 worktree-sweep fix from the installed `~/.claude/skills/team-agents/` copy back into the upstream source, so it survives the next `/go cleanup` (which otherwise re-installs the source over the installed copy and loses the patch).

## Why — root-cause, not symptom patch

Stale agent worktrees were polluting `maw-js` test runs — `bun test` was picking up ~1700 ghost tests from `agents/engine-isolator`, `agents/fail-debugger`, `agents/mock-builder`. See close comment on Soul-Brews-Studio/maw-js#336.

`TeamDelete()` *claims* to clean its worktrees, but when agents crash or sessions die without calling `TeamDelete`, the worktrees leak. The fix is an unconditional sweep at shutdown — no-op when nothing matches, but guaranteed correctness when something does.

## Changes

**NEW:** `src/skills/team-agents/scripts/shutdown-worktrees.sh` (~80 LOC)
- Uses `git worktree list --porcelain` as source of truth — catches stale registrations even if the directory was manually deleted.
- Matches both worktree patterns this skill produces:
  - `agents/<name>/` — Mode 1 (`--worktree` flag)
  - `.claude/worktrees/<name>/` — Mode 2 (Agent tool `isolation: "worktree"`)
- `--dry-run` flag for safe inspection.
- Accepts repo path arg; defaults to `$(pwd)`.

**UPDATED:** `src/skills/team-agents/scripts/team-ops.sh`
- `shutdown-worktrees|sweep-worktrees` dispatcher entry.
- Help text line: `shutdown-worktrees [repo]     🌳 Remove agent worktrees (#336)`.

**UPDATED:** `src/skills/team-agents/scripts/doctor.sh`
- Orphan-worktree detection rewritten to use `git worktree list --porcelain`. Previously only scanned `$repo/.claude/worktrees/*/` which missed Mode 1 (`agents/*`) worktrees entirely — that's the same gap #336 hit.

**UPDATED:** `src/skills/team-agents/SKILL.md`
- Shutdown block: explicit Step 3 "Sweep agent worktrees (#336 — root-cause fix)".
- Safety list: "Always sweep worktrees — even if shutdown looked clean" with the maw-js ~1700 ghost tests incident reference.
- `/team-agents shutdown` pseudocode: includes the sweep call + defensive-sweep note.

## Scope discipline

Only files under `src/skills/team-agents/` were touched. `package.json` / `CHANGELOG.md` bump is deliberately left for a follow-up PR.

## Skew observed

The source uses `maw panes`/`maw capture` wrappers throughout (v4 abstraction); the installed copy had been hand-patched with raw `tmux` commands alongside the #336 fix. This port applies ONLY the #336-specific changes (worktree detection + sweeper) while preserving the source's maw-based command layer.

Two source-only sections (`### How the Base System Works`, `### What Happens During Shutdown`) and the expanded ghost-detection guidance are upstream-only and were left untouched.

## Test plan

- [x] `bash src/skills/team-agents/scripts/shutdown-worktrees.sh /home/neo/Code/github.com/Soul-Brews-Studio/maw-js --dry-run` → clean exit, no worktrees matched.
- [x] `bash src/skills/team-agents/scripts/shutdown-worktrees.sh /home/neo/Code/github.com/Soul-Brews-Studio/maw-js` → "✅ No agent worktrees found — clean".
- [ ] Reviewer: spot-check `diff -r ~/.claude/skills/team-agents/scripts/ src/skills/team-agents/scripts/` — remaining deltas should be unrelated (maw vs tmux abstractions).

Retro: `ψ/memory/resonance/2026-04-15_1345_clean-four-agent-ship.md`
Related: Soul-Brews-Studio/maw-js#336

🤖 Generated with [Claude Code](https://claude.com/claude-code)