### PR TITLE
fix(#258): soul-sync reads installed version from VERSION.md

### DIFF
--- a/src/skills/oracle-soul-sync-update/SKILL.md
+++ b/src/skills/oracle-soul-sync-update/SKILL.md
@@ -20,11 +20,16 @@ All-in-one skill: `/soul-sync` + `/calibrate` + `/update` combined.
 
 ## Step 0: Timestamp + Check Current Version
 
-Your current version is shown in the skill description above (e.g., `v1.5.37 G-SKLL`).
+Read the installed version from `~/.claude/skills/VERSION.md` (the installer writes this on every install). Fall back to `arra-oracle-skills --version` if the file is missing.
 
-Extract just the version number:
 ```bash
-date "+🕐 %H:%M %Z (%A %d %B %Y)" && CURRENT="v1.5.37" && echo "Current installed: $CURRENT"
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+CURRENT=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+)?' ~/.claude/skills/VERSION.md 2>/dev/null | head -1)
+if [ -z "$CURRENT" ]; then
+  CURRENT=$(arra-oracle-skills --version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+)?' | head -1)
+  [ -n "$CURRENT" ] && [ "${CURRENT:0:1}" != "v" ] && CURRENT="v$CURRENT"
+fi
+echo "Current installed: ${CURRENT:-unknown}"
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes #258. The skill previously hardcoded `CURRENT="v1.5.37"` with a note "the LLM will read the real version from the description above" — which never worked. Every invocation reported v1.5.37 no matter what was installed, poisoning the sync-vs-don't-sync decision.

## Fix

Read from `~/.claude/skills/VERSION.md` (installer writes this on every install):

```bash
CURRENT=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+)?' ~/.claude/skills/VERSION.md 2>/dev/null | head -1)
```

Fallback: `arra-oracle-skills --version`.

## Verified live

On this box, `VERSION.md` contains `arra-oracle-skills-cli v3.9.1-alpha.1` — the regex returns `v3.9.1-alpha.1` correctly.

## Tests

133 pass / 0 fail.

Closes #258.

---
**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.