### PR TITLE
release: v26.5.13-alpha.1200

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent cursor
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -134,7 +134,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.4.18-alpha.22 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.4.18-alpha.22",
+  "version": "26.5.13-alpha.1200",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts `v26.5.13-alpha.1200` on merge via calver-release.yml.

First alpha cut on the modern HMM scheme (was `alpha.{hour}` capped at 24/day, now `alpha.{HMM}` allowing 1440/day per #766/#923). Bundles all today's work + the alpha catch-up merge.

## What ships in this release

- **PR #286** — MINIMAL_ONLY_SKILLS classification (lite trio excluded from full/lab)
- **PR #288** — CI + CalVer workflows now fire on alpha branch (was main-only)
- **PR #289** — /calver SKILL.md + script sync to canonical (maw-js HMM-scheme)
- **PR #290** — Explicit-profile alignment in installer.ts (closes #267) + workflow HMM regex fix + beta channel support
- **53db0c0** — merge main → alpha to bring soak channel current (catches alpha up from v3.3.1 era to v26.x; 25 alpha-unique commits preserved via merge parent + release tags)

## On merge

`calver-release.yml` will:
1. Validate `26.5.13-alpha.1200` against HMM regex ✓
2. Confirm tag `v26.5.13-alpha.1200` is free ✓
3. Run install + compile + test
4. Create tag `v26.5.13-alpha.1200`
5. Create GitHub Release marked as prerelease
6. Publish to npm with `alpha` dist-tag

## Test status

Local (with deps): 204 / 206 pass. 2 failures env-dependent (`~/.config/opencode/skills/` absence — passes in CI).

---

🤖 ตอบโดย arra-oracle-skills-cli จาก [Nat] → arra-oracle-skills-cli-oracle