### PR TITLE
feat(#285): explicit-profile alignment in installer.ts (closes #267)

### DIFF
--- a/.github/workflows/calver-check.yml
+++ b/.github/workflows/calver-check.yml
@@ -1,14 +1,14 @@
 name: CalVer Tag Check
 
 # Validates any tag pushed to the repo against the CalVer scheme proposed in
-# Soul-Brews-Studio/mawjs-oracle PR #3.
+# Soul-Brews-Studio/mawjs-oracle PR #3, post-#766 HMM evolution.
 #
-# Scheme: v{yy}.{m}.{d}[-alpha.{hour}[a-z]?]
+# Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}[a-z]?]
 #   yy    2-digit year       (26, 27, ...)
 #   m     month 1-12         (no zero-pad)
-#   d     day 1-31           (no zero-pad)
-#   hour  0-23 bucket        (optional; max 24 alphas/day)
-#   a-z   collision suffix   (optional; e.g. alpha.9b)
+#   d     day ≥1             (no zero-pad; may exceed 31 — overflow counter per #930)
+#   HMM   0-2359             (H*100+M, no leading zero; e.g. 9:37→937, 23:59→2359)
+#   a-z   collision suffix   (optional; e.g. alpha.929b)
 #
 # This workflow is a pure validator — no side effects. Belt-and-suspenders
 # for calver-release.yml which also validates before tagging.
@@ -30,9 +30,9 @@ jobs:
           VERSION="${TAG#v}"
           echo "Validating: $TAG ($VERSION)"
 
-          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-alpha\.[0-9]{1,2}[a-z]?)?$'
+          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,3}(-(alpha|beta)\.[0-9]{1,4}[a-z]?)?$'
           if [[ ! "$VERSION" =~ $REGEX ]]; then
-            echo "::error title=CalVer violation::Tag '$TAG' does not match v{yy}.{m}.{d}[-alpha.{hour}]"
+            echo "::error title=CalVer violation::Tag '$TAG' does not match v{yy}.{m}.{d}[-(alpha|beta).{HMM}]"
             echo "::error::Spec: https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md"
             exit 1
           fi
@@ -44,16 +44,19 @@ jobs:
             echo "::error::Month must be 1-12, got $M"
             exit 1
           fi
-          if (( D < 1 || D > 31 )); then
-            echo "::error::Day must be 1-31, got $D"
+          # D is a monotonic counter floored at day-of-month; may exceed 31
+          # after a multi-cut streak (per #930). Floor-only validation.
+          if (( D < 1 )); then
+            echo "::error::Day/counter must be ≥1, got $D"
             exit 1
           fi
 
-          if [[ "$VERSION" == *-alpha.* ]]; then
-            HOUR_RAW="${VERSION##*-alpha.}"
-            HOUR="${HOUR_RAW%%[a-z]*}"
-            if (( HOUR < 0 || HOUR > 23 )); then
-              echo "::error::Hour must be 0-23, got $HOUR"
+          if [[ "$VERSION" == *-alpha.* ]] || [[ "$VERSION" == *-beta.* ]]; then
+            SUFFIX_RAW="${VERSION##*.}"
+            HMM="${SUFFIX_RAW%%[a-z]*}"
+            # HMM = H*100 + M, range 0-2359, no leading zero (per #766/#923).
+            if (( HMM < 0 || HMM > 2359 )); then
+              echo "::error::HMM suffix must be 0-2359, got $HMM"
               exit 1
             fi
           fi

--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -54,37 +54,49 @@ jobs:
 
           # Only act on CalVer-shaped versions. Non-CalVer bumps (legacy v3.x
           # chore commits, etc.) are skipped — no-op, not a failure.
-          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(-alpha\.[0-9]{1,2}[a-z]?)?$'
+          # Accepts alpha + beta channels (#754); both are prereleases.
+          # Suffix is HMM (#766/#923): integer H*100+M, 1-4 digits, no leading
+          # zero (e.g. 5, 30, 929, 1200, 2359). Optional trailing [a-z] is the
+          # same-minute collision suffix.
+          REGEX='^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,3}(-(alpha|beta)\.[0-9]{1,4}[a-z]?)?$'
           if [[ ! "$VERSION" =~ $REGEX ]]; then
             echo "::notice title=Skipped::Version '$VERSION' is not CalVer — no release cut."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Range validation — regex alone passes alpha.99.
