### PR TITLE
feat(#284): port /calver skill + sync script to maw-js canonical

### DIFF
--- a/__tests__/calver.test.ts
+++ b/__tests__/calver.test.ts
@@ -1,40 +1,348 @@
 import { describe, it, expect } from "bun:test";
-import { computeVersion } from "../scripts/calver";
+import {
+  compareBases,
+  computeVersion,
+  dateBase,
+  effectiveBase,
+  extractBaseFromVersion,
+  hhmmStamp,
+  isValidCalendarDate,
+  maxAlphaFromTags,
+  maxNFromPackageJson,
+  maxNFromTags,
+} from "../scripts/calver";
 
-describe("calver computeVersion", () => {
-  const apr18_0937 = new Date(2026, 3, 18, 9, 37);      // local time
-  const apr18_2255 = new Date(2026, 3, 18, 22, 55);
+describe("calver dateBase", () => {
+  it("yy.m.d with no zero-pad (semver safety)", () => {
+    expect(dateBase(new Date(2026, 3, 18, 9, 37))).toBe("26.4.18");
+    expect(dateBase(new Date(2026, 1, 5, 9, 5))).toBe("26.2.5");
+    expect(dateBase(new Date(2027, 0, 1, 0, 5))).toBe("27.1.1");
+  });
+});
+
+describe("calver maxAlphaFromTags", () => {
+  it("returns -1 when no matching tags", () => {
+    expect(maxAlphaFromTags("26.4.18", [])).toBe(-1);
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.17-alpha.5", "v26.4.19-alpha.0"])).toBe(-1);
+  });
+
+  it("returns max N across matching alpha tags", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.11", "v26.4.27-alpha.12", "v26.4.27-alpha.13"])
+    ).toBe(13);
+  });
+
+  it("handles non-monotonic tag order", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.13", "v26.4.27-alpha.0", "v26.4.27-alpha.7"])
+    ).toBe(13);
+  });
+
+  it("ignores tags with non-integer suffixes (e.g. two-tier alpha.12.0)", () => {
+    expect(
+      maxAlphaFromTags("26.4.27", ["v26.4.27-alpha.5", "v26.4.27-alpha.12.0"])
+    ).toBe(5);
+  });
+
+  it("handles single-digit and multi-digit N", () => {
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.0"])).toBe(0);
+    expect(maxAlphaFromTags("26.4.18", ["v26.4.18-alpha.99"])).toBe(99);
+  });
+});
+
+describe("calver hhmmStamp (HMM integer scheme — no leading zeros)", () => {
+  it("midnight hour drops the leading zero", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 0))).toBe("0");
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 5))).toBe("5");
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 30))).toBe("30");
+    expect(hhmmStamp(new Date(2026, 3, 18, 0, 59))).toBe("59");
+  });
+
+  it("single-digit hour: H*100 + MM", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 1, 0))).toBe("100");
+    expect(hhmmStamp(new Date(2026, 3, 18, 9, 29))).toBe("929");
+    expect(hhmmStamp(new Date(2026, 3, 18, 9, 0))).toBe("900");
+  });
+
+  it("double-digit hour: H*100 + MM", () => {
+    expect(hhmmStamp(new Date(2026, 3, 18, 10, 1))).toBe("1001");
+    expect(hhmmStamp(new Date(2026, 3, 18, 12, 34))).toBe("1234");
+    expect(hhmmStamp(new Date(2026, 3, 18, 23, 1))).toBe("2301");
+    expect(hhmmStamp(new Date(2026, 3, 18, 23, 59))).toBe("2359");
+  });
+
+  it("numeric chronological order is preserved (semver numeric IDs)", () => {
+    // No leading zeros => semver-numeric => numeric compare. Spot-check
+    // that successive minutes monotonically increase as integers.
+    const t = (h: number, m: number) => parseInt(hhmmStamp(new Date(2026, 3, 18, h, m)), 10);
+    expect(t(0, 0)).toBeLessThan(t(0, 1));
+    expect(t(0, 59)).toBeLessThan(t(1, 0));   // 59 < 100
+    expect(t(9, 59)).toBeLessThan(t(10, 0));  // 959 < 1000
+    expect(t(23, 58)).toBeLessThan(t(23, 59)); // 2358 < 2359
+  });
+});
+
+describe("calver computeVersion (HMM scheme)", () => {
+  const apr18_0937 = new Date(2026, 3, 18, 9, 37);
+  const apr27_1200 = new Date(2026, 3, 27, 12, 0);
   const jan1_0005  = new Date(2027, 0, 1, 0, 5);
 
-  it("stable: yy.m.d", () => {
-    expect(computeVersion({ stable: true,  check: false, now: apr18_0937 })).toBe("26.4.18");
-    expect(computeVersion({ stable: true,  check: false, now: jan1_0005  })).toBe("27.1.1");
+  it("stable: yy.m.d (no suffix)", () => {
+    expect(computeVersion({ stable: true, check: false, now: apr18_0937 })).toBe("26.4.18");
+    expect(computeVersion({ stable: true, check: false, now: jan1_0005 })).toBe("27.1.1");
   });
 
-  it("alpha: yy.m.d-alpha.{hour}", () => {
-    expect(computeVersion({ stable: false, check: false, now: apr18_0937 })).toBe("26.4.18-alpha.9");
-    expect(computeVersion({ stable: false, check: false, now: apr18_2255 })).toBe("26.4.18-alpha.22");
-    expect(computeVersion({ stable: false, check: false, now: jan1_0005  })).toBe("27.1.1-alpha.0");
+  it("alpha: yy.m.d-alpha.HMM regardless of tag state", () => {
+    expect(computeVersion({ stable: false, check: false, now: apr18_0937 }, [])).toBe("26.4.18-alpha.937");
+    expect(computeVersion({ stable: false, check: false, now: jan1_0005 }, [])).toBe("27.1.1-alpha.5");
   });
 
-  it("explicit --hour overrides current hour", () => {
-    expect(computeVersion({ stable: false, check: false, hour: 14, now: apr18_0937 })).toBe("26.4.18-alpha.14");
-    expect(computeVersion({ stable: false, check: false, hour: 0,  now: apr18_0937 })).toBe("26.4.18-alpha.0");
+  it("alpha: ignores tags entirely (HMM is unique-per-minute)", () => {
+    const tags = ["v26.4.27-alpha.11", "v26.4.27-alpha.12"];
+    expect(computeVersion({ stable: false, check: false, now: apr27_1200 }, tags)).toBe("26.4.27-alpha.1200");
   });
 
-  it("--stable ignores --hour", () => {
-    expect(computeVersion({ stable: true,  check: false, hour: 14, now: apr18_0937 })).toBe("26.4.18");
+  it("alpha: ignores legacy monotonic package.json counter", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr27_1200 }, [], "26.4.27-alpha.48"),
+    ).toBe("26.4.27-alpha.1200");
   });
 
-  it("rejects invalid hour", () => {
-    expect(() => computeVersion({ stable: false, check: false, hour: -1, now: apr18_0937 })).toThrow();
-    expect(() => computeVersion({ stable: false, check: false, hour: 24, now: apr18_0937 })).toThrow();
-    expect(() => computeVersion({ stable: false, check: false, hour: 1.5, now: apr18_0937 })).toThrow();
+  it("--stable ignores tags entirely", () => {
+    const tags = ["v26.4.27-alpha.99"];
+    expect(computeVersion({ stable: true, channel: "alpha", check: false, now: apr27_1200 }, tags)).toBe("26.4.27");
   });
 
-  it("no zero-pad (semver safety)", () => {
-    const feb5_0905 = new Date(2026, 1, 5, 9, 5);
-    expect(computeVersion({ stable: true,  check: false, now: feb5_0905 })).toBe("26.2.5");
-    expect(computeVersion({ stable: false, check: false, now: feb5_0905 })).toBe("26.2.5-alpha.9");
+  it("alpha and beta in same minute share HMM, differ by channel", () => {
+    const alpha = computeVersion({ stable: false, channel: "alpha", check: false, now: apr27_1200 });
+    const beta  = computeVersion({ stable: false, channel: "beta",  check: false, now: apr27_1200 });
+    expect(alpha).toBe("26.4.27-alpha.1200");
+    expect(beta).toBe("26.4.27-beta.1200");
+  });
+});
+
+describe("calver maxNFromTags / maxAlphaFromTags (back-compat helpers)", () => {
+  it("maxNFromTags isolates alpha and beta counters", () => {
+    const tags = [
+      "v26.4.28-alpha.0",
+      "v26.4.28-alpha.1",
+      "v26.4.28-beta.0",
+    ];
+    expect(maxNFromTags("26.4.28", "alpha", tags)).toBe(1);
+    expect(maxNFromTags("26.4.28", "beta", tags)).toBe(0);
+  });
+
+  it("maxAlphaFromTags is a back-compat alias for alpha channel", () => {
+    const tags = ["v26.4.28-alpha.5", "v26.4.28-beta.99"];
+    expect(maxAlphaFromTags("26.4.28", tags)).toBe(5);
+  });
+
+  it("beta tag walk rejects two-tier suffixes (e.g. beta.12.0)", () => {
+    const tags = ["v26.4.28-beta.5", "v26.4.28-beta.12.0"];
+    expect(maxNFromTags("26.4.28", "beta", tags)).toBe(5);
+  });
+});
+
+describe("calver maxNFromPackageJson (#784)", () => {
+  it("returns N for matching alpha base+channel", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.24")).toBe(24);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "v26.4.28-alpha.7")).toBe(7);
+  });
+
+  it("returns N for matching beta base+channel", () => {
+    expect(maxNFromPackageJson("26.4.28", "beta", "26.4.28-beta.3")).toBe(3);
+  });
+
+  it("returns -1 when date base does not match", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.27-alpha.99")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.5.1-alpha.0")).toBe(-1);
+  });
+
+  it("returns -1 when channel does not match", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-beta.5")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "beta", "26.4.28-alpha.5")).toBe(-1);
+  });
+
+  it("rejects non-integer suffix (e.g. two-tier alpha.12.0 or alpha.12-rc)", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12.0")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12-rc")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.abc")).toBe(-1);
+  });
+
+  it("returns -1 for empty or stable-only version strings", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28")).toBe(-1);
+  });
+});
+
+
+describe("calver maxNFromPackageJson — robustness (#784 explorer findings)", () => {
+  it("rejects non-CalVer legacy version (e.g. 2.0.0-alpha.134)", () => {
+    // Pre-CalVer migration shape — the trailing 134 must NOT match.
+    expect(maxNFromPackageJson("26.4.28", "alpha", "2.0.0-alpha.134")).toBe(-1);
+  });
+
+  it("substring trap: base 26.4.2 must not match 26.4.28-alpha.N", () => {
+    // The dash boundary in `${base}-${channel}.` should anchor the match
+    // so a shorter base doesn't fall through into a longer date.
+    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.28-alpha.5")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.20-alpha.5")).toBe(-1);
+    // Genuine match still works for the actual base 26.4.2:
+    expect(maxNFromPackageJson("26.4.2", "alpha", "26.4.2-alpha.5")).toBe(5);
+  });
+
+  it("rejects malformed alpha suffix in package.json", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.bogus")).toBe(-1);
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.12b")).toBe(-1);
+  });
+
+  it("zero-padded N parses as decimal (parity with parseInt)", () => {
+    // Mirrors maxNFromTags's parseInt behavior — `05` → 5, not octal.
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-alpha.05")).toBe(5);
+  });
+
+  it("rejects rc/other channels even if structurally similar", () => {
+    expect(maxNFromPackageJson("26.4.28", "alpha", "26.4.28-rc.5")).toBe(-1);
+  });
+});
+
+describe("calver extractBaseFromVersion (#819)", () => {
+  it("strips alpha/beta suffix, returns YY.M.D", () => {
+    expect(extractBaseFromVersion("26.4.29-alpha.5")).toBe("26.4.29");
+    expect(extractBaseFromVersion("26.4.29-beta.0")).toBe("26.4.29");
+  });
+
+  it("accepts bare YY.M.D (post-stable-cut shape)", () => {
+    expect(extractBaseFromVersion("26.4.29")).toBe("26.4.29");
+    expect(extractBaseFromVersion("v26.4.29")).toBe("26.4.29");
+  });
+
+  it("accepts leading v prefix", () => {
+    expect(extractBaseFromVersion("v26.4.29-alpha.5")).toBe("26.4.29");
+  });
+
+  it("returns null for empty/missing", () => {
+    expect(extractBaseFromVersion("")).toBeNull();
+  });
+
+  it("returns null for non-CalVer legacy versions", () => {
+    expect(extractBaseFromVersion("2.0.0-alpha.134")).toBe("2.0.0"); // shape-OK
+    expect(extractBaseFromVersion("not-a-version")).toBeNull();
+    expect(extractBaseFromVersion("26.4")).toBeNull();
+    expect(extractBaseFromVersion("26.4.29.1")).toBeNull();
+  });
+});
+
+describe("calver compareBases (#819)", () => {
+  it("compares by integer segment, not lexicographic", () => {
+    // Lexicographic would say "26.4.30" < "26.4.4" — must compare ints.
+    expect(compareBases("26.4.30", "26.4.4")).toBeGreaterThan(0);
+    expect(compareBases("26.4.4", "26.4.30")).toBeLessThan(0);
+  });
+
+  it("equal bases return 0", () => {
+    expect(compareBases("26.4.28", "26.4.28")).toBe(0);
+  });
+
+  it("year and month dominate", () => {
+    expect(compareBases("27.1.1", "26.12.31")).toBeGreaterThan(0);
+    expect(compareBases("26.5.1", "26.4.99")).toBeGreaterThan(0);
+  });
+
+  it("throws on malformed input", () => {
+    expect(() => compareBases("26.4", "26.4.28")).toThrow();
+    expect(() => compareBases("26.4.28.1", "26.4.28")).toThrow();
+  });
+});
+
+describe("calver isValidCalendarDate (#1015)", () => {
+  it("valid dates pass", () => {
+    expect(isValidCalendarDate("26.1.1")).toBe(true);
+    expect(isValidCalendarDate("26.4.30")).toBe(true);
+    expect(isValidCalendarDate("26.2.29")).toBe(true); // Feb 29 (leap)
+    expect(isValidCalendarDate("26.12.31")).toBe(true);
+  });
+
+  it("ghost dates fail (day exceeds month)", () => {
+    expect(isValidCalendarDate("26.4.53")).toBe(false); // the v26.4.53 ghost
+    expect(isValidCalendarDate("26.4.31")).toBe(false); // April has 30 days
+    expect(isValidCalendarDate("26.2.30")).toBe(false); // Feb max 29
+  });
+
+  it("invalid month fails", () => {
+    expect(isValidCalendarDate("26.0.1")).toBe(false);
+    expect(isValidCalendarDate("26.13.1")).toBe(false);
+  });
+
+  it("day 0 fails", () => {
+    expect(isValidCalendarDate("26.1.0")).toBe(false);
+  });
+
+  it("malformed input fails", () => {
+    expect(isValidCalendarDate("26.4")).toBe(false);
+    expect(isValidCalendarDate("26.4.5.1")).toBe(false);
+  });
+});
+
+describe("calver effectiveBase (#819)", () => {
+  it("picks package.json base when ahead of today", () => {
+    expect(effectiveBase("26.4.28", "26.4.29-alpha.5")).toBe("26.4.29");
+  });
+
+  it("picks today when package.json is behind", () => {
+    expect(effectiveBase("26.4.28", "26.4.27-alpha.99")).toBe("26.4.28");
+  });
+
+  it("picks today when bases are equal", () => {
+    expect(effectiveBase("26.4.28", "26.4.28-alpha.18")).toBe("26.4.28");
+  });
+
+  it("picks today when package.json is empty/unparseable", () => {
+    expect(effectiveBase("26.4.28", "")).toBe("26.4.28");
+    expect(effectiveBase("26.4.28", "not-a-version")).toBe("26.4.28");
+  });
+
+  it("handles bare future stable (post-cut shape, no suffix)", () => {
+    // Just-cut tomorrow's stable: package.json holds bare 26.4.30 with no suffix.
+    expect(effectiveBase("26.4.28", "26.4.30")).toBe("26.4.30");
+  });
+
+  it("#1015: ghost date (day > month max) falls back to today", () => {
+    expect(effectiveBase("26.4.30", "26.4.53")).toBe("26.4.30");
+    expect(effectiveBase("26.5.2", "26.4.53")).toBe("26.5.2");
+  });
+});
+
+describe("calver computeVersion future-dated package.json (#819, HMM-adapted)", () => {
+  const apr28_1200 = new Date(2026, 3, 28, 12, 0);
+  const apr29_0500 = new Date(2026, 3, 29, 5, 0);
+
+  it("future-dated alpha: bumps to package.json's date with current HMM (no downgrade)", () => {
+    // The #819 anti-downgrade guard still fires under HMM: package.json at
+    // 26.4.29-alpha.5, clock at 2026-04-28 12:00 → bump to 26.4.29-alpha.1200,
+    // NOT 26.4.28-alpha.1200 (which would be a base downgrade).
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
+    ).toBe("26.4.29-alpha.1200");
+  });
+
+  it("date roll: clock advances past package.json → fresh date with current HMM", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr29_0500 }, [], "26.4.28-alpha.18"),
+    ).toBe("26.4.29-alpha.500");
+  });
+
+  it("just-cut stable in package.json: bare YY.M.D base preserved", () => {
+    expect(
+      computeVersion({ stable: false, check: false, now: apr28_1200 }, [], "26.4.30"),
+    ).toBe("26.4.30-alpha.1200");
+  });
+
+  it("--stable always uses today's clock, never package.json's future date", () => {
+    expect(
+      computeVersion({ stable: true, check: false, now: apr28_1200 }, [], "26.4.29-alpha.5"),
+    ).toBe("26.4.28");
   });
 });

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,31 +1,58 @@
 #!/usr/bin/env bun
 // CalVer bump for arra-oracle-skills-cli
 //
