### PR TITLE
feat(incubate): --status --include-offloaded + --offload --purge (#280)

### DIFF
--- a/src/skills/incubate/SKILL.md
+++ b/src/skills/incubate/SKILL.md
@@ -18,8 +18,10 @@ Clone or create repos for active development → set up branches, make changes, 
 /incubate [repo-name]                    # Finds in ghq or creates with default org
 /incubate [url] --flash "fix desc"       # Issue → branch → fix → PR → offload
 /incubate [url] --contribute             # Fork if needed → branch per feature → PRs
-/incubate --status                       # List all ψ/incubate/ with git status
+/incubate --status                       # List all active ψ/incubate/ with git status
+/incubate --status --include-offloaded   # Also list offloaded entries from .origins (#280)
 /incubate --offload [slug]               # Remove symlink, keep ghq clone
+/incubate --offload [slug] --purge       # Also drop entry from .origins manifest (#280)
 /incubate --init                         # Restore all origins after git clone
 ```
 
@@ -357,13 +359,21 @@ echo "✓ Offloaded (ghq kept for PR feedback)"
 
 No clone needed. List all active incubations with git status.
 
+Add `--include-offloaded` to also list entries in `.origins` whose symlinks
+have been removed (#280) — surfaces the historical record without losing it.
+
 ```bash
 ROOT="$(pwd)"
+INCLUDE_OFFLOADED="${1:-}"   # pass "--include-offloaded" to enable
 echo "🌱 Active Incubations"
 echo ""
+
+# Collect active slugs (those with live symlinks)
+declare -A ACTIVE_SLUGS=()
 for link in $(find "$ROOT/ψ/incubate" -name "origin" -type l 2>/dev/null); do
   REPO_DIR=$(dirname "$link")
   SLUG=$(echo "$REPO_DIR" | sed "s|$ROOT/ψ/incubate/||")
+  ACTIVE_SLUGS["$SLUG"]=1
   TARGET=$(readlink "$link")
   if [ -d "$TARGET" ]; then
     BRANCH=$(git -C "$TARGET" branch --show-current 2>/dev/null)
@@ -377,8 +387,39 @@ for link in $(find "$ROOT/ψ/incubate" -name "origin" -type l 2>/dev/null); do
   echo ""
 done
 
-COUNT=$(find "$ROOT/ψ/incubate" -name "origin" -type l 2>/dev/null | wc -l)
-echo "Total: $COUNT active incubation(s)"
+ACTIVE_COUNT=${#ACTIVE_SLUGS[@]}
+
+# --include-offloaded: also list .origins entries with no live symlink (#280)
+if [ "$INCLUDE_OFFLOADED" = "--include-offloaded" ] && [ -f "$ROOT/ψ/incubate/.origins" ]; then
+  echo ""
+  echo "📦 Offloaded (in .origins, no live symlink)"
+  echo ""
+  OFFLOADED_COUNT=0
+  while IFS= read -r slug; do
+    [ -z "$slug" ] && continue
+    if [ -z "${ACTIVE_SLUGS[$slug]:-}" ]; then
+      GHQ_ROOT=$(ghq root 2>/dev/null)
+      GHQ_PATH="$GHQ_ROOT/github.com/$slug"
+      if [ -d "$GHQ_PATH" ]; then
+        echo "  $slug (ghq preserved at $GHQ_PATH)"
+      else
+        echo "  $slug (ghq absent — fully purged)"
+      fi
+      OFFLOADED_COUNT=$((OFFLOADED_COUNT + 1))
+    fi
+  done < "$ROOT/ψ/incubate/.origins"
+  echo ""
+  echo "Active: $ACTIVE_COUNT | Offloaded: $OFFLOADED_COUNT"
+else
+  echo "Total: $ACTIVE_COUNT active incubation(s)"
+  if [ -f "$ROOT/ψ/incubate/.origins" ]; then
+    TOTAL_RECORDED=$(grep -cv '^$' "$ROOT/ψ/incubate/.origins" 2>/dev/null || echo 0)
+    OFFLOADED_HIDDEN=$((TOTAL_RECORDED - ACTIVE_COUNT))
+    if [ "$OFFLOADED_HIDDEN" -gt 0 ]; then
+      echo "  ($OFFLOADED_HIDDEN offloaded — use --include-offloaded to view)"
+    fi
+  fi
+fi
 ```
 
 **Done.** No hub file update needed.
@@ -389,9 +430,13 @@ echo "Total: $COUNT active incubation(s)"
 
 Remove symlink, keep ghq clone and hub file.
 
+Add `--purge` to also remove the entry from `.origins` manifest (#280) —
+useful when you want the offloaded slug to NOT count toward "Total" any more.
+
 ```bash
 ROOT="$(pwd)"
 SLUG="[OWNER/REPO or REPO]"
+PURGE="${1:-}"   # pass "--purge" to also remove from .origins
 
 # Find the symlink
 LINK=$(find "$ROOT/ψ/incubate" -name "origin" -type l | xargs -I{} dirname {} | grep -i "$SLUG" | head -1)
@@ -407,9 +452,19 @@ unlink "$LINK/origin"
 OWNER_DIR=$(dirname "$LINK")
 rmdir "$OWNER_DIR" 2>/dev/null
 
-echo "✓ Offloaded: $(echo $LINK | sed "s|$ROOT/ψ/incubate/||")"
+DEFLATED_SLUG=$(echo $LINK | sed "s|$ROOT/ψ/incubate/||")
+echo "✓ Offloaded: $DEFLATED_SLUG"
 echo "  Hub file remains: $LINK/$REPO_NAME.md"
 echo "  ghq clone preserved for future use"
+
+# --purge: remove from .origins manifest (#280)
+if [ "$PURGE" = "--purge" ] && [ -f "$ROOT/ψ/incubate/.origins" ]; then
+  TMPFILE=$(mktemp)
+  grep -v "^${DEFLATED_SLUG}$" "$ROOT/ψ/incubate/.origins" > "$TMPFILE" || true
+  mv "$TMPFILE" "$ROOT/ψ/incubate/.origins"
+  echo "  ✂ Purged '$DEFLATED_SLUG' from .origins manifest"
+  echo "  ⚠ This breadcrumb is gone — re-incubate to restore it (Principle 1: prefer --include-offloaded over --purge)"
+fi
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes #280. Adds two new flags to the \`/incubate\` skill that surface and manage \`.origins\` manifest history without violating Principle 1 by default.

## What changes

### \`--status --include-offloaded\` (new)

Plain \`--status\` only lists active symlinks. The new flag also reads \`.origins\`, finds entries with no live symlink, and shows them in a separate "Offloaded" section. Cross-checks ghq to label each:
- \`(ghq preserved at <path>)\` — clone still exists, can re-incubate
- \`(ghq absent — fully purged)\` — even the clone is gone

Plain \`--status\` (without the flag) gains a hint count:
\`\`\`
Total: 5 active incubation(s)
  (3 offloaded — use --include-offloaded to view)
\`\`\`

### \`--offload <slug> --purge\` (new)

Adds an opt-in flag to remove the slug from \`.origins\` in addition to unlinking the symlink. Includes a Principle 1 warning encouraging \`--include-offloaded\` over \`--purge\`:

\`\`\`
✓ Offloaded: octocat/Hello-World
  Hub file remains: ψ/incubate/octocat/Hello-World/Hello-World.md
  ghq clone preserved for future use
  ✂ Purged 'octocat/Hello-World' from .origins manifest
  ⚠ This breadcrumb is gone — re-incubate to restore it
    (Principle 1: prefer --include-offloaded over --purge)
\`\`\`

## Why

After several incubation cycles, \`.origins\` accumulates entries that no longer have live symlinks. Today (e2e on arra-oracle-skills-cli) we saw octocat/Hello-World remained in the manifest after offload. There was no way to:
- Query "active vs offloaded" distinction
- Clean the manifest without manually editing the file

\`--include-offloaded\` is the read-only, Principle-1-friendly answer. \`--purge\` is for users who explicitly want the manifest trimmed.

## Backward compatibility

- Plain \`--status\`: unchanged + new hint line about offloaded count
- Plain \`--offload\`: unchanged (symlink unlinked, \`.origins\` kept — historical record preserved by default)

## Test plan

Manual verification post-merge:
- [ ] \`/incubate --status\` shows active list + offloaded hint count
- [ ] \`/incubate --status --include-offloaded\` shows both sections
- [ ] \`/incubate --offload <slug>\` (no purge) keeps \`.origins\` intact
- [ ] \`/incubate --offload <slug> --purge\` removes line from \`.origins\` and prints warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)