### PR TITLE
feat(team-agents): broadcast-shutdown.sh helper for #212

### DIFF
--- a/src/skills/team-agents/SKILL.md
+++ b/src/skills/team-agents/SKILL.md
@@ -175,6 +175,14 @@ SendMessage({ to: "agent-2", message: { type: "shutdown_request" } })
 TeamDelete()
 ```
 
+**Don't write the loop by hand** — structured messages can't broadcast (#212), but the helper script generates the per-agent `SendMessage` block for you:
+```bash
+bash ~/.claude/skills/team-agents/scripts/broadcast-shutdown.sh $TEAM
+# → prints ready-to-paste SendMessage lines, one per teammate (lead excluded)
+# → also supports --names (raw list) and --json (array) for scripted loops
+# → --type=X to broadcast any structured message type, not just shutdown
+```
+
 **Strategy B: Rolling shutdown** — shutdown each agent as it completes:
 ```
 # On each DONE report: immediately shutdown that agent
@@ -357,7 +365,7 @@ git merge "agents/$AGENT" --no-ff -m "merge: $AGENT from team $TEAM"
 8. **~3-7x tokens** vs single agent
 9. **Same file = overwrites** — each agent must own different files
 10. **Shutdown slow** — agents finish current request first
-11. **Structured messages cannot broadcast** — send individually (#212)
+11. **Structured messages cannot broadcast** — send individually, or use `scripts/broadcast-shutdown.sh $TEAM` to auto-generate the per-agent block (#212)
 
 ---
 

--- a/src/skills/team-agents/scripts/broadcast-shutdown.sh
+++ b/src/skills/team-agents/scripts/broadcast-shutdown.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# broadcast-shutdown.sh — workaround for #212
+#
+# Upstream SendMessage rejects structured messages with to: "*":
+#   SendMessage({ to: "*", message: { type: "shutdown_request" } })
+#   → Error: structured messages cannot be broadcast
+#
+# This helper reads the team's config.json and prints:
+#   1. The list of agent names (one per line) — machine-readable
+#   2. A ready-to-copy SendMessage block the LLM can emit
+#
+# The script itself CANNOT invoke SendMessage (that's a tool call only the
+# LLM can make). The LLM should either pipe --names into a loop and emit
+# one SendMessage per name, or copy the printed block verbatim.
+#
+# Usage:
+#   bash broadcast-shutdown.sh <team-name>            # human-readable
+#   bash broadcast-shutdown.sh <team-name> --names    # names only, one per line
+#   bash broadcast-shutdown.sh <team-name> --json     # JSON array of names
+#   bash broadcast-shutdown.sh <team-name> --type=X   # custom structured type
+#
+# The lead is excluded from the shutdown list by default (lead cannot
+# shutdown itself via SendMessage). Override with --include-lead.
+
+set -euo pipefail
+
+TEAM="${1:-}"
+if [ -z "$TEAM" ]; then
+  echo "Usage: broadcast-shutdown.sh <team-name> [--names|--json] [--type=TYPE] [--include-lead]" >&2
+  echo "Lists teammates and prints SendMessage commands for structured broadcast (#212 workaround)." >&2
+  exit 1
+fi
+shift
+
+MODE="human"
+MSG_TYPE="shutdown_request"
+INCLUDE_LEAD=0
+LEAD_NAME="team-lead"
+
+for arg in "$@"; do
+  case "$arg" in
+    --names) MODE="names" ;;
+    --json)  MODE="json" ;;
+    --type=*) MSG_TYPE="${arg#--type=}" ;;
+    --include-lead) INCLUDE_LEAD=1 ;;
+    --lead=*) LEAD_NAME="${arg#--lead=}" ;;
+    *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+CONFIG="$HOME/.claude/teams/$TEAM/config.json"
+if [ ! -f "$CONFIG" ]; then
+  echo "Team config not found: $CONFIG" >&2
+  echo "Hint: check ~/.claude/teams/ for valid team names." >&2
+  exit 3
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but not installed" >&2
+  exit 4
+fi
+
+# Extract member names, optionally excluding the lead
+if [ "$INCLUDE_LEAD" = "1" ]; then
+  NAMES=$(jq -r '.members[].name' "$CONFIG")
+else
+  NAMES=$(jq -r --arg lead "$LEAD_NAME" '.members[] | select(.name != $lead) | .name' "$CONFIG")
+fi
+
+if [ -z "$NAMES" ]; then
+  echo "No teammates found in $CONFIG (lead excluded: $([ $INCLUDE_LEAD = 0 ] && echo yes || echo no))" >&2
+  exit 5
+fi
+
+case "$MODE" in
+  names)
+    # One name per line — pipe into a loop
+    printf '%s\n' "$NAMES"
+    ;;
+  json)
+    # JSON array — load into a tool or parse
+    printf '%s\n' "$NAMES" | jq -R . | jq -s .
+    ;;
+  human)
+    echo "# Team: $TEAM"
+    echo "# Teammates (lead '$LEAD_NAME' excluded: $([ $INCLUDE_LEAD = 0 ] && echo yes || echo no)):"
+    printf '%s\n' "$NAMES" | sed 's/^/#   - /'
+    echo ""
+    echo "# Structured broadcast is rejected upstream (#212). Emit N individual"
+    echo "# SendMessage calls — copy this block verbatim into your next turn:"
+    echo ""
+    while IFS= read -r name; do
+      [ -z "$name" ] && continue
+      echo "SendMessage({ to: \"$name\", message: { type: \"$MSG_TYPE\" } })"
+    done <<< "$NAMES"
+    echo ""
+    echo "# Then wait ~10s for shutdown_response from each, then TeamDelete()."
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `src/skills/team-agents/scripts/broadcast-shutdown.sh` — reads `~/.claude/teams/$TEAM/config.json` and prints per-agent `SendMessage` calls so the lead doesn't have to remember every teammate name.
- Works around the upstream limitation (`SendMessage({to: "*", message: {type: ...}}) → "structured messages cannot be broadcast"`) without touching Claude Code.
- Three output modes: human (annotated block, default), `--names` (raw list for shell loops), `--json` (array for tool loads). `--type=X` broadcasts any structured type; `--include-lead` / `--lead=NAME` adjust scope.
- `SKILL.md` updated: Strategy A references the helper; gotcha #11 links it.

## Why this shape

The script can't invoke `SendMessage` — that's an LLM tool call. What it CAN do is generate the exact commands the LLM should emit, grounded in the real team config. The lead pastes the printed block into its next turn. Zero new tokens per shutdown, zero upstream risk.

## Out of scope

This doesn't fix the broadcast rejection itself (that lives in Claude Code and is out of bounds). It also doesn't auto-cleanup stale teams — that's the other half of #212 and will need a separate design.

## Test plan

- [x] `bash broadcast-shutdown.sh <team>` prints human block with correct names
- [x] `--names` one per line, `--json` valid JSON array
- [x] `--type=task_announcement` generates non-shutdown block
- [x] `--include-lead` includes lead; default excludes
- [x] Missing team / missing jq / empty members all exit with helpful error
- [x] 139 existing tests still pass (lefthook pre-commit)
- [ ] Smoke test on a live team's end-of-session shutdown (human-in-loop)

---

**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)