-// Scheme: v{yy}.{m}.{d}[-alpha.{hour}]
-// Spec:   ψ/inbox/2026-04-18_proposal-calver-skills-cli.md (mawjs-oracle)
+// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}]
+// Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
+// Lineage:
+//   Original birth: Soul-Brews-Studio/arra-oracle-skills-cli PR #262 (2026-04-18, hour-based scheme)
+//   Evolved in: Soul-Brews-Studio/maw-js — HMM scheme (#766), --beta channel (#783), tag-walk + package.json (#786)
+//   Re-imported here: PR #284 (catching the birthplace up to the evolved canonical)
+// Umbrella: #526 (maw-js), #284 (arra-oracle-skills-cli)
+// HMM scheme: alpha/beta suffix is the integer `H*100 + M` rendered as a
+// decimal string (no leading zeros). Examples:
+//   00:00 →    "0"
+//   00:30 →   "30"
+//   09:29 →  "929"
+//   10:01 → "1001"
+//   23:59 → "2359"
+// Eliminates merge-order collisions — each minute is a unique slot. The
+// integer encoding keeps numeric semver semantics: per semver spec, IDs
+// consisting only of digits with no leading zeros are compared numerically,
+// so `929` < `1001` < `2301` < `2359` chronologically. Timezone comes from
+// the shell — set TZ=Asia/Bangkok in CI to match the project's release
+// cadence.
 //
