### PR TITLE
feat(work-with): mesh data contract for xyflow UI (#235)

### DIFF
--- a/src/skills/work-with/SKILL.md
+++ b/src/skills/work-with/SKILL.md
@@ -1109,6 +1109,78 @@ The CLI only renders text. The mesh UI renders edges between oracles. Consumer c
 - **Stale indicator** = if `hoursSinceLastSync > 3 × halfLife` (i.e. decayed < ~0.125), show dashed edge
 - **No auto-kick** = a decayed edge is a signal, never an eviction. Kicking is a human decision.
 
+### Mesh Data Contract (for xyflow CollaborationMesh UI — issue #235)
+
+The mesh UI (`maw-ui` federation_2d, xyflow + deep-ocean theme) is a pure consumer of files this skill writes. The mesh does not call any API — it reads, maps, renders. This section is the full contract.
+
+#### What is emitted
+
+| File                                                  | Schema                                 | Shape           | Update model   |
+|-------------------------------------------------------|----------------------------------------|-----------------|----------------|
+| `ψ/memory/collaborations/parties/<slug>.json`         | `schema/party.schema.json`             | `PartyStatus`   | Overwrite (atomic) |
+| `ψ/memory/collaborations/<oracle>/sync.history.jsonl` | `schema/sync-history.schema.json`      | append-only log | Append-only    |
+| `ψ/memory/collaborations/<oracle>/topics/<slug>.state.json` | (inline in SKILL.md § CommitState) | `TopicStateSidecar` | Overwrite      |
+
+Both schemas ship with this skill under `src/skills/work-with/schema/`. Installers place them at `~/.claude/skills/work-with/schema/` so the UI can fetch them at a stable path.
+
+#### Node / edge mapping (what xyflow consumes)
+
+For each party file, the UI builds:
+
+- **Nodes** — one per distinct `PartyMember.id` across all parties (union), plus the `leader.human` as a special `human` node:
+  - `id` = member id
+  - `label` = member id (display name comes from contacts.json; mesh UI may read that too, but it is NOT part of this contract)
+  - `data.node` = member.node (fleet node, used for swim-lane grouping)
+  - `data.status` = member.status (drives node color + pulse animation)
+  - `data.trust` = member.trust (drives node border style)
+  - `data.lastSync` = member.lastSync (drives "last-seen" badge)
+  - `position` — **not emitted**. Layout is UI-side (xyflow's layouting or persisted per-view). /work-with does not own screen coordinates.
+
+- **Edges** — one per (party × member) pair, representing the relationship *within that party*:
+  - `source` = party.leader.actingVia ?? party-initiator id
+  - `target` = member.id
+  - `data.topic` = party.topic
+  - `data.anchor` = party.anchor (e.g. 'maw-js#332')
+  - `data.syncRaw` = member.syncScore
+  - `data.decayedScore` = `decay(syncScore, lastSync, λ)` — **UI computes this on every render**, never trust a stored value (see § Sync Decay storage discipline)
+  - `data.lambda` = rules.decay_lambda (party override wins; else UI resolves via trust tier from `sync.history.jsonl`)
+  - `data.trust` = member.trust
+  - `data.role` = member.role
+  - `data.team` = party.team
+  - Edge is **directed** (leader acting-via → member) for layout purposes; sync itself is pairwise and each direction will eventually carry its own score — until then, render the single emitted value on both ends.
+
+#### Sparkline / history
+
+Each edge's hover sparkline comes from filtering `sync.history.jsonl`:
+
+```
+ψ/memory/collaborations/<member.id>/sync.history.jsonl
+  filter: topic == party.topic
+  sort: ts ascending
+  take last 7
+  map: (raw, ts, lambda) -> decay(raw, ts, lambda)
+```
+
+The optional `source` field on history entries (added for #235) lets a *federated* mesh consumer distinguish which oracle observed the score — one oracle's view of the same topic-pair may disagree with another's, and both are valid. Single-node UIs may ignore it.
+
+#### Update mechanism
+
+The mesh is pulled, not pushed. Recommended consumer loop:
+
+1. **On mount**: list `parties/*.json`, build initial graph.
+2. **Poll every 5s** (same cadence `/fleet` uses): re-stat each party file's mtime. If changed, re-read and diff nodes/edges.
+3. **Tail `sync.history.jsonl`** for each connected partner — any new line triggers sparkline refresh + edge opacity recompute.
+4. **No file-watch hooks**: `/work-with` emits no signals, spawns no daemons. File mtimes are the event bus (consistent with Rule: no hooks for /work-with, see MEMORY.md).
+
+A future `/work-with --mesh-json` query (not yet implemented; see GAP below) would emit a single normalised snapshot `{ nodes, edges, ts }` so a UI can bootstrap without scanning the whole `parties/` directory. Until then, scan + filter.
+
+#### What is NOT emitted (known gaps — tracked as follow-ups on #235)
+
+- **Position hints** — xyflow layout is owned by the UI.
+- **Directional sync pairs** — both halves of `A↔B` currently share one `syncScore`. When each side scores the other independently, the schema will grow a `direction` field.
+- **Cross-node federation snapshot** — pulling parties from *other* nodes requires /fleet or /wormhole glue that is not this skill's responsibility. Issue #235 comment thread tracks the federation-snapshot design.
+- **Human-node identity** — the leader appears as `{ human, actingVia }`; mesh can represent the human as a root node, but this skill does not enumerate humans across parties.
+
 ### Aggregation: `--team` Uses Decayed, Not Raw
 
 When `/work-with --team "name"` computes an aggregate sync score, it aggregates over the **decayed** score of each party member, not the raw one:
@@ -1832,6 +1904,7 @@ Trust that's never re-tested becomes superstition. Sync-checks ARE the re-audit.
 
 Schemas shipped with this skill:
 
+- `schema/party.schema.json` — contract for `parties/<slug>.json` (PartyStatus + nested PartyMember, PartyRules, PendingInvite). Consumed by the xyflow CollaborationMesh UI (issue #235). See the Mesh Data Contract section.
 - `schema/sync-history.schema.json` — contract for `sync.history.jsonl`. Consumed by mawui federation_2d and `/fleet` for fading-edge / sparkline rendering. See the Sync Decay section.
 
 ---

--- a/src/skills/work-with/schema/party.schema.json
+++ b/src/skills/work-with/schema/party.schema.json
@@ -1,0 +1,262 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli/src/skills/work-with/schema/party.schema.json",
+  "title": "Party Status",
+  "description": "Contents of ψ/memory/collaborations/parties/<topic-slug>.json. Represents one active /work-with party. Ratified 3/3 on maw-js#332 (mawui/mawjs/skills-cli). Consumed by the xyflow CollaborationMesh UI (maw-ui federation_2d) — see issue #235. Do not modify field names without re-ratification; add new optional fields instead (Nothing is Deleted).",
+  "type": "object",
+  "required": ["topic", "rules", "leader", "members", "pendingInvites", "created", "lastActivity"],
+  "additionalProperties": false,
+  "properties": {
+    "topic": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable topic (also the slug basis for the filename)."
+    },
+    "anchor": {
+      "type": "string",
+      "description": "GitHub anchor issue reference (e.g. 'maw-js#332'). Empty string when no anchor."
+    },
+    "anchorUrl": {
+      "type": "string",
+      "description": "Full URL to the anchor issue. Empty string when no anchor."
+    },
+    "rules": { "$ref": "#/$defs/PartyRules" },
+    "leader": {
+      "type": "object",
+      "description": "Leader is always human (Rule 6). Oracle is never leader.",
+      "required": ["human"],
+      "additionalProperties": false,
+      "properties": {
+        "human": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human who leads this party (e.g. 'Nat')."
+        },
+        "actingVia": {
+          "type": "string",
+          "description": "Which oracle the human is currently working through (e.g. 'skills-cli-oracle')."
+        }
+      }
+    },
+    "members": {
+      "type": "array",
+      "description": "Oracles that have accepted and are currently in the party.",
+      "items": { "$ref": "#/$defs/PartyMember" }
+    },
+    "pendingInvites": {
+      "type": "array",
+      "description": "Invites that have not reached a terminal ACCEPT/REJECT state.",
+      "items": { "$ref": "#/$defs/PendingInvite" }
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO8601 UTC when the party was organized."
+    },
+    "lastActivity": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO8601 UTC of the most recent party activity (invite, sync, tell, ...). Mesh UI uses this to sort + fade dormant parties."
+    },
+    "team": {
+      "type": ["string", "null"],
+      "description": "Optional lightweight team tag. Null or absent when the party is not tied to a declared team. See issue #233 (auto-broadcast tiers)."
+    }
+  },
+  "$defs": {
+    "PartyMember": {
+      "type": "object",
+      "required": ["id", "node", "status", "role", "syncScore", "lastSync", "trust", "joinedAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Oracle id (matches contacts.json key, e.g. 'mawjs')."
+        },
+        "node": {
+          "type": "string",
+          "description": "Fleet node the oracle lives on (e.g. 'oracle-world', 'white')."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["active", "idle", "compacted", "away", "dormant", "hidden", "busy"],
+          "description": "Presence state. See SKILL.md § Presence States. Drives mesh node styling."
+        },
+        "role": {
+          "type": "string",
+          "enum": ["initiator", "member"],
+          "description": "Party role. 'leader' is never valid — leader is human, lives on PartyStatus.leader."
+        },
+        "syncScore": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "RAW score at lastSync (THIS topic only, party-scoped). Decay is applied on read, never stored."
+        },
+        "decayedScore": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "DERIVED on read via decay(syncScore, lastSync, λ). Schema retains the field for compatibility (Nothing is Deleted), but any value here should be treated as informational only — recompute before rendering. See issue #239."
+        },
+        "overallTrust": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Optional rolled-up β trust across all parties with this oracle (see § Trust Model). Fleet-scope; party-scope uses α (the `trust` field)."
+        },
+        "lastSync": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO8601 UTC of last confirmed sync. Drives decay + 'Last' column."
+        },
+        "trust": {
+          "type": "string",
+          "enum": ["high", "medium", "initial", "uncalibrated"],
+          "description": "Party-scoped (α) trust tier. Mesh UI uses this to pick edge style (solid/dashed)."
+        },
+        "joinedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO8601 UTC when the oracle accepted the invite."
+        }
+      }
+    },
+    "PartyRules": {
+      "type": "object",
+      "required": [
+        "sync_cadence",
+        "decay_lambda",
+        "accept_threshold",
+        "kick_threshold",
+        "consensus_mode",
+        "broadcast_scope",
+        "divergence_tolerance",
+        "presence_notifications"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "sync_cadence": {
+          "type": "string",
+          "enum": ["daily", "on-trigger", "manual"],
+          "description": "How often --sync runs."
+        },
+        "decay_lambda": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Party-level λ override. Wins over trust-tier defaults (see SKILL.md § Sync Decay)."
+        },
+        "accept_threshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Below this decayed score = out of sync. Default 0.7."
+        },
+        "kick_threshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Below this decayed score = flagged stale (never auto-kick — human decides). Default 0.3."
+        },
+        "consensus_mode": {
+          "type": "string",
+          "enum": ["all", "majority", "leader-only"],
+          "description": "How party decisions require ratification."
+        },
+        "broadcast_scope": {
+          "type": "string",
+          "enum": ["party", "team", "fleet", "none"],
+          "description": "Default scope for /work-with tell in this party."
+        },
+        "divergence_tolerance": {
+          "type": "string",
+          "enum": ["high", "medium", "low"],
+          "description": "Default 'high' (anti-groupthink). Low scores should not auto-remediate."
+        },
+        "presence_notifications": {
+          "type": "string",
+          "enum": ["off", "summary", "verbose"],
+          "description": "How loudly the party surfaces presence changes."
+        }
+      }
+    },
+    "PendingInvite": {
+      "type": "object",
+      "required": ["target", "invitedAt", "invitedBy", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Oracle id being invited."
+        },
+        "invitedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO8601 UTC when the invite was sent."
+        },
+        "invitedBy": {
+          "type": "string",
+          "description": "Oracle that sent the invite (acting for the human leader)."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "deferred", "accepted", "declined", "expired"],
+          "description": "Will be aligned to CommitPhase vocabulary in a follow-up refactor (see phase3-design.md)."
+        },
+        "deferredUntil": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Required when status='deferred'."
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Optional absolute expiry. Absent = no expiry."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "topic": "party-system-design",
+      "anchor": "maw-js#332",
+      "anchorUrl": "https://github.com/Soul-Brews-Studio/maw-js/issues/332",
+      "rules": {
+        "sync_cadence": "manual",
+        "decay_lambda": 0.01,
+        "accept_threshold": 0.7,
+        "kick_threshold": 0.3,
+        "consensus_mode": "all",
+        "broadcast_scope": "party",
+        "divergence_tolerance": "high",
+        "presence_notifications": "summary"
+      },
+      "leader": { "human": "Nat", "actingVia": "skills-cli-oracle" },
+      "members": [
+        {
+          "id": "mawjs",
+          "node": "oracle-world",
+          "status": "active",
+          "role": "member",
+          "syncScore": 0.88,
+          "lastSync": "2026-04-17T09:00:00Z",
+          "trust": "high",
+          "joinedAt": "2026-04-14T16:15:00Z"
+        }
+      ],
+      "pendingInvites": [
+        {
+          "target": "pulse-oracle",
+          "invitedAt": "2026-04-17T08:48:00Z",
+          "invitedBy": "skills-cli-oracle",
+          "status": "pending"
+        }
+      ],
+      "created": "2026-04-14T16:00:00Z",
+      "lastActivity": "2026-04-17T09:00:00Z",
+      "team": "fleet-core"
+    }
+  ]
+}

