### PR TITLE
fix(#278): support Codex 0.128.0 plugin marketplace

### DIFF
--- a/__tests__/codex-plugin.test.ts
+++ b/__tests__/codex-plugin.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for Codex 0.128.0+ plugin marketplace support (issue #278).
+ *
+ * Verifies that installCodexPluginMarketplace():
+ *   1. Creates manifest.toml at the correct marketplace dir
+ *   2. Creates per-skill plugin.toml descriptors
+ *   3. Copies skill body as prompt.md
+ *   4. Updates config.toml with [marketplaces.*] and [plugins.*] entries
+ *   5. Skips hidden skills in plugin registration
+ *   6. Is idempotent (re-running does not duplicate config.toml sections)
+ *
+ * isCodexPluginMarketplace() and getCodexMarketplaceDir() are also exercised.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { readFile, mkdir, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import {
+  isCodexPluginMarketplace,
+  getCodexMarketplaceDir,
+  installCodexPluginMarketplace,
+} from "../src/cli/installer";
+import { discoverSkills } from "../src/cli/installer";
+import type { Skill } from "../src/cli/types";
+
+// ── Test directories ──────────────────────────────────────────────────────────
+
+const TEST_HOME = join(tmpdir(), `arra-codex-plugin-${Date.now()}`);
+const CODEX_DIR = join(TEST_HOME, ".codex");
+const CONFIG_PATH = join(CODEX_DIR, "config.toml");
+const MARKETPLACE_DIR = join(
+  TEST_HOME,
+  ".codex",
+  ".tmp",
+  "bundled-marketplaces",
+  "arra-oracle-skills"
+);
+
+// Minimal mock skills for unit tests (no disk I/O needed for descriptor tests)
+const MOCK_SKILLS: Skill[] = [
+  {
+    name: "rrr",
+    description: "Session retrospective with AI diary",
+    path: join(TEST_HOME, "skills", "rrr"), // non-existent path — prompt.md copy is skipped gracefully
+  },
+  {
+    name: "recap",
+    description: "Session orientation and awareness",
+    path: join(TEST_HOME, "skills", "recap"),
+  },
+  {
+    name: "secret-internal",
+    description: "Internal hidden skill",
+    path: join(TEST_HOME, "skills", "secret-internal"),
+    hidden: true,
+  },
+];
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await mkdir(CODEX_DIR, { recursive: true });
+  // Simulate Codex 0.128.0+ by creating a config.toml with existing marketplace entries
+  await writeFile(
+    CONFIG_PATH,
+    [
+      `[marketplaces.openai-bundled]`,
+      `source_type = "bundled"`,
+      ``,
+      `[marketplaces.openai-primary-runtime]`,
+      `source_type = "runtime"`,
+      ``,
+    ].join("\n")
+  );
+});
+
+afterAll(async () => {
+  if (existsSync(TEST_HOME)) await rm(TEST_HOME, { recursive: true });
+});
+
+// ── isCodexPluginMarketplace ──────────────────────────────────────────────────
+
+describe("isCodexPluginMarketplace", () => {
+  it("returns true when ~/.codex/config.toml exists", () => {
+    expect(isCodexPluginMarketplace(TEST_HOME)).toBe(true);
+  });
+
+  it("returns false for a home dir without config.toml", () => {
+    expect(isCodexPluginMarketplace(join(tmpdir(), "nonexistent-home-99999"))).toBe(false);
+  });
+});
+
+// ── getCodexMarketplaceDir ────────────────────────────────────────────────────
+
+describe("getCodexMarketplaceDir", () => {
+  it("returns path under the given homeDir", () => {
+    const dir = getCodexMarketplaceDir(TEST_HOME);
+    expect(dir).toBe(
+      join(TEST_HOME, ".codex", ".tmp", "bundled-marketplaces", "arra-oracle-skills")
+    );
+  });
+});
+
+// ── installCodexPluginMarketplace ─────────────────────────────────────────────
+
+describe("installCodexPluginMarketplace", () => {
+  // Run the installer once and test the results
+  beforeAll(async () => {
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
+      marketplaceDir: MARKETPLACE_DIR,
+      configPath: CONFIG_PATH,
+    });
+  });
+
+  it("creates the marketplace directory", () => {
+    expect(existsSync(MARKETPLACE_DIR)).toBe(true);
+  });
+
+  it("creates manifest.toml with correct name and version", async () => {
+    const manifestPath = join(MARKETPLACE_DIR, "manifest.toml");
+    expect(existsSync(manifestPath)).toBe(true);
+
+    const content = await readFile(manifestPath, "utf-8");
+    expect(content).toContain(`name = "arra-oracle-skills"`);
+    expect(content).toContain(`version = "26.5.0-test"`);
+    expect(content).toContain(`description =`);
+  });
+
+  it("creates plugins/ subdirectory", () => {
+    expect(existsSync(join(MARKETPLACE_DIR, "plugins"))).toBe(true);
+  });
+
+  it("creates a plugin.toml for each non-hidden skill", async () => {
+    for (const skill of MOCK_SKILLS) {
+      const pluginTomlPath = join(MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
+      expect(existsSync(pluginTomlPath)).toBe(true);
+
+      const content = await readFile(pluginTomlPath, "utf-8");
+      expect(content).toContain(`name = "${skill.name}"`);
+      expect(content).toContain(`command = "/${skill.name}"`);
+      expect(content).toContain(`version = "26.5.0-test"`);
+    }
+  });
+
+  it("plugin.toml includes the skill description", async () => {
+    const pluginTomlPath = join(MARKETPLACE_DIR, "plugins", "rrr", "plugin.toml");
+    const content = await readFile(pluginTomlPath, "utf-8");
+    expect(content).toContain("Session retrospective");
+  });
+
+  it("adds [marketplaces.arra-oracle-skills] to config.toml", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[marketplaces.arra-oracle-skills]`);
+    expect(content).toContain(`source_type = "local"`);
+    expect(content).toContain(`source = "${MARKETPLACE_DIR}"`);
+  });
+
+  it("preserves existing marketplace entries in config.toml", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[marketplaces.openai-bundled]`);
+    expect(content).toContain(`[marketplaces.openai-primary-runtime]`);
+  });
+
+  it("enables non-hidden skills as [plugins.*@arra-oracle-skills]", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[plugins."rrr@arra-oracle-skills"]`);
+    expect(content).toContain(`[plugins."recap@arra-oracle-skills"]`);
+    // Each enabled plugin should have enabled = true
+    expect(content).toContain(`enabled = true`);
+  });
+
+  it("does NOT register hidden skills as plugins in config.toml", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
+  });
+
+  it("is idempotent — re-running does not duplicate config.toml sections", async () => {
+    // Run again
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
+      marketplaceDir: MARKETPLACE_DIR,
+      configPath: CONFIG_PATH,
+    });
+
+    const content = await readFile(CONFIG_PATH, "utf-8");
+
+    // Count occurrences of the marketplace section header
+    const marketplaceCount = (content.match(/\[marketplaces\.arra-oracle-skills\]/g) || []).length;
+    expect(marketplaceCount).toBe(1);
+
+    // Count occurrences of the rrr plugin section header
+    const rrrPluginCount = (content.match(/\[plugins\."rrr@arra-oracle-skills"\]/g) || []).length;
+    expect(rrrPluginCount).toBe(1);
+  });
+});
+
+// ── Integration: uses real skills ─────────────────────────────────────────────
+
+describe("installCodexPluginMarketplace (real skills)", () => {
+  const REAL_MARKETPLACE_DIR = join(TEST_HOME, "real-marketplace");
+  const REAL_CONFIG_PATH = join(TEST_HOME, "real-config.toml");
+
+  beforeAll(async () => {
+    // Seed a minimal config.toml
+    await writeFile(
+      REAL_CONFIG_PATH,
+      `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`
+    );
+
+    const skills = await discoverSkills();
+    expect(skills.length).toBeGreaterThan(0);
+
+    await installCodexPluginMarketplace(
+      skills.slice(0, 3), // Use first 3 skills to keep the test fast
+      "26.5.0-integ",
+      "no-shell",
+      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH }
+    );
+  });
+
+  it("creates plugin.toml files for real skills", async () => {
+    const skills = await discoverSkills();
+    const tested = skills.slice(0, 3);
+
+    for (const skill of tested) {
+      const pluginToml = join(REAL_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
+      expect(existsSync(pluginToml)).toBe(true);
+      const content = await readFile(pluginToml, "utf-8");
+      expect(content).toContain(`name = "${skill.name}"`);
+    }
+  });
+
+  it("registers real skills in config.toml", async () => {
+    const skills = await discoverSkills();
+    const tested = skills.slice(0, 3);
+
+    const config = await readFile(REAL_CONFIG_PATH, "utf-8");
+    expect(config).toContain(`[marketplaces.arra-oracle-skills]`);
+
+    for (const skill of tested) {
+      if (skill.hidden) continue;
+      expect(config).toContain(`[plugins."${skill.name}@arra-oracle-skills"]`);
+    }
+  });
+});

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -17,6 +17,120 @@ import {
 } from './skill-source.js';
 import pkg from '../../package.json' with { type: 'json' };
 
+// ── Codex 0.128.0+ plugin marketplace helpers ────────────────────────────────
+
+/**
+ * Detect if Codex 0.128.0+ plugin marketplace mode is active.
+ * Codex 0.128.0 creates ~/.codex/config.toml; older versions do not.
+ */
+export function isCodexPluginMarketplace(homeDir?: string): boolean {
+  const home = homeDir ?? homedir();
+  return existsSync(join(home, '.codex', 'config.toml'));
+}
+
+/** Return the arra-oracle-skills marketplace bundle directory path. */
+export function getCodexMarketplaceDir(homeDir?: string): string {
+  const home = homeDir ?? homedir();
+  return join(home, '.codex', '.tmp', 'bundled-marketplaces', 'arra-oracle-skills');
+}
+
+/**
+ * Install skills for Codex 0.128.0+ plugin marketplace.
+ *
+ * Creates:
+ *   <marketplaceDir>/manifest.toml
+ *   <marketplaceDir>/plugins/<skill>/plugin.toml
+ *   <marketplaceDir>/plugins/<skill>/prompt.md   (skill body)
+ *
+ * Then updates ~/.codex/config.toml with:
+ *   [marketplaces.arra-oracle-skills]  source_type + source
+ *   [plugins."<skill>@arra-oracle-skills"]  enabled = true
+ */
+export async function installCodexPluginMarketplace(
+  skills: Skill[],
+  version: string,
+  shellMode: ShellMode,
+  opts?: { marketplaceDir?: string; configPath?: string }
+): Promise<void> {
+  const marketplaceDir = opts?.marketplaceDir ?? getCodexMarketplaceDir();
+  const configPath = opts?.configPath ?? join(homedir(), '.codex', 'config.toml');
+
+  // ── 1. Create marketplace bundle directory ─────────────────────────────────
+  await mkdirp(marketplaceDir, shellMode);
+
+  // ── 2. Write marketplace manifest ─────────────────────────────────────────
+  const manifestContent = [
+    `name = "arra-oracle-skills"`,
+    `version = "${version}"`,
+    `description = "Oracle skills for Codex by Soul Brews Studio"`,
+    ``,
+  ].join('\n');
+  await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+
+  // ── 3. Per-skill plugin directories ───────────────────────────────────────
+  const pluginsDir = join(marketplaceDir, 'plugins');
+  await mkdirp(pluginsDir, shellMode);
+
+  for (const skill of skills) {
+    const skillPluginDir = join(pluginsDir, skill.name);
+    await mkdirp(skillPluginDir, shellMode);
+
+    // plugin.toml descriptor
+    const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const pluginToml = [
+      `name = "${skill.name}"`,
+      `description = "${escapedDesc}"`,
+      `version = "${version}"`,
+      `command = "/${skill.name}"`,
+      ``,
+    ].join('\n');
+    await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
+
+    // prompt.md — skill body for Codex to execute
+    if (isCompiled()) {
+      // VFS mode: write entire skill tree (includes SKILL.md + any extras)
+      await writeSkillToDir(skill.name, skillPluginDir);
+    } else {
+      // Filesystem mode: copy SKILL.md as prompt.md
+      const skillMdPath = join(skill.path, 'SKILL.md');
+      if (existsSync(skillMdPath)) {
+        const content = await Bun.file(skillMdPath).text();
+        await Bun.write(join(skillPluginDir, 'prompt.md'), content);
+      }
+    }
+  }
+
+  // ── 4. Update ~/.codex/config.toml ────────────────────────────────────────
+  let configContent = existsSync(configPath) ? await Bun.file(configPath).text() : '';
+
+  // Add marketplace registration if not already present
+  const marketplaceSection = `[marketplaces.arra-oracle-skills]`;
+  if (!configContent.includes(marketplaceSection)) {
+    configContent += [
+      ``,
+      `${marketplaceSection}`,
+      `source_type = "local"`,
+      `source = "${marketplaceDir}"`,
+      ``,
+    ].join('\n');
+  }
+
+  // Enable each non-hidden skill as a plugin
+  for (const skill of skills) {
+    if (skill.hidden) continue;
+    const pluginKey = `[plugins."${skill.name}@arra-oracle-skills"]`;
+    if (!configContent.includes(pluginKey)) {
+      configContent += [
+        `${pluginKey}`,
+        `enabled = true`,
+        ``,
+      ].join('\n');
+    }
+  }
+
+  await Bun.write(configPath, configContent);
+}
+
 // Re-export discoverSkills from skill-source
 export const discoverSkills = _discoverSkills;
 
@@ -523,6 +637,14 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
         await cp(hookSrc, join(pluginDir, 'arra-oracle-skills.ts'), shellMode);
         p.log.success(`OpenCode plugin: ${pluginDir}/arra-oracle-skills.ts`);
       }
+    }
+
+    // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
+    // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
+    // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
+    if (agentName === 'codex' && isCodexPluginMarketplace()) {
+      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
+      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);


### PR DESCRIPTION
## Summary

Fixes #278 — Codex 0.128.0 ignores `~/.codex/skills/` + `prompts/` because the runtime switched to a **plugin marketplace** system.

- Detect Codex 0.128.0+ by checking if `~/.codex/config.toml` exists
- When detected, write a plugin marketplace bundle to `~/.codex/.tmp/bundled-marketplaces/arra-oracle-skills/` with:
  - `manifest.toml` (name, version, description)
  - `plugins/<skill>/plugin.toml` (per-skill descriptor with name, description, command)
  - `plugins/<skill>/prompt.md` (SKILL.md content for Codex to execute)
- Update `~/.codex/config.toml` with `[marketplaces.arra-oracle-skills]` registration and `[plugins."<skill>@arra-oracle-skills"] enabled = true` for each non-hidden skill
- Keep the legacy `~/.codex/skills/` + `~/.codex/prompts/` install path intact for backward compat with Codex < 0.128.0
- All three new helpers (`isCodexPluginMarketplace`, `getCodexMarketplaceDir`, `installCodexPluginMarketplace`) are exported for direct testing

## Files changed

- `src/cli/installer.ts` — +122 lines: three new exported functions + call site in `installSkills()`
- `__tests__/codex-plugin.test.ts` — new file: 15 tests

## Test results

```
bun test __tests__/codex-plugin.test.ts
 15 pass
 0 fail
 43 expect() calls
```

Full suite: 228 pass, 2 fail (pre-existing OpenCode env-dependent failures, unrelated to this PR)

---

🤖 ตอบโดย arra-oracle-skills-cli จาก [Nat] → arra-oracle-skills-cli-oracle