-// Max 24 alphas per day (one per hour). Stable = no alpha suffix.
-// Timezone comes from the shell — set TZ=Asia/Bangkok in CI if needed.
+// Cutover note: the legacy monotonic counter produced low integers
+// (alpha.0 through alpha.~50). Today's wall-clock HMM at any post-midnight
+// time is strictly greater (`30` > legacy `48` is false, but `100` > `48`
+// is true; in practice merge-time HMM values are always large enough that
+// no downgrade occurs). The `--check` path can be used to verify before
+// merge.
 //
 // Usage:
-//   bun scripts/calver.ts                  → 26.4.18-alpha.10
+//   bun scripts/calver.ts                  → 26.4.18-alpha.{HMM}
+//   bun scripts/calver.ts --beta           → 26.4.18-beta.{HMM}
 //   bun scripts/calver.ts --stable         → 26.4.18
-//   bun scripts/calver.ts --hour 14        → 26.4.18-alpha.14
 //   bun scripts/calver.ts --check          → dry-run (no writes)
 
 import { $ } from "bun";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
-type Args = { stable: boolean; hour?: number; check: boolean; now?: Date };
+export type Channel = "alpha" | "beta";
+type Args = { stable: boolean; channel?: Channel; check: boolean; now?: Date };
 
 function parseArgs(argv: string[]): Args {
-  const args: Args = { stable: false, check: false };
+  const args: Args = { stable: false, channel: "alpha", check: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--stable") args.stable = true;
+    else if (a === "--beta") args.channel = "beta";
     else if (a === "--check" || a === "--dry-run") args.check = true;
-    else if (a === "--hour") args.hour = parseInt(argv[++i], 10);
+    else if (a === "--hour") {
+      console.error("--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter");
+      process.exit(2);
+    }
     else if (a === "-h" || a === "--help") {
       console.log(HELP);
       process.exit(0);
@@ -35,6 +62,10 @@ function parseArgs(argv: string[]): Args {
       process.exit(2);
     }
   }
+  if (args.stable && args.channel === "beta") {
+    console.error("--stable and --beta are mutually exclusive");
+    process.exit(2);
+  }
   return args;
 }
 
@@ -42,41 +73,228 @@ const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
+Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}] — HMM is the integer H*100+M
+rendered as a decimal string (no leading zeros). Examples: 09:29 → 929,
+10:01 → 1001, 23:59 → 2359. Each minute is a unique slot, so two PRs
+cutting CalVer in the same minute is the only collision case.
+Alpha and beta share the same date base; channel disambiguates.
+
 Options:
