### PR TITLE
fix(#265): soul-sync shows date-drift (N days stale) not semver-drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y --agent claude-code
+npx arra-oracle-skills@26.4.18 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.4.18 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.4.18 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.4.18 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y --agent cursor
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.4.18 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.4.18 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.4.18 install -g -y --agent cursor
+npx arra-oracle-skills@26.4.18 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.4.18 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -132,7 +132,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@3.9.1-alpha.2 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.4.18 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/src/skills/oracle-soul-sync-update/SKILL.md
+++ b/src/skills/oracle-soul-sync-update/SKILL.md
@@ -36,6 +36,8 @@ echo "Current installed: ${CURRENT:-unknown}"
 
 ## Step 2: Check Latest Version (stable vs alpha)
 
+Tag format moved to CalVer (`v{YY}.{M}.{D}`, first number ≥ 25) in April 2026. Older tags are SemVer (`v3.x.x`). The latest-check picks CalVer first and treats SemVer as legacy.
+
 ```bash
 # Get ALL tags via jq, separate stable from alpha
 TAGS=$(curl -s https://api.github.com/repos/Soul-Brews-Studio/arra-oracle-skills-cli/tags | jq -r '.[].name')
@@ -63,13 +65,52 @@ echo "Track: $TRACK → comparing against $LATEST"
 
 ---
 
-## Step 3: Compare Versions
+## Step 3: Compare Versions — date-drift, not semver-drift (#265)
+
+CalVer tags encode the release date directly (`v26.4.18` = 2026-04-18). Staleness is more useful as "N days behind" than as a semver gap. Legacy SemVer tags (`v3.x.x`) are flagged for migration.
 
 ```bash
+# Helpers — parse tag → YYYY-MM-DD, diff in days
+tag_era() {  # "calver" | "semver" | "unknown"
+  local first=$(echo "$1" | sed 's/^v//; s/-.*$//' | cut -d. -f1)
+  [ -z "$first" ] && { echo unknown; return; }
+  [ "$first" -ge 25 ] 2>/dev/null && echo calver || echo semver
+}
+tag_to_date() {  # v26.4.18 → 2026-04-18
+  local core=$(echo "$1" | sed 's/^v//; s/-alpha.*$//')
+  local yy=$(echo "$core" | cut -d. -f1)
+  local m=$(echo "$core" | cut -d. -f2)
+  local d=$(echo "$core" | cut -d. -f3)
+  printf "%04d-%02d-%02d" "$((2000 + yy))" "$m" "$d"
+}
+alpha_hour() { echo "$1" | grep -oE 'alpha\.[0-9]+' | cut -d. -f2; }
+
+CUR_ERA=$(tag_era "$CURRENT")
+LAT_ERA=$(tag_era "$LATEST")
+
 if [ "$CURRENT" = "$LATEST" ]; then
   echo "✅ Soul synced! ($CURRENT) [$TRACK track]"
+elif [ "$CUR_ERA" = "semver" ] && [ "$LAT_ERA" = "calver" ]; then
+  echo "⚠️ Legacy version — migrate $CURRENT → $LATEST (CalVer cut-over)"
 else
-  echo "⚠️ Sync needed: $CURRENT → $LATEST [$TRACK track]"
+  CUR_DATE=$(tag_to_date "$CURRENT")
+  LAT_DATE=$(tag_to_date "$LATEST")
+  DAYS=$(( ( $(date -d "$LAT_DATE" +%s) - $(date -d "$CUR_DATE" +%s) ) / 86400 ))
+  if [ "$DAYS" -eq 0 ]; then
+    CUR_H=$(alpha_hour "$CURRENT")
+    LAT_H=$(alpha_hour "$LATEST")
+    if [ -n "$CUR_H" ] || [ -n "$LAT_H" ]; then
+      HOURS=$(( ${LAT_H:-0} - ${CUR_H:-0} ))
+      [ "$HOURS" -lt 0 ] && HOURS=$(( -HOURS ))
+      echo "⚠️ ${HOURS}h stale: $CURRENT → $LATEST ($CUR_DATE, same day)"
+    else
+      echo "⚠️ Same day, different tag: $CURRENT → $LATEST"
+    fi
+  else
+    echo "Current installed: $CURRENT   ($CUR_DATE)"
+    echo "Latest available:  $LATEST   ($LAT_DATE)"
+    echo "⚠️ $DAYS days stale [$TRACK track]"
+  fi
 fi
 ```
 


### PR DESCRIPTION
## Summary

Fixes #265. Now that we're on CalVer (`v{YY}.{M}.{D}`), the soul-sync staleness message reads as a day count instead of a semver gap — the UX win of CalVer was making staleness self-readable, and the front-door skill should reflect that.

## Before

```
Current installed: v3.6.1
Latest available: v26.4.18
⚠️ Sync needed: v3.6.1 → v26.4.18
```

## After

Same-era drift:
```
Current installed: v26.4.5   (2026-04-05)
Latest available:  v26.4.18   (2026-04-18)
⚠️ 13 days stale [stable track]
```

Legacy migration:
```
⚠️ Legacy version — migrate v3.6.1 → v26.4.18 (CalVer cut-over)
```

Same-day alpha drift (hours, not "0 days"):
```
⚠️ 3h stale: v26.4.18-alpha.5 → v26.4.18-alpha.8 (2026-04-18, same day)
```

## How

Three small bash helpers:

- `tag_era()` — first-digit ≥ 25 → calver, else semver
- `tag_to_date()` — parses `v{YY}.{M}.{D}[-alpha.N]` → ISO date
- `alpha_hour()` — extracts N from `-alpha.N`

Step 3 of SKILL.md branches on era pair to pick the right output format.

## Smoke test

Live on this box:

```
v26.4.18         → era=calver date=2026-04-18
v3.9.1-alpha.2   → era=semver
v26.4.5-alpha.9  → era=calver date=2026-04-05
v3.6.1           → era=semver

v26.4.5 → v26.4.18 = 13 days  ✓ (matches issue example)
```

## Tests

139 pass / 0 fail.

Closes #265.

---
**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.