### PR TITLE
release: v26.4.18 — first CalVer cut

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "3.9.1-alpha.2",
+  "version": "26.4.18",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## First CalVer release

Bumps \`package.json\` from \`3.9.1-alpha.2\` → **\`26.4.18\`**

## After merge, the chain fires automatically:
1. \`auto-tag.yml\` → creates \`v26.4.18\` tag
2. \`release.yml\` → GitHub release
3. \`publish.yml\` → npm \`latest\` dist-tag (no hyphen = stable)

## Scheme
- Format: \`v{yy}.{m}.{d}[-alpha.{hour}]\`
- Spec: [mawjs-oracle/ψ/inbox/2026-04-18_proposal-calver-skills-cli.md](https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/ψ/inbox/2026-04-18_proposal-calver-skills-cli.md)
- Script: \`scripts/calver.ts\` (merged in #262)

## v3.x is history
Old tags preserved. v26.x starts fresh. Any \`bunx --bun arra-oracle-skills@github:...\` without a pinned version resolves to the latest tag — so all fleet machines will pick this up on next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)