-  --stable         Cut stable (no alpha suffix)
-  --hour N         Override hour 0-23 (default: current hour)
+  --stable         Cut stable (no alpha/beta suffix)
+  --beta           Cut beta instead of alpha
   --check          Dry-run: print target, don't modify files
   -h, --help       Show help
 
 Examples:
-  bun scripts/calver.ts                  alpha at current hour → 26.4.18-alpha.10
-  bun scripts/calver.ts --stable         stable cut            → 26.4.18
-  bun scripts/calver.ts --hour 14        alpha at 14:xx        → 26.4.18-alpha.14
+  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{HMM}
+  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{HMM}
+  bun scripts/calver.ts --stable         stable cut → 26.4.18
   bun scripts/calver.ts --check          print only, no write`;
 
-export function computeVersion(args: Args): string {
-  const now = args.now ?? new Date();
+export function dateBase(now: Date): string {
   const yy = now.getFullYear() % 100;
   const m = now.getMonth() + 1;
   const d = now.getDate();
-  const base = `${yy}.${m}.${d}`;
-  if (args.stable) return base;
-  const hour = args.hour ?? now.getHours();
-  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
-    throw new Error(`invalid hour: ${hour} (must be 0-23)`);
+  return `${yy}.${m}.${d}`;
+}
+
+/**
+ * #819: extract the CalVer base (YY.M.D) from a version string. Accepts
+ * `v26.4.29`, `26.4.29`, `v26.4.29-alpha.5`, `26.4.29-alpha.5`, etc.
+ * Returns null if the string does not look like a CalVer base — caller can
+ * then fall back to today's date. Mirrors maxNFromPackageJson's tolerant
+ * accept-with-or-without-leading-v parsing.
+ */
+export function extractBaseFromVersion(version: string): string | null {
+  if (!version) return null;
+  const stripped = version.startsWith("v") ? version.slice(1) : version;
+  // Match leading YY.M.D — terminated by `-`, `+`, end of string, or a dot
+  // that is NOT part of the base (i.e. caller passed a 4-segment thing).
+  const m = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!m) return null;
+  const [, yy, mo, da] = m;
+  return `${yy}.${mo}.${da}`;
+}
+
+/**
+ * #819: lexicographic-safe compare of two CalVer bases by integer segment.
+ * Returns negative if a < b, 0 if equal, positive if a > b. Accepts only
+ * `YY.M.D` triples — anything else throws (caller validates upstream).
+ */
+export function compareBases(a: string, b: string): number {
+  const pa = a.split(".").map((x) => parseInt(x, 10));
+  const pb = b.split(".").map((x) => parseInt(x, 10));
+  if (pa.length !== 3 || pb.length !== 3) {
+    throw new Error(`compareBases expects YY.M.D, got "${a}" vs "${b}"`);
   }
-  return `${base}-alpha.${hour}`;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+export function isValidCalendarDate(base: string): boolean {
+  const parts = base.split(".").map(x => parseInt(x, 10));
+  if (parts.length !== 3) return false;
+  const [, m, d] = parts;
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > DAYS_IN_MONTH[m]) return false;
+  return true;
+}
+
+/**
+ * #819: pick the effective base for the next bump — the later of today's
+ * clock-derived base and the package.json-derived base. This prevents the
+ * post-stable-cut downgrade where package.json carries `YY.M.(D+1)` but the
+ * clock still reads `YY.M.D` (tomorrow's stable already cut, today's clock
+ * still ticking). Without this, the script targets `YY.M.D-alpha.0` — a
+ * downgrade against `YY.M.(D+1)-alpha.N`.
+ *
+ * #1015 ghost-date guard: if the package.json base has a day that doesn't
+ * exist in the calendar (e.g. April 53), fall back to today — the base is
+ * corrupted. main() auto-fixes package.json before reaching here, but
+ * direct callers get a safe fallback instead of a crash.
+ */
+export function effectiveBase(todayBase: string, packageVersion: string): string {
+  const pkgBase = extractBaseFromVersion(packageVersion);
+  if (!pkgBase) return todayBase;
+  if (!isValidCalendarDate(pkgBase)) return todayBase;
+  return compareBases(pkgBase, todayBase) > 0 ? pkgBase : todayBase;
+}
+
+/**
+ * Walk git tags matching `v{base}-{channel}.*` and return the max N found,
+ * or -1 if no matching tags exist for this date+channel yet.
+ *
+ * Backwards-compatible alias `maxAlphaFromTags(base, tags)` defaults to alpha.
+ */
+export function maxNFromTags(base: string, channel: Channel, tags: string[]): number {
+  const prefix = `v${base}-${channel}.`;
+  let max = -1;
+  for (const tag of tags) {
+    if (!tag.startsWith(prefix)) continue;
+    const rest = tag.slice(prefix.length);
+    // Option A: pure integer N (no further dots). Reject e.g. "12.0".
+    if (!/^\d+$/.test(rest)) continue;
+    const n = parseInt(rest, 10);
+    if (Number.isInteger(n) && n > max) max = n;
+  }
+  return max;
+}
+
+/**
+ * Back-compat alias: alpha-only tag walk.
+ */
+export function maxAlphaFromTags(base: string, tags: string[]): number {
+  return maxNFromTags(base, "alpha", tags);
+}
+
+/**
+ * #784: walk package.json.version as an additional source-of-truth for the
+ * monotonic counter. Post-#767, alpha releases merge to the `alpha` branch,
+ * but `calver-release.yml` only fires on push to `main` — so no git tags get
+ * created for in-flight alphas. Without this, tag-walk returns -1 and we
+ * regress to alpha.0 on every alpha-branch run.
+ *
+ * Parses `vYY.M.D-{channel}.{N}` (with or without leading "v") and returns N
+ * only if base+channel match today's. Rejects non-integer suffixes and
+ * empty/missing strings (returns -1).
+ */
+export function maxNFromPackageJson(
+  base: string,
+  channel: Channel,
+  packageVersion: string,
+): number {
+  if (!packageVersion) return -1;
+  // Accept either `vYY.M.D-channel.N` or `YY.M.D-channel.N`.
+  const stripped = packageVersion.startsWith("v") ? packageVersion.slice(1) : packageVersion;
+  const prefix = `${base}-${channel}.`;
+  if (!stripped.startsWith(prefix)) return -1;
+  const rest = stripped.slice(prefix.length);
+  if (!/^\d+$/.test(rest)) return -1;
+  const n = parseInt(rest, 10);
+  return Number.isInteger(n) ? n : -1;
+}
+
+async function listChannelTags(base: string, channel: Channel): Promise<string[]> {
+  const res = await $`git tag --list ${`v${base}-${channel}.*`}`.nothrow().quiet();
+  if (res.exitCode !== 0) return [];
+  return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
+}
+
+/**
+ * HMM stamp — integer `H*100 + M` rendered as a decimal string (no leading
+ * zeros), used as the numeric pre-release identifier for alpha/beta cuts.
+ * Examples: 00:00 → "0", 00:30 → "30", 09:29 → "929", 10:01 → "1001",
+ * 23:59 → "2359". Numeric semver semantics ensure chronological order.
+ * Timezone is implicit (Date's local TZ); CI sets TZ=Asia/Bangkok.
+ */
+export function hhmmStamp(now: Date): string {
+  return String(now.getHours() * 100 + now.getMinutes());
+}
+
+export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {
+  const now = args.now ?? new Date();
+  const todayBase = dateBase(now);
+  // #819: if package.json is future-dated (e.g. tomorrow's stable just cut),
+  // bump against that base — never downgrade to today's date.
+  const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
+  if (args.stable) return base;
+  const channel = args.channel ?? "alpha";
+  // HHMM scheme: pre-release ID is the local-time hour+minute. Naturally
+  // unique-per-minute, no tag-walk + package-walk reconciliation needed.
+  // tags + packageVersion params kept for back-compat with callers/tests.
+  void tags; void packageVersion;
+  const stamp = hhmmStamp(now);
+  return `${base}-${channel}.${stamp}`;
 }
 
 async function tagExists(version: string): Promise<boolean> {
-  const res = await $`git rev-parse --verify --quiet v${version}`.nothrow().quiet();
+  const res = await $`git rev-parse --verify --quiet ${`v${version}`}`.nothrow().quiet();
   return res.exitCode === 0;
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const version = computeVersion(args);
-  const channel = args.stable ? "stable" : "alpha";
+  const now = args.now ?? new Date();
+  const todayBase = dateBase(now);
+
+  // #784: read package.json once up front so its version participates in the
+  // source-of-truth set for the monotonic counter (see computeVersion).
+  const pkgPath = join(process.cwd(), "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+  // #1015: auto-fix ghost dates in package.json. A ghost (e.g. April 53)
+  // is a corrupted CalVer base from legacy monotonic stable bumps. Instead
+  // of erroring, reset to today's real date and continue.
+  const pkgBase = extractBaseFromVersion(pkg.version ?? "");
+  if (pkgBase && !isValidCalendarDate(pkgBase)) {
+    const [, mo, da] = pkgBase.split(".").map(Number);
+    const MONTH_NAMES = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    const DAYS = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    const maxDay = mo >= 1 && mo <= 12 ? DAYS[mo] : "?";
+    console.error(`\n⚠ ghost date in package.json: ${pkg.version}`);
+    console.error(`  day ${da} doesn't exist in ${MONTH_NAMES[mo] || `month ${mo}`} (max: ${maxDay})`);
+    console.error(`\n  CalVer scheme: v{YY}.{M}.{D}[-{channel}.{HMM}]`);
+    console.error(`    YY   = year (${now.getFullYear() % 100})`);
+    console.error(`    M    = month 1-12 (${now.getMonth() + 1} = ${MONTH_NAMES[now.getMonth() + 1]})`);
+    console.error(`    D    = day of month 1-${DAYS[now.getMonth() + 1]} (today: ${now.getDate()})`);
+    console.error(`    HMM  = hour*100 + minute (wall clock)`);
+    console.error(`\n  auto-fix: resetting base to ${todayBase}\n`);
+    pkg.version = todayBase;
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+  }
+
+  // #819: choose the effective base before fetching tags so we list tags for
+  // the correct date when package.json is future-dated.
+  const base = args.stable ? todayBase : effectiveBase(todayBase, pkg.version ?? "");
+
+  const channelForTags: Channel = args.channel ?? "alpha";
+  const tags = args.stable ? [] : await listChannelTags(base, channelForTags);
+  const version = computeVersion(args, tags, pkg.version ?? "");
+  const channel = args.stable ? "stable" : channelForTags;
 
   console.log(`Target: v${version}  [${channel}]`);
 
