### PR TITLE
docs(#271): replace arra_learn() pseudocode with explicit two-layer pattern

### DIFF
--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -544,10 +544,20 @@ This does NOT re-run the wizard or rebuild structure. It refreshes identity:
    - Current date as "re-awakened" date
    - Any new insights from learnings
    - Updated family context
-5. **Log re-awakening** — write retrospective via `/rrr` and sync via `arra_learn`:
-   ```
-   arra_learn({ pattern: "Re-awakened [oracle-name]: [summary of what changed]", concepts: ["reawaken", "identity"], source: "awaken --reawaken" })
-   ```
+5. **Log re-awakening** — write retrospective via `/rrr` and save the lesson (two-layer pattern):
+   1. Write to `ψ/memory/learnings/YYYY-MM-DD_reawaken-<oracle-name>.md` with frontmatter:
+      ```yaml
+      ---
+      pattern: "Re-awakened [oracle-name]: [summary of what changed]"
+      date: <today>
+      source: awaken --reawaken
+      concepts: ["reawaken", "identity"]
+      ---
+
+      # Re-awakening: [oracle-name]
+      [summary of what changed]
+      ```
+   2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 **Output:**
 

--- a/src/skills/bampenpien/SKILL.md
+++ b/src/skills/bampenpien/SKILL.md
@@ -266,15 +266,22 @@ mkdir -p "$PSI/memory/resonance/practice"
 [one word they used, or Oracle's read]
 ```
 
-### Sync to Oracle (if available)
+### Sync to Oracle (if available, two-layer pattern)
 
-```
-arra_learn({
-  pattern: "บำเพ็ญเพียร: [human] practices with [hard thing] — believes [belief]",
-  concepts: ["bampenpien", "practice", "belief", "perseverance"],
-  source: "bampenpien: [repo-name]"
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_bampenpien-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "บำเพ็ญเพียร: [human] practices with [hard thing] — believes [belief]"
+   date: <today>
+   source: bampenpien: [repo-name]
+   concepts: ["bampenpien", "practice", "belief", "perseverance"]
+   ---
+
+   # บำเพ็ญเพียร: [hard thing]
+   <session summary from the practice log>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ---
 

--- a/src/skills/i-believed/SKILL.md
+++ b/src/skills/i-believed/SKILL.md
@@ -226,15 +226,22 @@ mkdir -p "$PSI/memory/resonance/beliefs"
  Connect to the larger story: what was built, what was risked, what survived.]
 ```
 
-### Sync to Oracle (if available)
+### Sync to Oracle (if available, two-layer pattern)
 
-```
-arra_learn({
-  pattern: "Belief received: [human] [believed/believes] in [target] — [context]",
-  concepts: ["belief", "trust", "resonance", target-tags],
-  source: "i-believed: [repo-name]"
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_belief-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "Belief received: [human] [believed/believes] in [target] — [context]"
+   date: <today>
+   source: i-believed: [repo-name]
+   concepts: ["belief", "trust", "resonance", <target-tags>]
+   ---
+
+   # Belief: [target]
+   [context and meaning]
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ---
 

--- a/src/skills/incubate/SKILL.md
+++ b/src/skills/incubate/SKILL.md
@@ -577,13 +577,22 @@ The pattern is auto-added to `.gitignore` on first `/incubate` run (#250). If yo
 
 After incubation work, log to Oracle so it's discoverable via `/trace`:
 
-```
-arra_learn({
-  pattern: "Incubated [REPO]: [what was done — PR#, branch, outcome]",
-  concepts: ["incubate", "development", relevant-tags],
-  source: "incubate: OWNER/REPO"
-})
-```
+### Save the lesson (two-layer pattern)
+
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_incubate-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "Incubated [REPO]: [what was done — PR#, branch, outcome]"
+   date: <today>
+   source: incubate: OWNER/REPO
+   concepts: ["incubate", "development", <relevant-tags>]
+   ---
+
+   # Incubated [REPO]
+   <body: what was done, PR#, branch, outcome>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 This connects `/incubate` to the shared knowledge layer.
 

--- a/src/skills/learn/SKILL.md
+++ b/src/skills/learn/SKILL.md
@@ -361,13 +361,22 @@ For Oracles that want to commit docs but ignore symlinks:
 
 After writing docs, log the learning to Oracle so it's discoverable via `/trace`:
 
-```
-arra_learn({
-  pattern: "Learned [REPO]: [2-3 key insights]",
-  concepts: ["learn", "codebase", relevant-tags],
-  source: "learn: OWNER/REPO"
-})
-```
+### Save the lesson (two-layer pattern)
+
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "Learned [REPO]: [2-3 key insights]"
+   date: <today>
+   source: learn: OWNER/REPO
+   concepts: ["learn", "codebase", <relevant-tags>]
+   ---
+
+   # Learned [REPO]
+   <2-3 key insights in body>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 This connects `/learn` to the shared knowledge layer — future `/trace` queries find what was learned.
 

--- a/src/skills/oracle-family-scan/SKILL.md
+++ b/src/skills/oracle-family-scan/SKILL.md
@@ -314,14 +314,22 @@ arra_trace({
 })
 ```
 
-After finding new Oracle:
+After finding new Oracle, save the lesson (two-layer pattern):
 
-```
-arra_learn({
-  pattern: "New Oracle: [NAME] — [HUMAN] — [DATE]",
-  concepts: ["oracle-family", "birth"]
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_new-oracle-<name>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "New Oracle: [NAME] — [HUMAN] — [DATE]"
+   date: <today>
+   source: oracle-family-scan
+   concepts: ["oracle-family", "birth"]
+   ---
+
+   # New Oracle: [NAME]
+   [birth story, human, theme]
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ---
 

--- a/src/skills/philosophy/SKILL.md
+++ b/src/skills/philosophy/SKILL.md
@@ -41,7 +41,7 @@ date "+🕐 %H:%M %Z (%A %d %B %Y)"
 
 - Archive, don't erase
 - Use `arra_trace()` for searches
-- Use `arra_learn()` for findings
+- Write to `ψ/memory/learnings/` (two-layer pattern) for findings
 - Use `arra_supersede()` to mark outdated (preserves chain)
 - Git history preserves evolution
 
@@ -188,7 +188,7 @@ Layer 4: PRINCIPLES    → Core wisdom (awakening)
 2. Dig into results
 3. `/rrr` to reflect
 4. Pattern emerges → **Awakening**
-5. `arra_learn()` to preserve
+5. Write to `ψ/memory/learnings/` (two-layer pattern) to preserve
 
 ### The Insight
 

--- a/src/skills/project/project-manager.md
+++ b/src/skills/project/project-manager.md
@@ -122,7 +122,7 @@ laris-co/arra-oracle-v3: ~/Code/github.com/laris-co/arra-oracle-v3
 2. **Score** → Rank files by type (retrospectives=10, docs=5, CLAUDE.md=0)
 3. **Filter** → Skip i18n, CLAUDE.md, low-value files
 4. **Extract** → Get key content from high-value files
-5. **Learn** → Call `arra_learn` with source attribution
+5. **Learn** → Write to `ψ/memory/learnings/` (two-layer pattern: learning file + auto-memory)
 
 ## Offload Pattern
 

--- a/src/skills/resonance/SKILL.md
+++ b/src/skills/resonance/SKILL.md
@@ -65,15 +65,22 @@ Write to: `$PSI/memory/resonance/YYYY-MM-DD_HHMM_slug.md`
 [concept tags for future search]
 ```
 
-### 3. Sync to Oracle (if available)
+### 3. Sync to Oracle (if available, two-layer pattern)
 
-```
-arra_learn({
-  pattern: "[resonance title]: [what resonated]",
-  concepts: ["resonance", ...tags],
-  source: "resonance: [repo-name]"
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_resonance-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "[resonance title]: [what resonated]"
+   date: <today>
+   source: resonance: [repo-name]
+   concepts: ["resonance", <tags>]
+   ---
+
+   # [resonance title]
+   [what resonated and why]
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ### 4. Output
 

--- a/src/skills/retrospective/SKILL.md
+++ b/src/skills/retrospective/SKILL.md
@@ -32,11 +32,22 @@ Include:
 - Lessons Learned
 - Next Steps
 
-### 3. Sync to Oracle
+### 3. Sync to Oracle (two-layer pattern)
 
-```
-arra_learn({ pattern: [lesson], concepts: [tags], source: "retrospective: REPO" })
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: <lesson in one line>
+   date: <today>
+   source: retrospective: REPO
+   concepts: [<tags>]
+   ---
+
+   # <lesson title>
+   <body>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 Do NOT git add ψ/ — vault is shared state.
 

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -98,11 +98,22 @@ Write immediately, no prompts. Include:
 
 **Path**: `$PSI/memory/learnings/YYYY-MM-DD_slug.md`
 
-### 4. Oracle Sync
+### 4. Oracle Sync (two-layer pattern)
 
-```
-arra_learn({ pattern: [lesson content], concepts: [tags], source: "rrr: REPO" })
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: <lesson learned in one line>
+   date: <today>
+   source: rrr: REPO
+   concepts: [<tags>]
+   ---
+
+   # <lesson title>
+   <body>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ### 5. Save
 


### PR DESCRIPTION
## Summary

- Replaces `arra_learn({ pattern, concepts, source })` pseudocode with the explicit two-layer persistence pattern across 11 occurrences in 6+ skill files
- `arra_learn` has no runtime implementation in this CLI — the file write IS the persistence
- Two-layer pattern: (1) write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with YAML frontmatter, (2) Oracle auto-memory picks up the file automatically

## Files changed

- `src/skills/rrr/SKILL.md` — Oracle Sync step
- `src/skills/retrospective/SKILL.md` — Sync to Oracle step
- `src/skills/learn/SKILL.md` — Trace Connection section
- `src/skills/bampenpien/SKILL.md` — Sync to Oracle section
- `src/skills/awaken/SKILL.md` — Log re-awakening step (--reawaken flow)
- `src/skills/oracle-family-scan/SKILL.md` — Oracle Integration section
- `src/skills/incubate/SKILL.md` — Trace Connection section
- `src/skills/i-believed/SKILL.md` — Sync to Oracle section
- `src/skills/resonance/SKILL.md` — Sync to Oracle section
- `src/skills/philosophy/SKILL.md` — two inline list references
- `src/skills/project/project-manager.md` — Index Pattern step 5

## Test results

213 pass, 2 pre-existing failures (integration test expects `retrospective` skill to be installed — not caused by this PR).

## Closes

Fixes #271

Credit: proposal and validation by @natman95 (confirmed working on echo-oracle session `3515d514`).

---

🤖 ตอบโดย arra-oracle-skills-cli จาก [Nat] → arra-oracle-skills-cli-oracle