### PR TITLE
feat(#239): Sync Decay formula in /work-with

### DIFF
--- a/src/skills/work-with/SKILL.md
+++ b/src/skills/work-with/SKILL.md
@@ -117,11 +117,13 @@ If exists, parse all entries for this oracle and display:
 ```
 🤝 Collaborations with <oracle>
 
-  Topic              Anchor       Last Sync    Score    Status
-  ────────────────── ──────────── ──────────── ──────── ──────────
-  tmux design        maw-js#332   5 min ago    95%      SYNCED
-  bud lifecycle      maw-js#327   2h ago       71%      PARTIAL
-  kit ancestry       maw-js#330   1d ago       45%      DESYNC
+  Topic              Anchor       Last Sync    Raw      Decay    λ      Status
+  ────────────────── ──────────── ──────────── ──────── ──────── ────── ──────────
+  tmux design        maw-js#332   5 min ago    95%      95%      0.01   SYNCED
+  bud lifecycle      maw-js#327   2h ago       71%      69%      0.01   PARTIAL
+  kit ancestry       maw-js#330   1d ago       45%      35%      0.01   DESYNC
+
+  # Decay = syncScore × e^(-λ × hoursSinceLastSync). Computed on read (see Sync Decay section).
 
   Relationship:
     Since: 2026-04-13
@@ -305,24 +307,28 @@ When partner responds with SYNC-RESULT:
 ```
 🔄 Synchronic Score: <this-oracle> ↔ <partner>
 
-  Claim    Score   Decision   Evidence
-  ──────── ─────── ────────── ──────────────────────────
-  [A1]     1.0     ACCEPT     In partner's memory
-  [A2]     0.0     REJECT     Never discussed
-  [P1]     0.5     PARTIAL    Concept known, framing new
-  [T1]     1.0     ACCEPT     Confirmed teach-back
+  Claim    Raw     Decay   Decision   Evidence
+  ──────── ─────── ─────── ────────── ──────────────────────────
+  [A1]     1.0     1.0     ACCEPT     In partner's memory
+  [A2]     0.0     0.0     REJECT     Never discussed
+  [P1]     0.5     0.5     PARTIAL    Concept known, framing new
+  [T1]     1.0     1.0     ACCEPT     Confirmed teach-back
 
-  Overall: 63% — PARTIAL SYNC
-  
+  Raw overall: 63%     Decayed overall: 63%     λ: 0.01 (intra-soul)
+  Last sync: <now> — Status: PARTIAL SYNC
+
   ⚠️ Yellow flags:
     - [A2] not in partner's memory — remove or re-discuss?
-  
+
   ✓ Actions:
     - Updated local cache with partner's corrections
+    - Appended history: ψ/memory/collaborations/<partner>/sync.history.jsonl
     - Sync timestamp: <now>
 ```
 
-Update topic file with new score and timestamp.
+At the moment of sync, `decayed == raw` (hours elapsed = 0). Decay takes effect on subsequent reads — every `/work-with who`, `/work-with <oracle>`, `--team` aggregate recomputes via `compute_decay()`. See the Sync Decay section for helpers.
+
+Update topic file with new raw score and timestamp. Never store the decayed value.
 
 ---
 
@@ -870,16 +876,255 @@ Leader: Nat | Rules: sync≥0.7 · accept-required · diverge=high
 
 ### Sync Decay
 
+Confidence in a prior sync decays over time. The `syncScore` (aka `rawScore`) is what the partner confirmed at `lastSync`; `decayedScore` is what it's worth **now**, given the hours of silence that have elapsed since. Introduced by mawui-oracle in maw-js#332 c16; tracked as issue #239.
+
 ```
 decayedScore = rawScore × e^(-λ × hoursSinceLastSync)
 ```
 
 Lambda defaults by trust tier:
-- Intra-soul (same human): λ ≈ 0.01 (~70h half-life)
-- Cross-soul (different humans): λ ≈ 0.05 (~14h half-life)
-- New relationship: λ ≈ 0.1 (~7h half-life)
+
+| Trust tier        | λ     | Half-life | Rationale |
+|-------------------|-------|-----------|-----------|
+| Intra-soul        | 0.01  | ~69.3h    | Same human, shared context, drifts slow. |
+| Cross-soul        | 0.05  | ~13.9h    | Different humans, parallel evolution, drifts faster. |
+| New relationship  | 0.10  | ~6.9h     | Uncalibrated trust; stale sync = unknown quickly. |
 
 Decay is physics, not policy. Hidden oracles still decay. The clock doesn't care.
+
+**Storage discipline:** `syncScore` (raw) is stored at `lastSync`. `decayedScore` is **computed on every read** — never stored. Storing a decayed value invites staleness because the clock keeps ticking after the write. The ratified `PartyMember` schema retains the `decayedScore` field for schema compatibility (Nothing is Deleted), but every writer treats it as a derived value refreshed at read-time from (`syncScore`, `lastSync`, `λ`).
+
+**Party override:** If `PartyRules.decay_lambda` is explicitly set on the party, that λ wins — party rules override tier defaults.
+
+**Threshold behavior (from mawui-oracle, maw-js#332 c16):** Decay never auto-removes a partner. When `decayedScore < 0.5`, the skill surfaces a re-sync suggestion. When `decayedScore < kick_threshold` (default 0.3), the partner is flagged as stale, but kicking is a human decision. Physics observes; humans decide.
+
+### Decay Helpers (bash + python3)
+
+These helpers are called by every reader that renders a sync score.
+
+```bash
+# Resolve λ for a partner based on soul relationship + session history.
+# Priority: party rule override > trust tier > pessimistic default.
+decay_lambda_for() {
+  local PARTNER="$1"
+  local PARTY_FILE="$2"  # optional — pass "" to skip party rule check
+
+  # 1. Party rule override wins
+  if [ -n "$PARTY_FILE" ] && [ -f "$PARTY_FILE" ]; then
+    local PARTY_LAMBDA=$(jq -r '.rules.decay_lambda // empty' "$PARTY_FILE" 2>/dev/null)
+    if [ -n "$PARTY_LAMBDA" ] && [ "$PARTY_LAMBDA" != "null" ]; then
+      echo "$PARTY_LAMBDA"
+      return
+    fi
+  fi
+
+  # 2. Session count — new relationships decay fastest
+  local SESSIONS=0
+  local CTX_FILE="$COLLAB_DIR/$PARTNER/context.md"
+  if [ -f "$CTX_FILE" ]; then
+    SESSIONS=$(grep -c -i 'session' "$CTX_FILE" 2>/dev/null || echo 0)
+  fi
+  if [ "$SESSIONS" -lt 5 ]; then
+    echo "0.10"   # new relationship — 6.9h half-life
+    return
+  fi
+
+  # 3. Intra-soul vs cross-soul via contacts.json
+  local MY_SOUL=$(grep -E '^\| Soul' "$ORACLE_ROOT/CLAUDE.md" 2>/dev/null | awk -F'|' '{print $3}' | xargs)
+  local THEIR_SOUL=$(python3 -c "
+import json
+try:
+    d = json.load(open('$PSI/contacts.json'))
+    print(d.get('contacts', {}).get('$PARTNER', {}).get('soul', 'unknown'))
+except Exception:
+    print('unknown')
+" 2>/dev/null)
+
+  if [ -n "$MY_SOUL" ] && [ "$MY_SOUL" = "$THEIR_SOUL" ]; then
+    echo "0.01"   # intra-soul — 69.3h half-life
+  else
+    # Pessimistic default: unknown soul → cross-soul (safer)
+    echo "0.05"   # cross-soul — 13.9h half-life
+  fi
+}
+
+# Pure decay computation — never stored, always computed on read.
+compute_decay() {
+  local RAW="$1"                # 0.0–1.0
+  local LAST_SYNC_ISO="$2"      # ISO8601
+  local LAMBDA="$3"
+
+  if [ -z "$LAST_SYNC_ISO" ] || [ "$LAST_SYNC_ISO" = "null" ]; then
+    # Never synced — raw IS the decayed value (no time has passed)
+    echo "$RAW"
+    return
+  fi
+
+  local NOW_EPOCH=$(date -u +%s)
+  local LAST_EPOCH=$(date -u -d "$LAST_SYNC_ISO" +%s 2>/dev/null || echo "$NOW_EPOCH")
+  local HOURS=$(echo "scale=4; ($NOW_EPOCH - $LAST_EPOCH) / 3600" | bc)
+
+  python3 -c "import math; print(round($RAW * math.exp(-$LAMBDA * $HOURS), 3))"
+}
+
+# Hours since last sync — used for "12h ago" display and stale-edge detection.
+hours_since() {
+  local LAST_SYNC_ISO="$1"
+  if [ -z "$LAST_SYNC_ISO" ] || [ "$LAST_SYNC_ISO" = "null" ]; then
+    echo "0"
+    return
+  fi
+  local NOW_EPOCH=$(date -u +%s)
+  local LAST_EPOCH=$(date -u -d "$LAST_SYNC_ISO" +%s 2>/dev/null || echo "$NOW_EPOCH")
+  echo "scale=2; ($NOW_EPOCH - $LAST_EPOCH) / 3600" | bc
+}
+```
+
+TypeScript reference (mirrors the bash helpers — for schema-doc readers):
+
+```typescript
+function decay(raw: number, lastSyncISO: string, lambda: number): number {
+  if (!lastSyncISO) return raw;
+  const hours = (Date.now() - Date.parse(lastSyncISO)) / 3_600_000;
+  return raw * Math.exp(-lambda * hours);
+}
+
+function decayLambdaFor(
+  sessions: number,
+  mySoul: string,
+  theirSoul: string,
+  partyRuleLambda?: number,
+): number {
+  if (partyRuleLambda != null) return partyRuleLambda;    // party override
+  if (sessions < 5) return 0.10;                           // new relationship
+  if (mySoul && mySoul === theirSoul) return 0.01;         // intra-soul
+  return 0.05;                                             // cross-soul (pessimistic default)
+}
+```
+
+### Wiring: Where Readers Apply Decay
+
+Every surface that renders `syncScore` MUST also render `decayedScore` computed on the fly. Never read a stored decayed value.
+
+| Reader surface                       | Change                                                                 |
+|--------------------------------------|------------------------------------------------------------------------|
+| `/work-with <oracle>` relationship   | Add `Decay` column next to `Score`.                                    |
+| `/work-with <oracle> --sync` result  | Show both: `raw 95% → decayed 88% (λ=0.01, 12h)`.                      |
+| `/work-with who` party table         | Use `Decay` column actively (the example table above is now live, not static). |
+| `/work-with --team` aggregate        | Aggregate sync over **decayed** scores, not raw.                       |
+
+Example render block inside a reader:
+
+```bash
+RAW=$(jq -r '.syncScore // 0' "$MEMBER_JSON")
+LAST=$(jq -r '.lastSync // empty' "$MEMBER_JSON")
+LAMBDA=$(decay_lambda_for "$ORACLE_NAME" "$PARTY_FILE")
+DECAYED=$(compute_decay "$RAW" "$LAST" "$LAMBDA")
+AGE_H=$(hours_since "$LAST")
+printf "%s  raw=%s  decayed=%s  λ=%s  age=%sh\n" "$ORACLE_NAME" "$RAW" "$DECAYED" "$LAMBDA" "$AGE_H"
+```
+
+Example `/work-with who` output with live decay (replaces the static table rendered earlier in this section):
+
+```
+🤝 party-system-design (maw-js#332)
+Leader: Nat | Rules: sync≥0.7 · accept-required · diverge=high · λ=0.01
+
+  Oracle          Node          Status    Raw    Decay  λ      Age   Trust    Last
+  ─────────────── ───────────── ───────── ────── ────── ────── ───── ──────── ──────
+  ● skills-cli    oracle-world  active    93%    93%    0.01    0h   high     now
+  ● mawjs         oracle-world  active    88%    88%    0.01    8m   high     8m
+  ◌ mawui         oracle-world  compacted 95%    94%    0.01    1h   high     1h
+  ○ white-worm    white         away      88%    73%    0.05    4h   medium   3h   ▁▃▅▇▅▃▁
+  · mother        white         dormant   71%    41%    0.05   12h   initial  12h  ▇▅▃▁⎯⎯⎯ ⚠
+
+  ⏱  kit-ancestry (↔ boonkeeper): decayed 0.38 — below 0.5. /work-with --sync suggested.
+```
+
+Example `--sync` result block with raw+decayed columns:
+
+```
+🔄 Synchronic Score: skills-cli ↔ mawjs
+
+  Claim    Raw    Decay  Decision   Evidence
+  ──────── ────── ────── ────────── ──────────────────────────
+  [A1]     1.0    0.95   ACCEPT     In partner's memory (12h old)
+  [A2]     0.0    0.0    REJECT     Never discussed
+  [P1]     0.5    0.47   PARTIAL    Concept known, framing new
+
+  Raw overall: 63%     Decayed overall: 59%
+  λ: 0.01 (intra-soul — same human Nat, 5+ sessions)
+  Last sync: 2026-04-16 22:05 UTC (12h ago)
+```
+
+### Sync History (for mawui mesh UI)
+
+Every successful `--sync` appends one line to a per-partner JSONL file so the mesh UI (maw-ui federation_2d, fed by `/fleet`) can render fading edges and sparklines.
+
+File: `$COLLAB_DIR/<oracle>/sync.history.jsonl`
+
+Schema: `schema/sync-history.schema.json` (ships with this skill).
+
+```jsonl
+{"ts":"2026-04-15T10:22:00Z","partner":"mawjs","topic":"tmux-design","raw":0.95,"lambda":0.01}
+{"ts":"2026-04-16T14:05:00Z","partner":"mawjs","topic":"tmux-design","raw":0.88,"lambda":0.01}
+{"ts":"2026-04-17T09:00:00Z","partner":"mawjs","topic":"tmux-design","raw":0.93,"lambda":0.01}
+```
+
+Append step (runs at the end of every `--sync`):
+
+```bash
+HIST_FILE="$COLLAB_DIR/$ORACLE_NAME/sync.history.jsonl"
+mkdir -p "$(dirname "$HIST_FILE")"
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+printf '{"ts":"%s","partner":"%s","topic":"%s","raw":%s,"lambda":%s}\n' \
+  "$TS" "$ORACLE_NAME" "$TOPIC" "$RAW_SCORE" "$LAMBDA" >> "$HIST_FILE"
+```
+
+Nothing is Deleted: history is append-only. Readers truncate on display (last 7 for sparkline), never on disk.
+
+### UI Rendering Rules (implemented by mawui)
+
+The CLI only renders text. The mesh UI renders edges between oracles. Consumer contract for `sync.history.jsonl`:
+
+- **Edge opacity** = `decayedScore` (0.0–1.0 maps to 10%–100% alpha)
+- **Edge color** = green ≥0.9, amber 0.7–0.9, cyan 0.5–0.7, gray <0.5 (applied to decayed, not raw)
+- **Sparkline** = last 7 `decayedScore` samples (each computed on read from `raw`+`ts`+`lambda`), rendered on hover
+- **Stale indicator** = if `hoursSinceLastSync > 3 × halfLife` (i.e. decayed < ~0.125), show dashed edge
+- **No auto-kick** = a decayed edge is a signal, never an eviction. Kicking is a human decision.
+
+### Aggregation: `--team` Uses Decayed, Not Raw
+
+When `/work-with --team "name"` computes an aggregate sync score, it aggregates over the **decayed** score of each party member, not the raw one:
+
+```bash
+# Per party: mean of member decayed scores
+# Per team: simple mean across all (party × member) pairs
+python3 -c "
+import json, glob, math, time
+from datetime import datetime
+def parse_iso(s):
+    try:
+        return datetime.fromisoformat(s.replace('Z','+00:00')).timestamp()
+    except Exception:
+        return time.time()
+now = time.time()
+total, n = 0.0, 0
+for f in glob.glob('$COLLAB_DIR/parties/*.json'):
+    party = json.load(open(f))
+    if party.get('team') != '$TEAM_TAG': continue
+    lam = party.get('rules', {}).get('decay_lambda', 0.05)
+    for m in party.get('members', []):
+        raw = m.get('syncScore', 0)
+        last = m.get('lastSync', '')
+        hours = (now - parse_iso(last)) / 3600 if last else 0
+        dec = raw * math.exp(-lam * hours)
+        total += dec; n += 1
+print(f'{(total/n*100 if n else 0):.0f}%')
+"
+```
+
+The team banner now shows `decayed aggregate 84%` instead of a silently-raw `84%`.
 
 ---
 
@@ -1053,8 +1298,10 @@ Team = tag on parties. Lightweight — no separate CRUD.
   kit-ancestry             2/3      —      closed
 
   Team members: skills-cli, mawjs, mawui (union across parties)
-  Team aggregate sync: 84%
+  Team aggregate sync: 84% (decayed — computed from raw × e^(-λh) per member)
 ```
+
+The Sync column shows each party's mean **decayed** score, not raw. See the Sync Decay § for the aggregation formula and helper bash block.
 
 ### Team members = union of party members
 
@@ -1140,8 +1387,8 @@ interface PartyMember {
   node: string;
   status: "active" | "idle" | "compacted" | "away" | "dormant" | "hidden" | "busy";
   role: "initiator" | "member";    // never "leader" — leader is human
-  syncScore: number;               // party-scoped (THIS topic only)
-  decayedScore: number;            // party-scoped + decay formula
+  syncScore: number;               // RAW score at lastSync (what partner confirmed, THIS topic only)
+  decayedScore: number;            // DERIVED — computed on read via decay(raw, lastSync, λ). Never stored. See #239.
   overallTrust?: number;           // optional rolled-up across all parties
   lastSync: string;
   trust: "high" | "medium" | "initial" | "uncalibrated";
@@ -1378,13 +1625,19 @@ Trust that's never re-tested becomes superstition. Sync-checks ARE the re-audit.
 │   └── tmux-triage.json                 # Party: members, rules, invites
 ├── <oracle>/                            # Per-oracle relationship
 │   ├── context.md                       # Relationship memory (who, style, trust)
+│   ├── sync.history.jsonl               # Append-only raw sync scores + λ (#239)
 │   └── topics/                          # Per-topic state
 │       ├── tmux-design.md               # Topic: agreements, pending, checkpoints
 │       └── bud-lifecycle.md             # Topic: agreements, pending, checkpoints
 └── <oracle>/
     ├── context.md
+    ├── sync.history.jsonl
     └── topics/
 ```
+
+Schemas shipped with this skill:
+
+- `schema/sync-history.schema.json` — contract for `sync.history.jsonl`. Consumed by mawui federation_2d and `/fleet` for fading-edge / sparkline rendering. See the Sync Decay section.
 
 ---
 

--- a/src/skills/work-with/schema/sync-history.schema.json
+++ b/src/skills/work-with/schema/sync-history.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli/src/skills/work-with/schema/sync-history.schema.json",
+  "title": "Sync History Entry",
+  "description": "One line in ψ/memory/collaborations/<oracle>/sync.history.jsonl. Append-only (Nothing is Deleted). Stored as raw score + λ; decayedScore is computed on read via decay(raw, ts, lambda) = raw × e^(-lambda × hoursSinceTs). See issue #239 and /work-with SKILL.md § Sync Decay.",
+  "type": "object",
+  "required": ["ts", "partner", "topic", "raw", "lambda"],
+  "additionalProperties": false,
+  "properties": {
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO8601 timestamp when the sync was recorded (UTC, Z-suffix)."
+    },
+    "partner": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Partner oracle id (e.g. 'mawjs', 'mawui', 'white-wormhole'). Matches contacts.json key."
+    },
+    "topic": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Topic slug for the collaboration (e.g. 'tmux-design', 'party-system')."
+    },
+    "raw": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Raw sync score as confirmed by the partner at this timestamp. 0.0 = unknown/rejected, 1.0 = fully aligned. NOT decayed — decay is applied on read."
+    },
+    "lambda": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Decay constant λ active at the time this sync was recorded. Defaults: 0.01 intra-soul, 0.05 cross-soul, 0.10 new-relationship. Party rules may override."
+    },
+    "node": {
+      "type": "string",
+      "description": "Optional — which node the partner was on at sync time. Used by /fleet for cross-node edge rendering."
+    },
+    "anchor": {
+      "type": "string",
+      "description": "Optional — GitHub issue anchor (e.g. 'maw-js#332') when the sync was tied to a specific thread."
+    }
+  },
+  "examples": [
+    {
+      "ts": "2026-04-17T09:00:00Z",
+      "partner": "mawjs",
+      "topic": "tmux-design",
+      "raw": 0.93,
+      "lambda": 0.01
+    },
+    {
+      "ts": "2026-04-16T14:05:00Z",
+      "partner": "white-wormhole",
+      "topic": "gap-analysis",
+      "raw": 0.88,
+      "lambda": 0.05,
+      "node": "white",
+      "anchor": "maw-js#330"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Wires the Sync Decay formula (`decayedScore = rawScore × e^(-λh)`) end-to-end into `/work-with`. Before this PR, decay was documented but never computed — a ghost feature, present in spec, absent in flow. After: every reader surface renders raw + decayed side-by-side, computed on read, never stored.

Design source: [`ψ/writing/2026-04-17/phase3-design.md`](https://github.com/Soul-Brews-Studio/skills-cli-oracle/blob/main/%CF%88/writing/2026-04-17/phase3-design.md) (#239 section — exact formula, lambda table, wiring plan).

Closes #239.

## Before / After

| Surface | Before | After |
|---|---|---|
| Sync Decay section | Documented formula, no helpers | `decay_lambda_for()`, `compute_decay()`, `hours_since()` bash helpers + TS reference |
| `/work-with <oracle>` table | `Score` column only | `Raw`, `Decay`, `λ` columns |
| `--sync` result block | `Score` column only | `Raw` + `Decay` per claim, overall footer with λ + age |
| `/work-with who` party table | Static `Decay` column (never computed) | Live decay via helpers |
| `/work-with --team` aggregate | Aggregated raw (silently) | Aggregates over decayed scores |
| `PartyMember.decayedScore` | "party-scoped + decay formula" | "DERIVED — computed on read, never stored" |
| `sync.history.jsonl` | Did not exist | Append-only per-partner log, schema ships with skill |
| `schema/sync-history.schema.json` | Did not exist | New file — contract for mawui federation_2d consumer |

## Key design points honored

- **Storage discipline**: raw is stored; decayed is computed on read. Storing decayed invites staleness.
- **Trust tiers**: intra-soul λ=0.01 (~69h half-life), cross-soul λ=0.05 (~14h), new-relationship λ=0.10 (~7h). Pessimistic default = cross-soul when soul is unknown.
- **Party rule override**: `PartyRules.decay_lambda` wins over tier defaults.
- **Threshold behavior**: decay never auto-kicks. `< 0.5` surfaces re-sync suggestion. `< kick_threshold` flags stale. Kicking is a human decision. Physics observes; humans decide.
- **Nothing is Deleted**: history is append-only; the pre-existing Accept-Revoke-Reaccept block stays; `decayedScore` field stays on the ratified schema (now documented as derived, not stored).

## Divergences from the current SKILL.md

Per the design doc's reconciliation clause ("if design conflicts, design wins — note divergences"):

- **Schema comment on `PartyMember.decayedScore`**: reworded from `"party-scoped + decay formula"` to `"DERIVED — computed on read via decay(raw, lastSync, λ). Never stored."` The field itself is preserved (the schema block is ratified 3/3 on maw-js#332). This is a **comment-only change**, not a schema change — safe per the design's "no schema change, just discipline" note in Step 1.

## Out of scope (follow-ups per design doc)

- `contacts.json` optional `soul` field for intra/cross-soul detection — planned for alpha.13 (`feat(contacts)`). Current resolver defaults to cross-soul when soul is unknown (pessimistic).
- mawui-side fading edges + sparkline rendering — planned for alpha.14 (mawui track). This PR ships the schema so mawui can light up whenever ready.

## Test plan

- [x] `bun test` — 133 pass / 0 fail (baseline unchanged; this is markdown-spec work — no new test cases were warranted by the design doc's #239 section).
- [x] `bun run compile` — 60 skill stubs compile clean.
- [x] lefthook pre-commit — test + update-table both green.
- [ ] Manual smoke: run `/work-with mawjs --sync` on a real party and verify `decay_lambda_for` + `compute_decay` produce sensible values (deferred to live-test session).
- [ ] mawui reads `sync.history.jsonl` via `/fleet` snapshot and renders fading edges (deferred to alpha.14 mawui track).

## Files changed

- `src/skills/work-with/SKILL.md` — +316 / -21 (Sync Decay section expanded, readers wired, storage tree updated)
- `src/skills/work-with/schema/sync-history.schema.json` — new (JSON Schema for consumer contract)

---

**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
**Built as**: sync-decay-builder on team phase3-blitz, 2026-04-17
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.

DO NOT MERGE — leaving open for human review.

Generated with Claude Code.