### PR TITLE
feat(rrr): auto-append session-metrics + recurring-pattern check

### DIFF
--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -98,11 +98,57 @@ Write immediately, no prompts. Include:
 
 **Path**: `$PSI/memory/learnings/YYYY-MM-DD_slug.md`
 
+### 3.5. Append Session-Metrics Row (REQUIRED)
+
+**Path**: `$PSI/memory/learnings/session-metrics.md`
+
+If the file doesn't exist, create with this header:
+
+```markdown
+# Oracle Session Metrics
+
+Rule (parent CLAUDE.md §"Self-Evaluation Loop"): same friction 3 sessions → fix root cause, not another workaround.
+
+| when | session | done | stuck | win | friction |
+|---|---|---|---|---|---|
+```
+
+Then append ONE row:
+
+| Column | Content |
+|---|---|
+| `when` | `YYYY-MM-DD HH:MM` in GMT+7 |
+| `session` | first 8 chars of `SESSION_ID` (from Step 1.5). If detection failed, write `unknown` |
+| `done` | tasks/items completed this session (comma-separated, terse) |
+| `stuck` | items blocked, deferred, or dropped — or `n/a` |
+| `win` | biggest unlock or ship this session (one line) |
+| `friction` | biggest drag, wall, or recurring pain (one line) |
+
+**Rule**: never skip. Trivial session? Still append with `trivial` in win/friction. Gaps break the pattern-detection value of the file.
+
 ### 4. Oracle Sync
 
 ```
 arra_learn({ pattern: [lesson content], concepts: [tags], source: "rrr: REPO" })
 ```
+
+### 4.5. Pattern Check (last 7 rows)
+
+Read the last 7 rows (or all rows if fewer) of `$PSI/memory/learnings/session-metrics.md`.
+
+Count keyword themes in the `friction` column. If any theme appears **≥3 times** in the window, append this section to the retrospective:
+
+```markdown
+## 🔁 Recurring Pattern Detected
+
+"<theme>" appeared in <N> of last 7 sessions (<session IDs>). Per parent CLAUDE.md §"Self-Evaluation Loop" — consider root-cause fix instead of another workaround.
+
+Suggested: open issue `root-cause: <theme>` or raise with Boss during next standup.
+```
+
+If no theme reaches ≥3 → skip this section silently.
+
+**Rule**: surface only. Do NOT auto-open issues or take action beyond flagging. Principle 3 (External Brain, Not Command) — Boss decides.
 
 ### 5. Save
 


### PR DESCRIPTION
## Summary

Adds two required steps to \`/rrr\` default flow (inherited by \`--detail\` and \`--dig\`):

- **3.5** — Auto-append a 6-column row to \`\$PSI/memory/learnings/session-metrics.md\` (create with header if missing). Columns: when / session / done / stuck / win / friction. Never skip; trivial sessions still append with \`trivial\`.
- **4.5** — Read last 7 rows, count friction themes. If any theme ≥3 → flag under \`🔁 Recurring Pattern Detected\` with suggested root-cause action. Surface-only, no auto-issue (Principle 3: External Brain, Not Command).

## Why

Parent CLAUDE.md §"Self-Evaluation Loop" already mandates this append, but enforcement was honor-system. Evidence: 14-day gap in Neo's repo — \`session-metrics.md\` didn't exist despite daily retros. Rule-without-habit fails silently. Moving the habit into the skill itself makes it happen by default.

## Patch origin & territory

Drafted by **Neo Oracle** (\`neo-oracle/ψ/writing/2026-04-20_rrr-skill-patch-proposal.md\`), reviewed + applied by **Labubu** (owner of this repo). Neo did not commit directly — showed good cross-oracle territory discipline.

## Test plan

- [ ] Apply locally, run \`/rrr\` in Labubu repo → verify first row appended
- [ ] Seed 3 rows with same friction keyword → run \`/rrr\` → verify "Recurring Pattern Detected" section appears
- [ ] Remove one keyword row → run \`/rrr\` → verify section disappears

## Rollback

Purely additive. Delete steps 3.5 and 4.5 to revert. No data migration needed — the metrics file is harmless if orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)