### PR TITLE
fix(#254 Bug 5): make install additive only — no silent downgrade

### DIFF
--- a/__tests__/e2e-features.test.ts
+++ b/__tests__/e2e-features.test.ts
@@ -103,11 +103,13 @@ describe("e2e: install with lab profile", () => {
   });
 });
 
-describe("e2e: profile switch (full → standard)", () => {
+describe("e2e: profile switch (full → standard) is additive", () => {
   beforeEach(cleanup);
 
-  it("switching from full to standard removes extra skills", async () => {
-    // Install full first
+  // #254 Bug 5: install is additive only. Switching full → standard must
+  // NOT silently drop full-only skills. Explicit `uninstall` is the only
+  // way to remove.
+  it("switching from full to standard keeps full-only skills", async () => {
     await installSkills([TEST_AGENT], {
       global: true,
       profile: "full",
@@ -120,7 +122,6 @@ describe("e2e: profile switch (full → standard)", () => {
     const fullCount = allSkills.length - labOnly.filter(s => allSkills.some(sk => sk.name === s)).length - excludedCount;
     expect(installed.length).toBe(fullCount);
 
-    // Switch to standard
     await installSkills([TEST_AGENT], {
       global: true,
       profile: "standard",
@@ -128,14 +129,10 @@ describe("e2e: profile switch (full → standard)", () => {
     });
 
     installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(profiles.standard.include!.length);
-
-    // Full-only skills should be gone
-    const allNames = allSkills.map((s) => s.name);
-    const standardSet = new Set(profiles.standard.include!);
-    const fullOnly = allNames.filter((s) => !standardSet.has(s));
-    for (const name of fullOnly) {
-      expect(installed).not.toContain(name);
+    // Additive: count unchanged, all full skills still present.
+    expect(installed.length).toBe(fullCount);
+    for (const name of profiles.standard.include!) {
+      expect(installed).toContain(name);
     }
   });
 });

--- a/__tests__/e2e-install.test.ts
+++ b/__tests__/e2e-install.test.ts
@@ -241,8 +241,11 @@ describe("e2e: uninstall preserves external skills", () => {
   });
 });
 
-describe("e2e: profile switch (full → standard)", () => {
-  it("installs full then switches to standard, removes extras", async () => {
+describe("e2e: profile switch (full → standard) is additive", () => {
+  // #254 Bug 5: install is additive only. A second install with a smaller
+  // profile must not remove skills from the larger profile. Users remove
+  // explicitly via `uninstall`.
+  it("installs full then switches to standard, keeps extras", async () => {
     await installSkills([TEST_AGENT], {
       global: true,
       profile: "full",
@@ -265,16 +268,13 @@ describe("e2e: profile switch (full → standard)", () => {
     skills = await listSkillDirs(SKILLS_DIR);
     const standardSkills = profiles.standard.include!;
 
-    expect(skills.length).toBe(standardSkills.length);
+    // Additive: count unchanged, all full skills still present.
+    expect(skills.length).toBe(fullSkills.length);
     for (const name of standardSkills) {
       expect(skills).toContain(name);
     }
-
-    const standardOnly = fullSkills.map(s => s.name).filter(
-      (s) => !standardSkills.includes(s)
-    );
-    for (const name of standardOnly) {
-      expect(skills).not.toContain(name);
+    for (const s of fullSkills) {
+      expect(skills).toContain(s.name);
     }
   });
 

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -430,35 +430,10 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
 
     p.log.success(`${agent.displayName}: ${targetDir}`);
 
-    // Profile mode: uninstall skills NOT in the profile set
-    if (profileSkillNames) {
-      const profileSet = new Set(skillsToInstall.map((s) => s.name));
-      const installed = readdirSync(targetDir, { withFileTypes: true })
-        .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
-        .map((d) => d.name);
-
-      const toRemove = installed.filter(
-        (name) => !profileSet.has(name) && !name.startsWith('.')
-      );
-
-      if (toRemove.length > 0) {
-        for (const skill of toRemove) {
-          const skillPath = join(targetDir, skill);
-          if (await isOurSkill(skillPath)) {
-            await rmrf(skillPath, shellMode);
-
-            if (agent.commandsDir) {
-              const commandsDir = options.global ? agent.globalCommandsDir! : join(process.cwd(), agent.commandsDir);
-              const ext = agent.commandFormat === 'toml' ? 'toml' : 'md';
-              const flatFile = join(commandsDir, `${skill}.${ext}`);
-              if (existsSync(flatFile)) await rmf(flatFile, shellMode);
-            }
-
-            p.log.info(`Profile cleanup: removed ${skill}`);
-          }
-        }
-      }
-    }
+    // #254 Bug 5: install is additive only. Skills present but not in the
+    // requested profile are kept — users must remove them via `uninstall`
+    // explicitly. The prior silent profile-downgrade caused capability loss
+    // without warning when running `install -g -y --profile <smaller>`.
   }
 
   spinner.stop(`Installed ${skillsToInstall.length} skills to ${targetAgents.length} agent(s)`);


### PR DESCRIPTION
## Summary

Bug 5 of #254: `install -g -y --profile <smaller>` silently removed skills that weren't in the new profile, causing surprise capability loss (e.g. switching from standard to minimal dropped 6 skills with no prompt and no diff).

This PR removes the silent profile-downgrade block in `installer.ts`. **install is now purely additive** — matching the existing behavior of the `-s` flag (additive since #221).

## Behavior change

| Command | Before | After |
|---------|--------|-------|
| `install -g --profile minimal` (from standard) | Removes 6 skills silently | Keeps all, adds missing minimal skills |
| `install -g --profile lab` (from minimal) | Installs 33 more | Installs 33 more (unchanged) |
| `install -g --profile minimal -s learn` | 7 minimal + learn, rest removed | 7 minimal + learn added, rest kept |
| `uninstall -g <skill>` | unchanged | **The only way to remove skills** |

No new flags, no warnings, no prompts. `uninstall` is the explicit removal path.

## Why no `--downgrade` flag?

Per discussion with the human: no new command, no new flag, no downgrade UX in `install`. Removal goes through `uninstall` exclusively — same surface area, same explicit semantics.

## Files

- `src/cli/installer.ts` (-28 / +5) — removed the "Profile mode: uninstall skills NOT in the profile set" block
- `__tests__/e2e-features.test.ts` (-14 / +13) — updated profile-switch test to assert additive semantics
- `__tests__/e2e-install.test.ts` (-9 / +8) — same

## Tests

```
133 pass / 0 fail
986 expect() calls
```

## Closes

#254 Bug 5 (silent capability loss on profile downgrade). Other sub-bugs in #254 are already resolved (see verifier's comment on that issue).

---
**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.