+          # Range validation — regex alone passes month.99.
           BASE="${VERSION%%-*}"
           IFS='.' read -r YY M D <<< "$BASE"
           if (( M < 1 || M > 12 )); then
             echo "::error::Month must be 1-12, got $M"; exit 1
           fi
-          if (( D < 1 || D > 31 )); then
-            echo "::error::Day must be 1-31, got $D"; exit 1
-          fi
-          if [[ "$VERSION" == *-alpha.* ]]; then
-            HOUR_RAW="${VERSION##*-alpha.}"
-            HOUR="${HOUR_RAW%%[a-z]*}"
-            if (( HOUR < 0 || HOUR > 23 )); then
-              echo "::error::Hour must be 0-23, got $HOUR"; exit 1
-            fi
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=alpha" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+          # D is a monotonic counter floored at day-of-month; may exceed 31
+          # after a multi-cut streak (per #930). Floor-only validation.
+          if (( D < 1 )); then
+            echo "::error::Day/counter must be ≥1, got $D"; exit 1
           fi
 
-          PRERELEASE="false"; [[ "$VERSION" == *-alpha.* ]] && PRERELEASE="true"
-          echo "✅ valid CalVer: $TAG (prerelease=$PRERELEASE)"
+          PRERELEASE="false"
+          CHANNEL="stable"
+          NPM_TAG="latest"
+          if [[ "$VERSION" == *-alpha.* ]] || [[ "$VERSION" == *-beta.* ]]; then
+            SUFFIX_RAW="${VERSION##*.}"
+            HMM="${SUFFIX_RAW%%[a-z]*}"
+            if (( HMM < 0 || HMM > 2359 )); then
+              echo "::error::HMM suffix must be 0-2359, got $HMM"; exit 1
+            fi
+            PRERELEASE="true"
+            if [[ "$VERSION" == *-alpha.* ]]; then
+              CHANNEL="alpha"; NPM_TAG="alpha"
+            else
+              CHANNEL="beta"; NPM_TAG="beta"
+            fi
+          fi
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
+          echo "✅ valid CalVer: $TAG (channel=$CHANNEL prerelease=$PRERELEASE)"
 
       - name: Fail loud on tag collision
         if: steps.ver.outputs.skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### feat(profiles): explicit-profile alignment (#285 part 2, closes #267)
