### PR TITLE
fix(incubate): auto-stash source clone before ghq pull (#279)

### DIFF
--- a/src/skills/incubate/SKILL.md
+++ b/src/skills/incubate/SKILL.md
@@ -103,6 +103,20 @@ OWNER=$(echo "$URL" | sed -E 's|.*github.com/([^/]+)/.*|\1|')
 REPO=$(echo "$URL" | sed -E 's|.*/([^/]+)(\.git)?$|\1|')
 SLUG="$OWNER/$REPO"
 
+# Auto-stash unstaged changes in source clone before pulling (#279).
+# `ghq get -u` runs `git pull` under the hood and aborts on dirty trees,
+# stranding the ritual. Detect + stash with a clear log + restore hint.
+GHQ_ROOT_PRECHECK=$(ghq root 2>/dev/null)
+SOURCE_PRECHECK="$GHQ_ROOT_PRECHECK/github.com/$SLUG"
+if [ -d "$SOURCE_PRECHECK/.git" ]; then
+  if [ -n "$(git -C "$SOURCE_PRECHECK" status --porcelain 2>/dev/null)" ]; then
+    STASH_NAME="pre-incubate-$(date +%Y-%m-%d)"
+    echo "⚠️  Source clone has uncommitted changes — auto-stashing as '$STASH_NAME'"
+    git -C "$SOURCE_PRECHECK" stash push -u -m "$STASH_NAME"
+    echo "    (run \`git -C $SOURCE_PRECHECK stash pop\` to restore)"
+  fi
+fi
+
 # Check if repo exists on GitHub
 if gh repo view "$SLUG" --json name &>/dev/null; then
   ghq get -u "https://github.com/$SLUG"


### PR DESCRIPTION
## Summary

Closes #279. Adds auto-stash logic before \`ghq get -u\` in the \`/incubate\` skill so a dirty source clone no longer strands the ritual.

## What changes

\`src/skills/incubate/SKILL.md\` — adds 12 lines of bash before the existing \`ghq get -u\` call:

\`\`\`bash
# Detect dirty tree
GHQ_ROOT_PRECHECK=\$(ghq root 2>/dev/null)
SOURCE_PRECHECK="\$GHQ_ROOT_PRECHECK/github.com/\$SLUG"
if [ -d "\$SOURCE_PRECHECK/.git" ]; then
  if [ -n "\$(git -C "\$SOURCE_PRECHECK" status --porcelain 2>/dev/null)" ]; then
    STASH_NAME="pre-incubate-\$(date +%Y-%m-%d)"
    echo "⚠️  Source clone has uncommitted changes — auto-stashing as '\$STASH_NAME'"
    git -C "\$SOURCE_PRECHECK" stash push -u -m "\$STASH_NAME"
    echo "    (run \\\`git -C \$SOURCE_PRECHECK stash pop\\\` to restore)"
  fi
fi
\`\`\`

## Why

Encountered live during today's real e2e on \`Soul-Brews-Studio/arra-oracle-skills-cli\`:

\`\`\`
[02:14] maw incubate Soul-Brews-Studio/arra-oracle-skills-cli
[02:14] /incubate skill: ghq get -u → fails (CLAUDE.md modified)
[02:15] spawned /team-agents help-team
[02:16] investigator: git stash push -u -m 'pre-incubate-2026-05-08'
        watcher: confirmed ritual completed
\`\`\`

90 seconds of manual unblock that the skill should automate.

## Behavior

- Clean tree → no-op (existing behavior)
- Dirty tree → auto-stash + log warning + clear restore hint
- Source not yet cloned → pre-check is a no-op (the \`-d .git\` guard)

User keeps their work (Principle 1: Nothing is Deleted) — stash is restorable via the printed command.

## Test plan

Documentation/skill change. Manual verify post-merge:
- [ ] \`maw incubate <repo>\` on a clone with uncommitted edits → ritual completes, stash created, warning printed
- [ ] \`maw incubate <repo>\` on a clean clone → no stash, no extra output

🤖 Generated with [Claude Code](https://claude.com/claude-code)