--- a/src/skills/work-with/schema/sync-history.schema.json
+++ b/src/skills/work-with/schema/sync-history.schema.json
@@ -40,6 +40,10 @@
     "anchor": {
       "type": "string",
       "description": "Optional — GitHub issue anchor (e.g. 'maw-js#332') when the sync was tied to a specific thread."
+    },
+    "source": {
+      "type": "string",
+      "description": "Optional — id of the oracle that recorded this entry (i.e. the 'from' side of the edge). Writers may omit it because the file path (ψ/memory/collaborations/<partner>/) already implies the partner; a cross-node mesh consumer (issue #235) needs both endpoints when merging multiple oracles' histories, so emit this field in any federated snapshot. Pair (source, partner) defines one directed mesh edge."
     }
   },
   "examples": [


### PR DESCRIPTION
## Summary

The CollaborationMesh UI (`maw-ui` federation_2d, xyflow + deep-ocean theme, owned by mawui-oracle) is a pure consumer of files `/work-with` writes. It had a contract for `sync.history.jsonl` (shipped in #261) but none for `parties/*.json`, and no documented node/edge mapping or update mechanism.

This PR closes the small/obvious gaps on **our** side of the contract. Architectural gaps are left as explicit follow-ups.

## What's in

### Added
- **`schema/party.schema.json`** — JSON Schema for `parties/<slug>.json` (PartyStatus + nested PartyMember, PartyRules, PendingInvite). Mirrors the ratified TypeScript interfaces from maw-js#332 (3/3 consent). Examples validate under Draft 2020-12.
- **SKILL.md § "Mesh Data Contract (for xyflow CollaborationMesh UI — #235)"**:
  - Table of emitted files + schemas + update models
  - Node mapping: party members → xyflow nodes (`id`, `data.node`, `data.status`, `data.trust`, `data.lastSync`; position is UI-side, not emitted)
  - Edge mapping: (party × member) → xyflow edges (`topic`, `anchor`, `syncRaw`, `decayedScore` computed on read, `λ`, `trust`, `role`, `team`)
  - Sparkline source: filter `sync.history.jsonl` by topic, last 7, decay on read
  - Update mechanism: pull-based, 5s poll (same cadence as `/fleet`), mtime is the event bus, no hooks (consistent with [no-hooks-for-workwith](https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli/issues/235) rule)
  - Explicit **"What is NOT emitted"** list tracking architectural follow-ups

### Changed
- **`schema/sync-history.schema.json`** — added optional `source` field so a cross-node mesh consumer can merge multiple oracles' histories and render directed edges. Single-node UIs may ignore it.
- Storage section lists both schemas shipped with this skill.

## Gaps identified, not closed here (need design discussion)

These are deliberately **left out** — documented in the "What is NOT emitted" subsection so mawui can plan around them:

1. **Position hints** — xyflow layout ownership should live in the UI (or its own persisted config), not in `/work-with`.
2. **Directional sync pairs** — `A↔B` currently share one `syncScore`. When each side scores the other independently, the schema grows a `direction` field. Needs ratification with mawjs + mawui.
3. **Cross-node federation snapshot** — pulling parties from *other* nodes is `/fleet` or `/wormhole` territory. Separate design thread on #235.
4. **Human-node identity** — leader appears as `{ human, actingVia }`; enumerating humans across parties isn't this skill's job.

## Non-goals

- No code change. Schemas are documentation + validation; no writer behaviour changes.
- Nothing is Deleted: `decayedScore` stays in the schema for compatibility, but is explicitly documented as derived (recompute before rendering).

## Test plan

- [x] `bun test` — 139 pass, 0 fail (unchanged from main)
- [x] `schema/party.schema.json` validates under `jsonschema.Draft202012Validator`; example validates against schema
- [x] `schema/sync-history.schema.json` validates; both examples validate
- [x] Lefthook pre-commit passed (test + update-table)
- [ ] mawui-oracle review: does the documented contract match what xyflow needs? (posting on #235)
- [ ] Manual: run `/work-with organize` → `/work-with invite` → confirm emitted `parties/*.json` validates against new schema

## Rule 6

**From**: Skills CLI Oracle (The Whetstone)
**Node**: oracle-world
**As**: auditor on team issue-finisher, 2026-04-18
Rule 6: "Oracle Never Pretends to Be Human"
Written by an Oracle — AI speaking as itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)