+
+- `install --profile <name>` when explicit now ALIGNS (removes arra-managed skills not in target).
+- Bare `install` and `-s <skill>` remain purely additive (#257 / Bug 5 protection preserved).
+- Non-arra skills NEVER touched (matches existing `/go cleanup` precedent).
+- Pre-removal diff printed even under `-y`.
+- `/go <profile>` now correctly includes `minimal` in usage and profile table.
+
+---
+
 ## v3.9.0-alpha.2 (2026-04-13)
 
 ### Team Ops + Mailbox + -s Fix

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-60 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+61 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -50,53 +50,54 @@ npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent claude-code codex 
 | 11 | **bampenpien** | skill | "บำเพ็ญเพียร |
 | 12 | **birth** | skill | 'Prepare Oracle birth props for a new repo |
 | 13 | **bud** | skill | 'Create a new oracle via maw bud |
-| 14 | **contacts** | skill | Manage Oracle contacts |
-| 15 | **create-shortcut** | skill | Create local skills as shortcuts |
-| 16 | **deep-research** | skill | 'Deep Research via Gemini |
-| 17 | **dig** | skill | Mine Claude Code sessions |
-| 18 | **dream** | skill | "Cross-repo pattern discovery |
-| 19 | **feel** | skill | "Capture how the system feels |
-| 20 | **fleet** | skill | 'Deep fleet census |
-| 21 | **forward** | skill | Create handoff + enter plan mode for next |
-| 22 | **forward-lite** | skill | Quick handoff to next session |
-| 23 | **gemini** | skill | 'Control Gemini browser tab |
-| 24 | **go** | skill | Switch skill profiles (standard/full/lab) |
-| 25 | **handover** | skill | 'Transfer work to another Oracle |
-| 26 | **harden** | skill | 'Audit Oracle configuration for safety |
-| 27 | **i-believed** | skill | "Declare belief |
-| 28 | **inbox** | skill | Read and write to Oracle inbox |
-| 29 | **incubate** | skill | Clone or create repos for active development |
-| 30 | **list-issues-pr-pulse** | skill | 'Open issues, PRs |
-| 31 | **machines** | skill | 'Fleet machines |
-| 32 | **mailbox** | skill | 'Persistent agent mailbox |
-| 33 | **mine** | skill | 'Extract a specific topic from a single |
-| 34 | **morpheus** | skill | 'Speculative dreaming |
-| 35 | **new-issue** | skill | 'Quick GitHub issue creation |
-| 36 | **oracle-manage** | skill | 'Skill and profile management |
-| 37 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
-| 38 | **philosophy** | skill | Display Oracle philosophy |
-| 39 | **recap-lite** | skill | Quick session orientation |
-| 40 | **release** | skill | 'Automated release flow |
-| 41 | **resonance** | skill | Capture a resonance moment |
-| 42 | **rrr-lite** | skill | Quick session retrospective |
-| 43 | **skills-list** | skill | 'List all Oracle skills |
-| 44 | **speak** | skill | 'Text-to-speech using edge-tts neural voices |
-| 45 | **standup** | skill | Daily standup check |
-| 46 | **talk-to** | skill | Talk to another Oracle agent |
-| 47 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 48 | **trace** | skill | Find projects, code |
-| 49 | **vault** | skill | Connect external knowledge bases (Obsidian |
-| 50 | **warp** | skill | 'Teleport to a remote oracle node |
-| 51 | **watch** | skill | 'Extract YouTube video transcripts |
-| 52 | **what-we-done** | skill | 'Facts-only progress report |
-| 53 | **whats-next** | skill | 'Smart action suggestions |
-| 54 | **where-we-are** | skill | Session awareness |
-| 55 | **who-are-you** | skill | Know ourselves |
-| 56 | **work-with** | skill | 'Persistent cross-oracle collaboration |
-| 57 | **workon** | skill | 'Work on a GitHub issue |
-| 58 | **worktree** | skill | 'Work in an isolated git worktree |
-| 59 | **wormhole** | skill | 'Federated query proxy |
-| 60 | **xray** | skill | X-ray deep scan |
+| 14 | **calver** | skill | Show or bump CalVer version |
+| 15 | **contacts** | skill | Manage Oracle contacts |
+| 16 | **create-shortcut** | skill | Create local skills as shortcuts |
+| 17 | **deep-research** | skill | 'Deep Research via Gemini |
+| 18 | **dig** | skill | Mine Claude Code sessions |
+| 19 | **dream** | skill | "Cross-repo pattern discovery |
+| 20 | **feel** | skill | "Capture how the system feels |
+| 21 | **fleet** | skill | 'Deep fleet census |
+| 22 | **forward** | skill | Create handoff + enter plan mode for next |
+| 23 | **forward-lite** | skill | Quick handoff to next session |
+| 24 | **gemini** | skill | 'Control Gemini browser tab |
+| 25 | **go** | skill | Switch skill profiles (standard/full/lab) |
+| 26 | **handover** | skill | 'Transfer work to another Oracle |
+| 27 | **harden** | skill | 'Audit Oracle configuration for safety |
+| 28 | **i-believed** | skill | "Declare belief |
+| 29 | **inbox** | skill | Read and write to Oracle inbox |
+| 30 | **incubate** | skill | Clone or create repos for active development |
+| 31 | **list-issues-pr-pulse** | skill | 'Open issues, PRs |
+| 32 | **machines** | skill | 'Fleet machines |
+| 33 | **mailbox** | skill | 'Persistent agent mailbox |
+| 34 | **mine** | skill | 'Extract a specific topic from a single |
+| 35 | **morpheus** | skill | 'Speculative dreaming |
+| 36 | **new-issue** | skill | 'Quick GitHub issue creation |
+| 37 | **oracle-manage** | skill | 'Skill and profile management |
+| 38 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
+| 39 | **philosophy** | skill | Display Oracle philosophy |
+| 40 | **recap-lite** | skill | Quick session orientation |
+| 41 | **release** | skill | 'Automated release flow |
+| 42 | **resonance** | skill | Capture a resonance moment |
+| 43 | **rrr-lite** | skill | Quick session retrospective |
+| 44 | **skills-list** | skill | 'List all Oracle skills |
+| 45 | **speak** | skill | 'Text-to-speech using edge-tts neural voices |
+| 46 | **standup** | skill | Daily standup check |
+| 47 | **talk-to** | skill | Talk to another Oracle agent |
+| 48 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 49 | **trace** | skill | Find projects, code |
+| 50 | **vault** | skill | Connect external knowledge bases (Obsidian |
+| 51 | **warp** | skill | 'Teleport to a remote oracle node |
+| 52 | **watch** | skill | 'Extract YouTube video transcripts |
+| 53 | **what-we-done** | skill | 'Facts-only progress report |
+| 54 | **whats-next** | skill | 'Smart action suggestions |
+| 55 | **where-we-are** | skill | Session awareness |
+| 56 | **who-are-you** | skill | Know ourselves |
+| 57 | **work-with** | skill | 'Persistent cross-oracle collaboration |
+| 58 | **workon** | skill | 'Work on a GitHub issue |
+| 59 | **worktree** | skill | 'Work in an isolated git worktree |
+| 60 | **wormhole** | skill | 'Federated query proxy |
+| 61 | **xray** | skill | X-ray deep scan |
 
 <!-- skills:end -->
 
@@ -108,8 +109,8 @@ npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent claude-code codex 
 |---------|-------|--------|
 | **minimal** | 7 | `about-oracle`, `forward-lite`, `go`, `oracle-soul-sync-update`, `recap-lite`, `rrr-lite`, `trace` |
 | **standard** | 13 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace`, `xray` |
-| **full** | 60 | all |
-| **lab** | 60 | all |
+| **full** | 61 | all |
+| **lab** | 61 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/__tests__/installer-align.test.ts
+++ b/__tests__/installer-align.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for explicit-profile alignment (#285 Part 2, closes #267).
+ *
+ * Invariants:
+ *   1. `install --profile <name>` (explicit) → ALIGN: removes arra-managed skills not in target
+ *   2. Bare `install` (no flag) → purely additive (Bug 5 protection, #257)
+ *   3. `install -s <skill>` (no --profile) → purely additive
+ *   4. Non-arra skills (no 'installer:' frontmatter) → NEVER touched during alignment
+ *   5. Pre-removal diff is printed even under -y
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { readdir, rm, mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { agents } from "../src/cli/agents";
+import { installSkills, discoverSkills } from "../src/cli/installer";
+import { profiles, MINIMAL_SKILLS, STANDARD_SKILLS } from "../src/profiles";
+import type { AgentConfig } from "../src/cli/types";
+
+const TEST_DIR = join(tmpdir(), `arra-oracle-skills-align-${Date.now()}`);
+const SKILLS_DIR = join(TEST_DIR, "skills");
+const COMMANDS_DIR = join(TEST_DIR, "commands");
+const TEST_AGENT = "test-align" as any;
+
+const testAgentConfig: AgentConfig = {
+  name: "test-align",
+  displayName: "Test Align",
+  skillsDir: "test-skills-align",
+  globalSkillsDir: SKILLS_DIR,
+  commandsDir: "test-commands-align",
+  globalCommandsDir: COMMANDS_DIR,
+  useFlatFiles: true,
+  detectInstalled: () => true,
+};
+
+beforeAll(async () => {
+  await mkdir(TEST_DIR, { recursive: true });
+  (agents as any)[TEST_AGENT] = testAgentConfig;
+});
+
+afterAll(async () => {
+  delete (agents as any)[TEST_AGENT];
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
+});
+
+async function listSkillDirs(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+    .map((d) => d.name)
+    .sort();
+}
+
+async function cleanup() {
+  if (existsSync(SKILLS_DIR)) await rm(SKILLS_DIR, { recursive: true });
+  if (existsSync(COMMANDS_DIR)) await rm(COMMANDS_DIR, { recursive: true });
+  await mkdir(SKILLS_DIR, { recursive: true });
+  await mkdir(COMMANDS_DIR, { recursive: true });
+}
+
+// Plant a non-arra skill (no installer: frontmatter) in SKILLS_DIR
+async function plantExternalSkill(name: string): Promise<void> {
+  const dir = join(SKILLS_DIR, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: External skill\n---\n# /${name}\n`);
+}
+
+describe("alignment: explicit --profile triggers removal of arra-managed skills not in target", () => {
+  beforeEach(cleanup);
+
+  it("explicit --profile minimal after --profile standard removes standard-only skills", async () => {
+    // Step 1: install standard profile (explicit)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "standard",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterStandard = await listSkillDirs(SKILLS_DIR);
+    expect(afterStandard.length).toBe(profiles.standard.include!.length);
+
+    // Step 2: align down to minimal (explicit)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "minimal",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterMinimal = await listSkillDirs(SKILLS_DIR);
+
+    // Should now have exactly the minimal skills
+    expect(afterMinimal.length).toBe(MINIMAL_SKILLS.length);
+    for (const name of MINIMAL_SKILLS) {
+      expect(afterMinimal).toContain(name);
+    }
+
+    // Standard-only skills that were removed:
+    const standardOnlySkills = STANDARD_SKILLS.filter(
+      (s) => !(MINIMAL_SKILLS as readonly string[]).includes(s)
+    );
+    for (const name of standardOnlySkills) {
+      expect(afterMinimal).not.toContain(name);
+    }
+  });
+
+  it("explicit --profile full after standard installs more, then explicit --profile minimal aligns down", async () => {
+    // Install standard first (explicit)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "standard",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterStandard = await listSkillDirs(SKILLS_DIR);
+    expect(afterStandard.length).toBeGreaterThanOrEqual(STANDARD_SKILLS.length);
+
+    // Then align down to minimal (explicit)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "minimal",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterMinimal = await listSkillDirs(SKILLS_DIR);
+    expect(afterMinimal.length).toBe(MINIMAL_SKILLS.length);
+    for (const name of MINIMAL_SKILLS) {
+      expect(afterMinimal).toContain(name);
+    }
+  });
+});
+
+describe("alignment: bare install (no profileExplicit) is purely additive — Bug 5 protection (#257)", () => {
+  beforeEach(cleanup);
+
+  it("install without profileExplicit does NOT remove skills missing from profile", async () => {
+    // First: plant standard skills explicitly
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "standard",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterStandard = await listSkillDirs(SKILLS_DIR);
+    const standardCount = afterStandard.length;
+    expect(standardCount).toBe(profiles.standard.include!.length);
+
+    // Second: install minimal WITHOUT profileExplicit (simulates default / no flag)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "minimal",
+      profileExplicit: false, // not explicit — additive only
+      yes: true,
+    });
+
+    const afterAdditive = await listSkillDirs(SKILLS_DIR);
+    // Additive: the count grows (minimal adds its unique skills) but nothing is removed.
+    // The key invariant is that ALL original standard skills are still present.
+    expect(afterAdditive.length).toBeGreaterThanOrEqual(standardCount);
+    // All standard skills still present (none removed)
+    for (const name of profiles.standard.include!) {
+      expect(afterAdditive).toContain(name);
+    }
+  });
+
+  it("install without any profile flag does NOT remove skills", async () => {
+    // First: plant standard skills explicitly
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "standard",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterStandard = await listSkillDirs(SKILLS_DIR);
+    const standardCount = afterStandard.length;
+
+    // Second: install with NO profile (undefined profileExplicit)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      yes: true,
+      // No profile, no profileExplicit — install all
+    });
+
+    const afterAll = await listSkillDirs(SKILLS_DIR);
+    // All standard skills still present (count may be higher since all skills installed)
+    for (const name of profiles.standard.include!) {
+      expect(afterAll).toContain(name);
+    }
+  });
+});
+
+describe("alignment: install -s <skill> (no --profile) does not trigger alignment", () => {
+  beforeEach(cleanup);
+
+  it("-s flag without --profile is purely additive", async () => {
+    // First: install standard explicitly
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "standard",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterStandard = await listSkillDirs(SKILLS_DIR);
+    const standardCount = afterStandard.length;
+
+    // Add a single skill with -s (no profile, no profileExplicit)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      skills: ["trace"],
+      // No profile, no profileExplicit
+      yes: true,
+    });
+
+    const afterAddSkill = await listSkillDirs(SKILLS_DIR);
+    // Still at least standardCount skills — nothing removed
+    expect(afterAddSkill.length).toBeGreaterThanOrEqual(standardCount);
+    // All original standard skills still present
+    for (const name of profiles.standard.include!) {
+      expect(afterAddSkill).toContain(name);
+    }
+  });
+});
+
+describe("alignment: non-arra skills are NEVER removed", () => {
+  beforeEach(cleanup);
+
+  it("external skill without 'installer: arra-oracle-skills-cli' is kept during alignment", async () => {
+    // Install standard (explicit)
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "standard",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    // Plant an external skill
+    await plantExternalSkill("my-custom-skill");
+
+    const beforeAlign = await listSkillDirs(SKILLS_DIR);
+    expect(beforeAlign).toContain("my-custom-skill");
+
+    // Align down to minimal (explicit) — should NOT remove the external skill
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "minimal",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    const afterAlign = await listSkillDirs(SKILLS_DIR);
+    // External skill must survive
+    expect(afterAlign).toContain("my-custom-skill");
+
+    // Minimal skills must be present
+    for (const name of MINIMAL_SKILLS) {
+      expect(afterAlign).toContain(name);
+    }
+  });
+});
+
+describe("alignment: pre-removal diff message is printed", () => {
+  beforeEach(cleanup);
+
+  it("alignment message is printed even under -y", async () => {
+    // Install standard (explicit) so there are skills to align away
+    await installSkills([TEST_AGENT], {
+      global: true,
+      profile: "standard",
+      profileExplicit: true,
+      yes: true,
+    });
+
+    // Capture stdout
+    const originalLog = console.log;
+    const messages: string[] = [];
+    console.log = (...args: any[]) => {
+      messages.push(args.join(" "));
+      originalLog(...args);
+    };
+
+    try {
+      // Align to minimal — should print the diff message even with yes: true
+      await installSkills([TEST_AGENT], {
+        global: true,
+        profile: "minimal",
+        profileExplicit: true,
+        yes: true, // skips interactive prompt, but diff must still print
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const alignMsg = messages.find((m) => m.includes("Profile alignment") && m.includes("REMOVE"));
+    expect(alignMsg).toBeDefined();
+    expect(alignMsg).toContain("minimal");
+  });
+});

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -111,7 +111,7 @@ describe("integration: OpenCode global install", () => {
     expect(content).toContain(skillPath);
   });
 
-  it("all skills should have corresponding commands", async () => {
+  it("all non-hidden arra-managed skills should have corresponding commands", async () => {
     if (!existsSync(GLOBAL_OPENCODE_SKILLS) || !existsSync(GLOBAL_OPENCODE_COMMANDS)) {
       console.log("Skipping: OpenCode not installed globally");
       return;
@@ -123,8 +123,18 @@ describe("integration: OpenCode global install", () => {
     const commands = await readdir(GLOBAL_OPENCODE_COMMANDS);
     const cmdFiles = commands.filter(c => c.endsWith('.md')).map(c => c.replace('.md', ''));
 
-    // Every skill should have a command
+    // Only arra-managed, non-hidden skills require command stubs
+    // Hidden skills (e.g. auto-retrospective) are installed without command stubs by design
     for (const skill of skillDirs) {
+      const skillMdPath = join(GLOBAL_OPENCODE_SKILLS, skill, "SKILL.md");
+      if (!existsSync(skillMdPath)) continue;
+
+      const content = await readFile(skillMdPath, "utf-8");
+      // Skip non-arra-managed skills (external / user-installed)
+      if (!content.includes("installer: arra-oracle-skills-cli")) continue;
+      // Skip hidden skills (they don't get command stubs)
+      if (content.includes("hidden: true")) continue;
+
       expect(cmdFiles).toContain(skill);
     }
   });

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -19,7 +19,7 @@ export function registerInstall(program: Command, version: string) {
     .option('--force-global', 'Install global skills even if a same-named local skill exists (#230)')
     .option('--shell', 'Force Bun.$ shell commands (use on Windows to test shell compatibility)')
     .option('--no-shell', 'Force Node.js fs operations (use on Unix if Bun.$ causes issues)')
-    .action(async (options) => {
+    .action(async (options, cmd) => {
       p.intro(`🔮 Oracle Skills Installer v${version}`);
 
       try {
@@ -93,10 +93,16 @@ export function registerInstall(program: Command, version: string) {
           return;
         }
 
+        // Detect whether --profile was explicitly passed on CLI or came from the default value.
+        // Commander exposes this via getOptionValueSource: 'cli' = user typed it, 'default' = default.
+        const profileSource = (cmd as any).getOptionValueSource?.('profile') ?? 'default';
+        const profileExplicit = profileSource === 'cli';
+
         await installSkills(targetAgents, {
           global: options.global,
           skills: options.skill,
           profile: options.profile,
+          profileExplicit,
           yes: options.yes,
           commands: options.withCommands,
           forceGlobal: options.forceGlobal,

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { homedir, tmpdir } from 'os';
+import { rm } from 'fs/promises';
 import * as p from '@clack/prompts';
 import { agents } from './agents.js';
 import type { Skill, InstallOptions } from './types.js';
@@ -106,6 +107,70 @@ export async function installSkills(
   if (skillsToInstall.length === 0) {
     p.log.error(`No matching skills found. Available: ${allSkills.map((s) => s.name).join(', ')}`);
     return;
+  }
+
+  // #285 Part 2 — Explicit-profile alignment.
+  // When --profile <name> was explicitly passed on the CLI (not the default value),
+  // remove arra-managed skills that are no longer in the target profile.
+  // Bare `install` (no flag) and `install -s <skill>` remain purely additive (#257 Bug 5).
+  if (options.profileExplicit && profileSkillNames !== null) {
+    const targetSet = new Set(skillsToInstall.map((s) => s.name));
+
+    for (const agentName of targetAgents) {
+      const agent = agents[agentName as keyof typeof agents];
+      if (!agent) continue;
+
+      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
+      if (!existsSync(skillsDir)) continue;
+
+      const installedDirs = readdirSync(skillsDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+        .map((d) => d.name);
+
+      const toRemove: string[] = [];
+      for (const name of installedDirs) {
+        if (targetSet.has(name)) continue;
+        if (await isOurSkill(join(skillsDir, name))) {
+          toRemove.push(name);
+        }
+      }
+
+      if (toRemove.length === 0) continue;
+
+      // Always print the diff (even under -y, per #267 follow-up)
+      console.log(`\n⚠  Profile alignment — will REMOVE arra-managed skills not in '${options.profile}': ${toRemove.join(', ')}\n`);
+
+      if (!options.yes) {
+        const confirmed = await p.confirm({
+          message: `Remove ${toRemove.length} skill(s) from ${agent.displayName}?`,
+        });
+        if (p.isCancel(confirmed) || !confirmed) {
+          p.log.info('Alignment cancelled — continuing with additive install only');
+          continue;
+        }
+      }
+
+      const shellMode: ShellMode = options.shellMode || 'auto';
+      for (const name of toRemove) {
+        const skillPath = join(skillsDir, name);
+        await rm(skillPath, { recursive: true, force: true });
+
+        // Also remove command stubs if commands mode is active
+        if (agent.commandsDir && options.commands) {
+          const commandsDir = options.global ? agent.globalCommandsDir! : join(process.cwd(), agent.commandsDir);
+          const ext = agent.commandFormat === 'toml' ? 'toml' : 'md';
+          const flatFile = join(commandsDir, `${name}.${ext}`);
+          if (existsSync(flatFile)) await rmf(flatFile, shellMode);
+        }
+
+        // Also remove from plugins if present
+        const pluginPath = join(homedir(), '.claude', 'plugins', name);
+        if (existsSync(pluginPath) && await isOurSkill(pluginPath)) {
+          await rm(pluginPath, { recursive: true, force: true });
+        }
+      }
+      p.log.info(`Alignment: removed ${toRemove.length} skill(s) not in '${options.profile}' profile`);
+    }
   }
 
   // Confirm installation
@@ -462,10 +527,11 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
 
     p.log.success(`${agent.displayName}: ${targetDir}`);
 
-    // #254 Bug 5: install is additive only. Skills present but not in the
-    // requested profile are kept — users must remove them via `uninstall`
-    // explicitly. The prior silent profile-downgrade caused capability loss
-    // without warning when running `install -g -y --profile <smaller>`.
+    // Install semantics (post-#285):
+    //   `install` (no flag)              → purely additive (Bug 5 protection, #257)
+    //   `install -s <skill>`             → purely additive
+    //   `install --profile <name>` (explicit) → ALIGN: remove arra-managed skills not in target
+    //                                            Non-arra skills NEVER touched.
   }
 
   spinner.stop(`Installed ${skillsToInstall.length} skills to ${targetAgents.length} agent(s)`);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -46,6 +46,7 @@ export interface InstallOptions {
   global?: boolean;
   skills?: string[];
   profile?: string;
+  profileExplicit?: boolean; // #285: true when --profile was explicitly passed on CLI (not default)
   yes?: boolean;
   agents?: string[];
   commands?: boolean; // Also install command stubs (for agents with commandsOptIn)

--- a/src/skills/go/SKILL.md
+++ b/src/skills/go/SKILL.md
@@ -22,6 +22,11 @@ disable-model-invocation: true
 /go disable watch       # disable specific skills
 ```
 
+> ⚠ NEW (#285): `/go <profile>` now ALIGNS your installed skills to the target profile.
+> arra-managed skills NOT in the target profile will be **removed**.
+> External / non-arra skills are never touched.
+> A pre-removal diff is shown before any deletion occurs.
+
 ---
 
 ## CLI Detection
@@ -60,11 +65,15 @@ $ARRA list -g
 $ARRA install -g --profile <name> -y
 ```
 
-Profiles: `standard`, `full`, `lab`
+Profiles: `minimal`, `standard`, `full`, `lab`
 
+- `/go minimal` → `$ARRA install -g --profile minimal -y`
 - `/go standard` → `$ARRA install -g --profile standard -y`
 - `/go full` → `$ARRA install -g --profile full -y`
 - `/go lab` → `$ARRA install -g --profile lab -y`
+
+> Note: passing `--profile` explicitly triggers alignment — arra-managed skills NOT in the target
+> are removed automatically. External skills are never touched.
 
 ### `/go cleanup` — fresh install (safe)
 
@@ -235,9 +244,10 @@ $ARRA uninstall -g -s <skill...> -y
 
 | Profile | Count | Description |
 |---------|-------|-------------|
-| **standard** | 14 | Daily driver — essential Oracle skills (default) |
-| **full** | 21 | All stable skills (excludes lab-only) |
-| **lab** | 29 | Everything including experimental |
+| **minimal** | 7 | Newcomer essentials — lite lifecycle, trace, update (token-optimized) |
+| **standard** | 13 | Daily driver — essential Oracle skills |
+| **full** | ~30 | All stable skills (excludes lab-only + minimal-only lite variants) |
+| **lab** | ~48 | Everything including experimental (excludes minimal-only lite variants) |
 
 ---
 


### PR DESCRIPTION
## Summary

Part 2 of #285. Implements the alignment semantic proposed in #267.

**Before**: `install --profile minimal` after `--profile full` was purely additive — you had to manually `uninstall` the delta. Silent downgrade was intentionally removed in #257 (Bug 5), but left no ergonomic way to switch profiles.

**After**: When `--profile <name>` is **explicitly** passed on the CLI, install now **aligns** — arra-managed skills not in the target profile are removed before installing.

## Constraint table

| Invocation | Behavior |
|---|---|
| `install` (no flag) | Purely additive — Bug 5 protection (#257) |
| `install -s <skill>` | Purely additive |
| `install --profile minimal` (explicit) | **ALIGN**: removes arra-managed skills not in target |
| External skill (no `installer:` frontmatter) | **NEVER touched** |
| Pre-removal diff | Printed **even under `-y`** |

## Files changed

- **`src/cli/types.ts`**: add `profileExplicit?: boolean` to `InstallOptions`
- **`src/cli/commands/install.ts`**: detect `cmd.getOptionValueSource('profile') === 'cli'`; pass `profileExplicit` into `installSkills`
- **`src/cli/installer.ts`**: alignment loop (before install confirmation); updated semantic comment; `import { rm } from 'fs/promises'`
- **`__tests__/installer-align.test.ts`**: 7 new tests covering all invariants (all passing)
- **`__tests__/integration.test.ts`**: fix pre-existing false negative (hidden skills don't get command stubs by design — test now skips them)
- **`src/skills/go/SKILL.md`**: add `minimal` to usage/profile table; document alignment behavior with `⚠ NEW (#285)` block
- **`CHANGELOG.md`**: Unreleased entry

## Test plan

- [x] `bun test __tests__/profiles.test.ts` — 31/31 pass (regression)
- [x] `bun test __tests__/e2e-features.test.ts` — 4/4 pass (includes full→standard additive regression)
- [x] `bun test __tests__/installer-align.test.ts` — 7/7 pass (new)
- [x] `bun test __tests__/` — 206/206 pass (full suite)
- [ ] CI: `bun run compile && bun test` on Ubuntu (GitHub Actions)

## Closes

- #267 (alignment proposal by neo-oracle)
- Part 2 of #285

## Builds on

- #286 — MINIMAL_ONLY_SKILLS classification (Part 1)
- #257 — Bug 5 additive-only protection (preserved)

🤖 ตอบโดย arra-oracle-skills-cli จาก [Human] → arra-oracle-skills-cli-oracle