### PR TITLE
fix(ci): fire CI + CalVer release workflows on alpha branch too

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -2,10 +2,13 @@ name: CalVer Release
 
 # Unified tag + release + npm publish pipeline for CalVer versions.
 #
-# Triggered when package.json is modified on main. All steps run in ONE job
-# so there is no workflow-cascade gap (GITHUB_TOKEN-created tags/releases
+# Triggered when package.json is modified on main OR alpha. All steps run in
+# ONE job so there is no workflow-cascade gap (GITHUB_TOKEN-created tags/releases
 # deliberately don't trigger downstream workflows; doing it inline sidesteps
 # that rule entirely).
+#
+# alpha is the soak channel — bumps land there first, then alpha → main for
+# stable. Matches the maw-js canonical (#287 surfaced the parity gap).
 #
 # Secret required: NPM_TOKEN
 # Everything else uses the repo's built-in GITHUB_TOKEN with write perms.
@@ -14,7 +17,7 @@ name: CalVer Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, alpha]
     paths:
       - package.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, alpha]
   pull_request:
-    branches: [main]
+    branches: [main, alpha]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Both `ci.yml` and `calver-release.yml` previously only triggered on `main`, leaving `alpha` as dead infrastructure. PR #287 (release attempt to alpha, now closed) surfaced this gap.

This PR brings parity with the maw-js canonical workflow config:

```diff
# ci.yml
- push: { branches: [main] }
- pull_request: { branches: [main] }
+ push: { branches: [main, alpha] }
+ pull_request: { branches: [main, alpha] }

# calver-release.yml
- push: { branches: [main], paths: [package.json] }
+ push: { branches: [main, alpha], paths: [package.json] }
```

## Effect after merge

- PRs targeting `alpha` will get CI test runs (was: skipped)
- Pushes to `alpha` that touch `package.json` will trigger tag + GitHub release (was: silent)
- `alpha` becomes a real soak channel — matches the `/release-alpha` skill's contract

## Out of scope

The fact that `alpha` branch is currently **178 commits behind main** (stuck at v3.3.1 era) is a separate problem. Resolving it requires a non-destructive strategy (no force-push / no destructive rebase / no painful merge) — to be decided later by maintainer.

## Refs

- Surfaces from: PR #287 (closed — workflows wouldn't have fired even on clean merge)
- Canonical reference: `maw-js/.github/workflows/calver-release.yml`

---

🤖 ตอบโดย arra-oracle-skills-cli จาก [Nat] → arra-oracle-skills-cli-oracle