### PR TITLE
feat(profiles): MINIMAL_ONLY_SKILLS classification (#285 part 1)

### DIFF
--- a/__tests__/e2e-features.test.ts
+++ b/__tests__/e2e-features.test.ts
@@ -5,7 +5,7 @@ import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { agents } from "../src/cli/agents";
 import { installSkills, discoverSkills } from "../src/cli/installer";
-import { profiles, labOnly, resolveProfile } from "../src/profiles";
+import { profiles, labOnly, minimalOnly, resolveProfile } from "../src/profiles";
 import type { AgentConfig } from "../src/cli/types";
 
 const TEST_DIR = join(tmpdir(), `arra-oracle-skills-profile-${Date.now()}`);
@@ -68,7 +68,7 @@ describe("e2e: install with standard profile", () => {
 describe("e2e: install with full profile", () => {
   beforeEach(cleanup);
 
-  it("full installs all stable skills (excludes lab-only)", async () => {
+  it("full installs all stable skills (excludes lab-only and minimal-only)", async () => {
     const allSkills = await discoverSkills();
     await installSkills([TEST_AGENT], {
       global: true,
@@ -78,9 +78,14 @@ describe("e2e: install with full profile", () => {
 
     const installed = await listSkillDirs(SKILLS_DIR);
     const excludedCount = allSkills.filter(s => s.secret || s.zombie).length;
-    const expectedCount = allSkills.length - labOnly.filter(s => allSkills.some(sk => sk.name === s)).length - excludedCount;
+    const labCount = labOnly.filter(s => allSkills.some(sk => sk.name === s)).length;
+    const minimalOnlyCount = minimalOnly.filter(s => allSkills.some(sk => sk.name === s)).length;
+    const expectedCount = allSkills.length - labCount - minimalOnlyCount - excludedCount;
     expect(installed.length).toBe(expectedCount);
     for (const name of labOnly) {
+      expect(installed).not.toContain(name);
+    }
+    for (const name of minimalOnly) {
       expect(installed).not.toContain(name);
     }
   });
@@ -89,7 +94,7 @@ describe("e2e: install with full profile", () => {
 describe("e2e: install with lab profile", () => {
   beforeEach(cleanup);
 
-  it("lab installs all skills (excludes secrets + zombies)", async () => {
+  it("lab installs all skills (excludes secrets + zombies + minimal-only)", async () => {
     const allSkills = await discoverSkills();
     await installSkills([TEST_AGENT], {
       global: true,
@@ -99,7 +104,11 @@ describe("e2e: install with lab profile", () => {
 
     const installed = await listSkillDirs(SKILLS_DIR);
     const excludedCount = allSkills.filter(s => s.secret || s.zombie).length;
-    expect(installed.length).toBe(allSkills.length - excludedCount);
+    const minimalOnlyCount = minimalOnly.filter(s => allSkills.some(sk => sk.name === s)).length;
+    expect(installed.length).toBe(allSkills.length - excludedCount - minimalOnlyCount);
+    for (const name of minimalOnly) {
+      expect(installed).not.toContain(name);
+    }
   });
 });
 
@@ -119,7 +128,9 @@ describe("e2e: profile switch (full → standard) is additive", () => {
     const allSkills = await discoverSkills();
     let installed = await listSkillDirs(SKILLS_DIR);
     const excludedCount = allSkills.filter(s => s.secret || s.zombie).length;
-    const fullCount = allSkills.length - labOnly.filter(s => allSkills.some(sk => sk.name === s)).length - excludedCount;
+    const labCount = labOnly.filter(s => allSkills.some(sk => sk.name === s)).length;
+    const minimalOnlyCount = minimalOnly.filter(s => allSkills.some(sk => sk.name === s)).length;
+    const fullCount = allSkills.length - labCount - minimalOnlyCount - excludedCount;
     expect(installed.length).toBe(fullCount);
 
     await installSkills([TEST_AGENT], {

--- a/__tests__/e2e-install.test.ts
+++ b/__tests__/e2e-install.test.ts
@@ -5,7 +5,7 @@ import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
-import { profiles, labOnly } from "../src/profiles";
+import { profiles, labOnly, minimalOnly } from "../src/profiles";
 import type { AgentConfig } from "../src/cli/types";
 
 const TEST_DIR = join(tmpdir(), `arra-oracle-skills-e2e-${Date.now()}`);
@@ -147,14 +147,14 @@ describe("e2e: install full profile", () => {
     });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !s.secret && !s.zombie);
+    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !minimalOnly.includes(s.name) && !s.secret && !s.zombie);
     expect(installed.length).toBe(fullSkills.length);
   });
 
   it("every full-profile skill has a directory", async () => {
     const allSkills = await discoverSkills();
     const installed = await listSkillDirs(SKILLS_DIR);
-    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !s.secret && !s.zombie);
+    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !minimalOnly.includes(s.name) && !s.secret && !s.zombie);
 
     for (const skill of fullSkills) {
       expect(installed).toContain(skill.name);
@@ -254,7 +254,7 @@ describe("e2e: profile switch (full → standard) is additive", () => {
     });
 
     const allSkills = await discoverSkills();
-    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !s.secret && !s.zombie);
+    const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !minimalOnly.includes(s.name) && !s.secret && !s.zombie);
     let skills = await listSkillDirs(SKILLS_DIR);
     expect(skills.length).toBe(fullSkills.length);
 

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from "bun:test";
-import { profiles, labOnly, MINIMAL_SKILLS, STANDARD_SKILLS, LAB_SKILLS, ZOMBIE_SKILLS, resolveProfile } from "../src/profiles";
+import { profiles, labOnly, minimalOnly, MINIMAL_SKILLS, STANDARD_SKILLS, LAB_SKILLS, MINIMAL_ONLY_SKILLS, ZOMBIE_SKILLS, resolveProfile } from "../src/profiles";
 
-// Simulated full skill list — must include all standard + lab + zombie + other discovered skills
+// Simulated full skill list — must include all standard + lab + zombie + minimal-only + other discovered skills
 const ALL_SKILLS = [
   ...STANDARD_SKILLS,
   ...LAB_SKILLS,
   ...ZOMBIE_SKILLS,
-  // Full/other skills (not standard, not lab-only)
+  ...MINIMAL_ONLY_SKILLS,
+  // Full/other skills (not standard, not lab-only, not minimal-only)
   "about-oracle", "auto-retrospective", "create-shortcut", "incubate",
   "oracle-family-scan", "oracle-soul-sync-update", "philosophy", "project",
   "resonance", "skills-list", "standup", "where-we-are", "who-are-you",
@@ -29,13 +30,13 @@ describe("profiles", () => {
     expect(profiles.standard.include).toHaveLength(13);
   });
 
-  it("full excludes lab-only skills", () => {
-    expect(profiles.full.exclude).toEqual(labOnly);
+  it("full excludes lab-only AND minimal-only skills (post-#285)", () => {
+    expect(profiles.full.exclude).toEqual([...labOnly, ...minimalOnly]);
   });
 
-  it("lab has no include or exclude (means all)", () => {
+  it("lab has no include list but excludes minimal-only skills (post-#285)", () => {
     expect(profiles.lab.include).toBeUndefined();
-    expect(profiles.lab.exclude).toBeUndefined();
+    expect(profiles.lab.exclude).toEqual(minimalOnly);
   });
 
   it("standard includes dig", () => {
@@ -78,6 +79,39 @@ describe("profiles", () => {
       expect(labSet.has(skill)).toBe(false);
     }
   });
+
+  // #285: MINIMAL_ONLY classification — lite skills excluded from full + lab
+  it("MINIMAL_ONLY_SKILLS has 3 lite variants", () => {
+    expect(MINIMAL_ONLY_SKILLS).toHaveLength(3);
+    expect(MINIMAL_ONLY_SKILLS).toContain("forward-lite");
+    expect(MINIMAL_ONLY_SKILLS).toContain("recap-lite");
+    expect(MINIMAL_ONLY_SKILLS).toContain("rrr-lite");
+  });
+
+  it("minimalOnly alias matches MINIMAL_ONLY_SKILLS", () => {
+    expect(minimalOnly).toEqual([...MINIMAL_ONLY_SKILLS]);
+  });
+
+  it("minimal profile still includes all 3 lite skills (regression guard)", () => {
+    for (const skill of MINIMAL_ONLY_SKILLS) {
+      expect(MINIMAL_SKILLS).toContain(skill);
+    }
+  });
+
+  it("full profile excludes both lab and minimal-only skills", () => {
+    expect(profiles.full.exclude).toEqual([...labOnly, ...minimalOnly]);
+  });
+
+  it("lab profile excludes minimal-only skills", () => {
+    expect(profiles.lab.exclude).toEqual(minimalOnly);
+  });
+
+  it("no overlap between STANDARD_SKILLS and MINIMAL_ONLY_SKILLS", () => {
+    const standardSet = new Set(STANDARD_SKILLS);
+    for (const skill of MINIMAL_ONLY_SKILLS) {
+      expect(standardSet.has(skill as any)).toBe(false);
+    }
+  });
 });
 
 describe("resolveProfile", () => {
@@ -91,11 +125,14 @@ describe("resolveProfile", () => {
     expect(result).toHaveLength(13);
   });
 
-  it("full returns all minus lab-only and zombies", () => {
+  it("full returns all minus lab-only, minimal-only, and zombies", () => {
     const result = resolveProfile("full", ALL_SKILLS, [], ZOMBIE_LIST)!;
     expect(result).not.toBeNull();
-    expect(result.length).toBe(ALL_SKILLS.length - labOnly.length - ZOMBIE_LIST.length);
+    expect(result.length).toBe(ALL_SKILLS.length - labOnly.length - minimalOnly.length - ZOMBIE_LIST.length);
     for (const name of labOnly) {
+      expect(result).not.toContain(name);
+    }
+    for (const name of minimalOnly) {
       expect(result).not.toContain(name);
     }
     for (const name of ZOMBIE_LIST) {
@@ -111,9 +148,15 @@ describe("resolveProfile", () => {
     }
   });
 
-  it("lab returns null when no exclusions", () => {
-    const result = resolveProfile("lab", ALL_SKILLS);
-    expect(result).toBeNull();
+  it("lab returns all minus minimal-only skills, even with no secrets/zombies (#285)", () => {
+    // Pre-#285: lab profile was {}, returned null for "all skills". Post-#285: lab
+    // excludes minimalOnly so a filtered list is always returned, never null.
+    const result = resolveProfile("lab", ALL_SKILLS)!;
+    expect(result).not.toBeNull();
+    expect(result.length).toBe(ALL_SKILLS.length - minimalOnly.length);
+    for (const name of minimalOnly) {
+      expect(result).not.toContain(name);
+    }
   });
 
   it("unknown profile returns null", () => {
@@ -144,6 +187,30 @@ describe("resolveProfile", () => {
       expect(standard).not.toContain(name);
       expect(full).not.toContain(name);
       expect(lab).not.toContain(name);
+    }
+  });
+
+  // #285: lite skills must NOT appear in full or lab resolutions
+  it("full does NOT include any minimal-only lite skills", () => {
+    const result = resolveProfile("full", ALL_SKILLS, [], ZOMBIE_LIST)!;
+    expect(result).not.toBeNull();
+    for (const lite of MINIMAL_ONLY_SKILLS) {
+      expect(result).not.toContain(lite);
+    }
+  });
+
+  it("lab does NOT include any minimal-only lite skills", () => {
+    const result = resolveProfile("lab", ALL_SKILLS, [], ZOMBIE_LIST)!;
+    expect(result).not.toBeNull();
+    for (const lite of MINIMAL_ONLY_SKILLS) {
+      expect(result).not.toContain(lite);
+    }
+  });
+
+  it("minimal STILL includes all 3 lite skills (regression guard for resolveProfile)", () => {
+    const result = resolveProfile("minimal", ALL_SKILLS)!;
+    for (const lite of MINIMAL_ONLY_SKILLS) {
+      expect(result).toContain(lite);
     }
   });
 });

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -2,14 +2,18 @@
  * Skill profiles — 3 tiers, single source of truth.
  *
  * minimal: newcomer essentials — 7 skills (lifecycle + trace + update + upgrade)
- * standard: daily driver (default) — 13 essential skills (data-driven, session 8+9)
- * full: all stable skills (excludes lab-only experiments)
- * lab: everything including experimental / bleeding edge
+ * standard: daily driver — 13 essential skills (data-driven, session 8+9)
+ * full: all stable skills (excludes lab-only experiments AND minimal-only lite variants)
+ * lab: everything including experimental / bleeding edge (still excludes minimal-only lite variants)
  *
  * Profile audit: 120 sessions mined (2026-04-15). Skills earning standard
  * must have 10+ session appearances. Demoted: about-oracle (5), create-shortcut (6),
  * oracle-soul-sync-update (6), standup (10), skills-list (3), oracle-family-scan (8).
  * These move to full (still installable, not lab-gated).
+ *
+ * MINIMAL_ONLY classification (#285): forward-lite, recap-lite, rrr-lite are token-
+ * optimized replacements for full versions. They have value in minimal only —
+ * elsewhere they duplicate functionality of forward/recap/rrr. Excluded from full+lab.
  */
 
 /** Minimal profile — lite lifecycle + trace + update + upgrade (token-optimized) */
@@ -30,6 +34,14 @@ export const LAB_SKILLS = [
   'release', 'schedule', 'vault', 'warp', 'watch', 'work-with', 'worktree', 'wormhole',
 ] as const;
 
+/** Minimal-only skills — token-optimized lite variants that replace the full
+ *  version when in `minimal` profile. They have no value outside minimal because
+ *  the full versions (`forward`, `recap`, `rrr`) are present in higher tiers.
+ *  Excluded from `full` and `lab` profiles. Closes #285. */
+export const MINIMAL_ONLY_SKILLS = [
+  'forward-lite', 'recap-lite', 'rrr-lite',
+] as const;
+
 /** Zombie skills — internal development candidates from arra-symbiosis-skills.
  *  Excluded from ALL profiles. Install by name only: `arra install -s workon`
  *  These are dormant — available for development, not for users. */
@@ -41,6 +53,7 @@ export const ZOMBIE_SKILLS = [
 
 // Backwards-compatible aliases
 export const labOnly = [...LAB_SKILLS] as string[];
+export const minimalOnly = [...MINIMAL_ONLY_SKILLS] as string[];
 
 export const profiles: Record<string, { include?: string[]; exclude?: string[] }> = {
   minimal: {
@@ -50,9 +63,11 @@ export const profiles: Record<string, { include?: string[]; exclude?: string[] }
     include: [...STANDARD_SKILLS],
   },
   full: {
-    exclude: labOnly,  // all skills except lab-only experiments
+    exclude: [...labOnly, ...minimalOnly],  // all skills except lab-only + minimal-only lite variants
   },
-  lab: {},             // everything — all discovered skills
+  lab: {
+    exclude: minimalOnly,                    // everything except minimal-only lite variants (full versions present)
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Part 1 of #285 — adds the `MINIMAL_ONLY_SKILLS` classification.

The lite trio (`forward-lite`, `recap-lite`, `rrr-lite`) are token-optimized replacements for `forward`/`recap`/`rrr`. They have value in `minimal` only — elsewhere they duplicate functionality of skills already present.

Mirrors the existing `LAB_SKILLS` pattern.

## Effect

| Profile | Before | After |
|---------|--------|-------|
| `minimal` | 7 skills (incl. 3 lite) | unchanged — 7 skills (incl. 3 lite) |
| `standard` | 13 skills (no lite) | unchanged — 13 skills (no lite) |
| `full` | all except `LAB_SKILLS` (**incl. lite**) | all except `LAB_SKILLS` + `MINIMAL_ONLY_SKILLS` (**no lite**) |
| `lab` | everything (**incl. lite**) | everything except `MINIMAL_ONLY_SKILLS` (**no lite**) |

So `/go full` and `/go lab` no longer install lite skills. `/go minimal` unchanged.

## What this does NOT do

This is Part 1 of #285 — **classification only**. Part 2 will add the alignment semantic (removing already-installed lite skills when switching profiles via explicit `--profile <name>`) in a separate PR.

So this PR alone:
- ✅ Future `/go full` installs without lite skills
- ❌ Does NOT remove lite skills if you currently have them installed — that needs Part 2

Bare `install` (no flag) is unchanged — still purely additive (#257 / Bug 5 protection preserved).

## Changes

```
src/profiles.ts                +20 -5
__tests__/profiles.test.ts     +79 -12
```

### profiles.ts

- New `MINIMAL_ONLY_SKILLS` const (3 skills)
- New `minimalOnly` alias (mirror of `labOnly`)
- `full.exclude` extended to include minimal-only
- `lab.exclude` set to minimal-only (was `{}`)
- Header comment updated

### profiles.test.ts

**New assertions (9):**
- `MINIMAL_ONLY_SKILLS has 3 lite variants`
- `minimalOnly alias matches MINIMAL_ONLY_SKILLS`
- `minimal profile still includes all 3 lite skills (regression guard)`
- `full profile excludes both lab and minimal-only skills`
- `lab profile excludes minimal-only skills`
- `no overlap between STANDARD_SKILLS and MINIMAL_ONLY_SKILLS`
- `full does NOT include any minimal-only lite skills` (via `resolveProfile`)
- `lab does NOT include any minimal-only lite skills` (via `resolveProfile`)
- `minimal STILL includes all 3 lite skills` (regression via `resolveProfile`)

**Updated assertions (3):**
- `full excludes lab-only AND minimal-only skills (post-#285)`
- `lab has no include list but excludes minimal-only skills (post-#285)`
- `lab returns all minus minimal-only skills, even with no secrets/zombies (#285)`

## Test results

```
profiles.test.ts: 31 pass, 0 fail (was 22 pass before)
full suite delta vs main: +9 pass, 0 new fail
```

(23 pre-existing failures in `installer.test.ts` / `install-uninstall.test.ts` are unaffected — environmental ENOENTs unrelated to profile changes.)

## Manual verification

```bash
bun -e 'import { resolveProfile, MINIMAL_ONLY_SKILLS } from "./src/profiles.ts"; const all = ["forward","forward-lite","recap","recap-lite","rrr","rrr-lite","dig","release"]; console.log("full:", resolveProfile("full", all)); console.log("lab:", resolveProfile("lab", all)); console.log("minimal:", resolveProfile("minimal", ["about-oracle","forward-lite","go","oracle-soul-sync-update","recap-lite","rrr-lite","trace"]));'
```

## Relationship to other work

- **Closes**: Part 1 of #285
- **Builds on**: #257 (additive install) — preserved exactly
- **Adjacent**: #267 (alignment + default-flip) — orthogonal, this PR doesn't take a position on default
- **Next**: Part 2 of #285 (alignment semantic in installer.ts) as a follow-up PR

## Coordination

@neo-oracle — you filed #267 with the alignment proposal. This PR doesn't implement alignment yet, but it adds the missing classification piece your proposal didn't include. Comments welcome.

---

🤖 ตอบโดย arra-oracle-skills-cli จาก [Nat] → arra-oracle-skills-cli-oracle