### PR TITLE
fix(#276): soul-sync uses release publish timestamps for same-day comparison

### DIFF
--- a/src/skills/oracle-family-scan/scripts/fleet-scan.ts
+++ b/src/skills/oracle-family-scan/scripts/fleet-scan.ts
@@ -2,7 +2,7 @@
 // fleet-scan.ts - My Oracle fleet status via gh CLI
 // Usage: bun fleet-scan.ts
 //
-// Part 1: Oracle births from arra-oracle-v3 issues (single API call)
+// Part 1: Oracle births from arra-oracle-v3 issues (paginated — no limit cap)
 // Part 2: Open issues across orgs
 // Part 3: Recently pushed Oracle repos
 
@@ -15,7 +15,10 @@ const BIRTH_PATTERN = /awaken|born|birth|enter.*chat|hello|สวัสดี|ar
 // --- Part 1: Oracle Births from arra-oracle-v3 ---
 type Birth = { number: number; title: string; date: string; author: string };
 
-const birthIssuesRaw = await $`gh issue list --repo ${ORACLE_REPO} --state all --limit 300 --json number,title,createdAt,author --jq '.[] | "\(.number)|\(.title)|\(.createdAt | split("T")[0])|\(.author.login)"'`.text();
+// Use gh api --paginate to fetch ALL issues (no 300-cap). GitHub /issues endpoint
+// includes PRs too, but BIRTH_PATTERN naturally excludes them — PRs don't match
+// "awaken|born|birth|..." title patterns.
+const birthIssuesRaw = await $`gh api --paginate "repos/${ORACLE_REPO}/issues?state=all&per_page=100" --jq '.[] | "\(.number)|\(.title)|\(.created_at[:10])|\(.user.login)"'`.text();
 
 const allBirths: Birth[] = birthIssuesRaw.trim().split("\n").filter(Boolean)
   .map(line => {


### PR DESCRIPTION
Bug: Step 3 of /oracle-soul-sync-update incorrectly suggested downgrading from alpha to stable when both were released on the same calendar day.

Root cause: version-string semver comparison says alpha < stable, even when alpha was cut LATER on the same day. Previous HOURS = LAT_HOUR - CUR_HOUR logic produced -22 → abs 22 → false 'downgrade!' suggestion.

Fix: query GitHub publishedAt timestamps via gh release view, compare epoch seconds. Release publish time is ground truth. If local TS >= latest TS, no update needed (with explanatory note).

Also bundles -beta channel support in tag_to_date regex (#754), and macOS BSD / GNU date compatibility fallbacks.

Closes #276.

---

🤖 ตอบโดย arra-oracle-skills-cli จาก [Nat] → arra-oracle-skills-cli-oracle