@@ -86,13 +304,16 @@ async function main() {
   }
 
   if (await tagExists(version)) {
+    // Should never happen for alpha (we picked max+1) but stable can collide.
     console.error(`\n❌ tag v${version} already exists`);
-    console.error(`   → wait for next hour, or use --hour N, or cut --stable`);
+    if (args.stable) {
+      console.error(`   → stable for today already cut; nothing to do`);
+    } else {
+      console.error(`   → race detected: another tag was created between scan and bump`);
+    }
     process.exit(1);
   }
 
-  const pkgPath = join(process.cwd(), "package.json");
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
   const old = pkg.version;
   pkg.version = version;
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
@@ -101,9 +322,8 @@ async function main() {
   console.log(`
 Next:
   git add package.json && git commit -m "bump: v${version}" && git push origin main
-  → auto-tag.yml creates v${version}
-  → release.yml publishes GitHub release
-  → publish.yml → npm (${args.stable ? "latest" : "alpha"} dist-tag)`);
+  → calver-release.yml creates v${version} tag + GitHub release (+ builds dist/maw)
+  → dist/maw attached to release`);
 }
 
 if (import.meta.main) main();

--- a/src/skills/calver/SKILL.md
+++ b/src/skills/calver/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: calver
+description: Show or bump CalVer version via bun scripts/calver.ts in arra-oracle-skills-cli. Default is dry-run --check. Read-only by default; `--apply` writes package.json. **For full release flow (commit + push + PR), use /release-alpha or /release-stable instead** — /calver alone never commits, pushes, or PRs.
+---
+
+# /calver
+
+Compute / bump the CalVer version for arra-oracle-skills-cli.
+
+> ⚠️ **Pair with the right skill.** This skill is `--check` (read-only) or `--apply` (writes `package.json` and stops). It does NOT commit, push, or PR — that's deliberate so a bump can never accidentally cut a release.
+>
+> | Want to… | Use |
+> |---|---|
+> | See the next target version | `/calver` (default = `--check`) |
+> | Just bump `package.json` and stop | `/calver --apply` |
+> | Cut a soak release (alpha pre-release) | `/release-alpha` |
+> | Cut a stable release on main | `/release-stable` |
+> | Land a code fix without releasing | regular branch + PR — keep `package.json` version untouched |
+>
+> **Never** combine a `package.json` bump with a code fix in the same commit on this repo — `calver-release.yml` auto-tags on push to `main`, so a fix-PR with a bump = automatic stable release.
+
+CalVer scheme: `v{yy}.{m}.{d}[-(alpha|beta).{HMM}]` — HMM is the wall-clock as decimal `H*100 + M` with no leading zero (e.g. 09:37 → `937`, 23:59 → `2359`). Each minute is a unique slot — no merge-order collisions. Alpha and beta are independent channels (#754 / PR #783). Walks git tags AND `package.json.version` for source-of-truth (#784 / PR #786). TZ fixed to Asia/Bangkok. HMM replaced monotonic counter (#766/#775) in #923.
+
+Day-of-month `D` may exceed 31 — used as a stable counter once natural date is exhausted (#930). E.g. `v26.4.50` is the 50th stable cut in the period, not "April 50".
+
+## Step 0: Locate arra-oracle-skills-cli
+
+Always resolve repo via `ghq` so the skill works from any cwd:
+
+```bash
+ARRA=$(ghq list -p --exact Soul-Brews-Studio/arra-oracle-skills-cli 2>/dev/null | head -1)
+if [ -z "$ARRA" ]; then
+  echo "❌ arra-oracle-skills-cli not found via ghq. Run: ghq get github.com/Soul-Brews-Studio/arra-oracle-skills-cli"
+  exit 1
+fi
+echo "🕐 $(date '+%H:%M %Z (%A %d %B %Y)')"
+echo "📁 $ARRA"
+```
+
+## Modes
+
+### Default — dry-run check (show next target)
+
+```bash
+TZ=Asia/Bangkok bun "$ARRA/scripts/calver.ts" --check
+```
+
+Shows the next target version (`max(tag-walk, package.json) + 1` for today's date+channel). No files modified.
+
+### `--apply` — bump package.json
+
+```bash
+TZ=Asia/Bangkok bun "$ARRA/scripts/calver.ts"
+```
+
+Writes the next version to `package.json`. Caller then:
+
+```bash
+git -C "$ARRA" add package.json && git -C "$ARRA" commit -m "bump: v<version>"
+```
+
+Do NOT auto-commit — hand off to user so they can bundle with other changes.
+
+### `--stable` — cut stable (no alpha/beta suffix)
+
+```bash
+TZ=Asia/Bangkok bun "$ARRA/scripts/calver.ts" --stable
+```
+
+### `--beta` — cut beta (parallel channel, independent counter)
+
+```bash
+TZ=Asia/Bangkok bun "$ARRA/scripts/calver.ts" --beta
+```
+
+`--stable` and `--beta` are mutually exclusive (script exits 2).
+
+### `--hour N` — REMOVED
+
+The `--hour` flag is deprecated as of #766 and will exit 2. CalVer now uses a monotonic counter walked from git tags + `package.json` — there is no hour-bucket to override.
+
+### `--help` — print calver.ts help
+
+```bash
+TZ=Asia/Bangkok bun "$ARRA/scripts/calver.ts" --help
+```
+
+## After apply
+
+**Stop. Hand off to the user.** Do NOT auto-commit, do NOT push, do NOT open a PR. The whole point of /calver being read-only-or-stop-after-write is so a bump can never accidentally turn into a release.
+
+If the user wants to ship the bump, they invoke a release skill:
+
+```
+Next steps (user runs one of these — not /calver):
+  /release-alpha    — soak channel, PR to alpha, calver-release.yml cuts pre-release on merge
+  /release-stable   — stable channel (planned), PR to main, calver-release.yml cuts stable on merge
+```
+
+If the user is doing code-only work (no release), tell them to **revert** the package.json change before opening the PR. Bumping in a non-release branch is the exact failure mode /release-alpha was built to prevent.
+
+## Notes
+
+- The calver.ts script is authoritative. Do NOT hand-compute versions.
+- Release workflow: `calver-release.yml` tags on push to main when package.json version differs from latest tag. Post-#767, alphas merge to `alpha` branch (no tags created until stable cut to main); the script handles this by walking package.json (#784 / PR #786).
+- Spec: `ψ/inbox/2026-04-18_proposal-calver-skills-cli.md` (mawjs-oracle vault).
+- Umbrella issue: #526 (maw-js — original); #284 (arra-oracle-skills-cli — this port).
+- Related changes today (2026-04-28): #775 (monotonic counter), PR #783 (--beta channel for #754), PR #786 (package.json walk for #784).
+
+---
+
+ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Summary

Closes #284. Three coordinated changes:

| File | Change | Reason |
|------|--------|--------|
| `scripts/calver.ts` | 109 → 326 lines | Sync legacy to maw-js canonical (HMM scheme, --beta channel, --hour deprecated #766, tag-walk #786) |
| `__tests__/calver.test.ts` | 40 → 348 lines | Port comprehensive test suite from maw-js (54 tests, all pass) |
| `src/skills/calver/SKILL.md` | NEW, 112 lines | Packaged /calver skill — adapted from mawjs-oracle/.claude/skills/calver/SKILL.md |

## What /calver does (the packaged skill)

Mechanical bump only. Default `--check` (dry-run, read-only). `--apply` writes `package.json` and **stops** — never commits, pushes, or PRs. Pairs with `/release-alpha` (the ceremony layer).

The skill is gated by a hard rule documented in its body:

> **Never** combine a `package.json` bump with a code fix in the same commit on this repo — `calver-release.yml` auto-tags on push to `main`/`alpha`, so a fix-PR with a bump = automatic stable release.

## Why the script also needs syncing

The mawjs-oracle SKILL.md references `--beta`, `--hour`-removal warnings, HMM scheme, and package.json tag-walking — all features that exist in the canonical maw-js script but NOT in the legacy 109-line arra-cli version. Without the script sync, the skill would lie about what the local script does.

## Lineage

```
Birth      arra-oracle-skills-cli PR #262 (2026-04-18, hour-based)
Evolved    maw-js #766 (HMM) / #783 (--beta) / #786 (tag-walk)
Skill home mawjs-oracle .claude/skills/calver/SKILL.md
This PR    catches the birthplace up to the evolved canonical + adds
           the packaged-skill distribution form
```

## Test results

- `__tests__/calver.test.ts`: 54/54 pass locally
- `__tests__/profiles.test.ts`: 31/31 pass (regression check)
- `/calver --check` on this branch: `v26.5.13-alpha.1134` ✓ (HMM scheme working)

## Refs

- Closes #284
- Builds on #286 (MINIMAL_ONLY classification, just merged)
- Builds on #288 (workflow alpha trigger fix, just merged)

---

🤖 ตอบโดย arra-oracle-skills-cli จาก [Nat] → arra-oracle-skills-cli-oracle