### PR TITLE
fix(#230): local-skill-precedence shield in global installer

### DIFF
--- a/__tests__/install-uninstall.test.ts
+++ b/__tests__/install-uninstall.test.ts
@@ -120,6 +120,59 @@ describe("uninstall preserves external skills", () => {
   });
 });
 
+describe("#230 local-skill-precedence shield", () => {
+  const LOCAL_SKILLS_DIR = join(process.cwd(), "test-skills");
+
+  beforeEach(async () => {
+    await cleanup();
+    if (existsSync(LOCAL_SKILLS_DIR)) await rm(LOCAL_SKILLS_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    if (existsSync(LOCAL_SKILLS_DIR)) await rm(LOCAL_SKILLS_DIR, { recursive: true });
+  });
+
+  it("skips global install of a skill shadowed by a non-ours local skill", async () => {
+    // Seed a local user-authored skill at <cwd>/test-skills/recap/ (NOT ours — no marker)
+    const localRecap = join(LOCAL_SKILLS_DIR, "recap");
+    await mkdir(localRecap, { recursive: true });
+    await writeFile(join(localRecap, "SKILL.md"), "# local recap\n\nUser's own recap.\n");
+
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed).not.toContain("recap");
+    // Other skills should still install
+    expect(installed.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT skip if the local skill is ours (installer marker present)", async () => {
+    const localTrace = join(LOCAL_SKILLS_DIR, "trace");
+    await mkdir(localTrace, { recursive: true });
+    await writeFile(
+      join(localTrace, "SKILL.md"),
+      "---\ninstaller: arra-oracle-skills-cli v1.0.0\n---\n# trace\n"
+    );
+
+    await installSkills([TEST_AGENT], { global: true, yes: true });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed).toContain("trace");
+  });
+
+  it("--force-global installs the skill anyway", async () => {
+    const localRrr = join(LOCAL_SKILLS_DIR, "rrr");
+    await mkdir(localRrr, { recursive: true });
+    await writeFile(join(localRrr, "SKILL.md"), "# local rrr\n");
+
+    await installSkills([TEST_AGENT], { global: true, yes: true, forceGlobal: true });
+
+    const installed = await listSkillDirs(SKILLS_DIR);
+    expect(installed).toContain("rrr");
+  });
+
+});
+
 describe("orphan cleanup on install", () => {
   beforeEach(cleanup);
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -16,6 +16,7 @@ export function registerInstall(program: Command, version: string) {
     .option('-l, --list', 'List available skills without installing')
     .option('-y, --yes', 'Skip confirmation prompts')
     .option('--with-commands', 'Also install command stubs to ~/.claude/commands/')
+    .option('--force-global', 'Install global skills even if a same-named local skill exists (#230)')
     .option('--shell', 'Force Bun.$ shell commands (use on Windows to test shell compatibility)')
     .option('--no-shell', 'Force Node.js fs operations (use on Unix if Bun.$ causes issues)')
     .action(async (options) => {
@@ -98,6 +99,7 @@ export function registerInstall(program: Command, version: string) {
           profile: options.profile,
           yes: options.yes,
           commands: options.withCommands,
+          forceGlobal: options.forceGlobal,
           shellMode,
         });
 

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -137,6 +137,38 @@ export async function installSkills(
     // Create target directory
     await mkdirp(targetDir, shellMode);
 
+    // #230 Local-skill-precedence shield (workaround for Claude Code's
+    // global-over-local loader order): when installing GLOBALLY, skip any
+    // skill whose name already exists as a NON-OURS local skill in the
+    // user's cwd. Claude Code would load the global copy and shadow the
+    // user's local override — which is the opposite of what they want.
+    // Use --force-global to install anyway.
+    let agentSkillsToInstall = skillsToInstall;
+    const shadowedSkills: string[] = [];
+    if (options.global && !options.forceGlobal) {
+      const localSkillsDir = join(process.cwd(), agent.skillsDir);
+      if (existsSync(localSkillsDir)) {
+        const filtered: Skill[] = [];
+        for (const skill of skillsToInstall) {
+          const localSkillMd = join(localSkillsDir, skill.name, 'SKILL.md');
+          if (existsSync(localSkillMd) && !(await isOurSkill(join(localSkillsDir, skill.name)))) {
+            shadowedSkills.push(skill.name);
+            continue;
+          }
+          filtered.push(skill);
+        }
+        agentSkillsToInstall = filtered;
+      }
+      if (shadowedSkills.length > 0) {
+        p.log.warn(
+          `Skipping ${shadowedSkills.length} skill(s) shadowed by your local ${agent.skillsDir}/: ${shadowedSkills.join(', ')}`
+        );
+        p.log.info(
+          `Your local skill(s) take precedence. Use --force-global to install the Oracle version anyway.`
+        );
+      }
+    }
+
     // Auto-cleanup: remove orphaned skills installed by arra-oracle-skills-cli
     // Only removes skills that: 1) have installer: arra-oracle-skills-cli marker, 2) no longer exist in source
     const sourceSkillNames = allSkills.map((s) => s.name);
@@ -195,7 +227,7 @@ export async function installSkills(
     // Track skills with hooks for separate plugin installation
     const skillsWithHooks: Skill[] = [];
 
-    for (const skill of skillsToInstall) {
+    for (const skill of agentSkillsToInstall) {
       // Check if skill has hooks - needs plugin installation
       if (await skillHasHooks(skill.name)) {
         skillsWithHooks.push(skill);
@@ -282,7 +314,7 @@ export async function installSkills(
     const manifest = {
       version: pkg.version,
       installedAt: new Date().toISOString(),
-      skills: skillsToInstall.map((s) => s.name),
+      skills: agentSkillsToInstall.map((s) => s.name),
       agent: agentName,
     };
     await Bun.write(join(targetDir, '.arra-oracle-skills.json'), JSON.stringify(manifest, null, 2));
@@ -293,7 +325,7 @@ export async function installSkills(
 Installed by: **arra-oracle-skills-cli v${pkg.version}**
 Installed at: ${new Date().toISOString()}
 Agent: ${agent.displayName}
-Skills: ${skillsToInstall.length}
+Skills: ${agentSkillsToInstall.length}
 
 ## Report This Version
 
@@ -304,7 +336,7 @@ arra-oracle-skills-cli v${pkg.version}
 
 ## Installed Skills
 
-${skillsToInstall.map((s) => `- ${s.name}`).join('\n')}
+${agentSkillsToInstall.map((s) => `- ${s.name}`).join('\n')}
 
 ## Update Skills
 
@@ -321,7 +353,7 @@ bunx --bun arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli#v$
       const commandsDir = options.global ? agent.globalCommandsDir! : join(process.cwd(), agent.commandsDir);
       if (existsSync(commandsDir)) {
         const ext = agent.commandFormat === 'toml' ? 'toml' : 'md';
-        for (const skill of skillsToInstall) {
+        for (const skill of agentSkillsToInstall) {
           const cmdFile = join(commandsDir, `${skill.name}.${ext}`);
           if (existsSync(cmdFile)) {
             await rmf(cmdFile, shellMode);
@@ -341,7 +373,7 @@ bunx --bun arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli#v$
       
       const cmdFormat = agent.commandFormat || 'md';
 
-      for (const skill of skillsToInstall) {
+      for (const skill of agentSkillsToInstall) {
         // Hidden skills: install SKILL.md but skip command stub (not in autocomplete)
         if (skill.hidden) continue;
 

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -49,5 +49,6 @@ export interface InstallOptions {
   yes?: boolean;
   agents?: string[];
   commands?: boolean; // Also install command stubs (for agents with commandsOptIn)
+  forceGlobal?: boolean; // #230 Override local-skill-precedence check and install global anyway
   shellMode?: ShellMode;
 }


### PR DESCRIPTION
## Summary

Workaround for Claude Code's global-over-local skill loader order (#230) — implemented entirely on our side, no upstream change needed.

**Behavior change**: `install -g` now skips any skill whose name is already taken by a user-authored local skill in `<cwd>/<agent.skillsDir>/<name>/SKILL.md`. The user's local override wins, which is what they asked for by creating it.

**Escape hatch**: `--force-global` overrides the shield and installs the global skill anyway.

**Safety**: the `isOurSkill()` marker check governs the shield — we only refuse to stomp skills we did not install. Any skill we previously installed locally is treated as replaceable.

## Why (a) over (b) and (c)

- **(a) Shield ✅** — surgical, ~40 LOC, preserves user intent, reversible via flag.
- **(b) Rename to `X-global` ❌** — breaks every `/skill` reference across docs, hooks, muscle memory. Non-starter.
- **(c) Docs only ❌** — doesn't solve the problem; user still has to manually rename their local to `/projects` etc.

## Files

- `src/cli/types.ts` — add `forceGlobal?: boolean` to `InstallOptions`
- `src/cli/installer.ts` — per-agent shield + filtered `agentSkillsToInstall`; manifest/VERSION.md now reflect the effective install set
- `src/cli/commands/install.ts` — wire `--force-global` flag
- `__tests__/install-uninstall.test.ts` — 3 new cases

## Test plan

- [x] `bun test` — 142/142 pass (was 139; +3 new)
- [ ] Manual smoke: create `<repo>/.claude/skills/project/SKILL.md` then run `arra-oracle-skills install -g -y` — global `project` should be skipped with a warning; other skills install normally.
- [ ] Manual smoke: same setup + `--force-global` — global `project` installs, shadowing the local.

## Not merging

Review-gated per Nat's rule. **DO NOT MERGE** until Neo approves.

---

**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
**Team**: issue-finisher / loader-patcher
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.