### PR TITLE
docs(CLAUDE.md): always alpha, never main — close the bug-fix loophole

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,30 +103,34 @@ Skills with `hooks/hooks.json` are installed as Claude Code plugins:
 
 Currently `ralph-loop-soulbrews` has hooks.
 
-## Branch Strategy
+## Branch Strategy — **always alpha, never main**
 
-**NEVER push directly to main.** Always use branches:
+**Every PR targets `alpha`. No exceptions for bug fixes or features.** `main` is reserved for stable cuts that happen as alpha → main release PRs (and only those).
 
-| Work Type | Branch | Merge |
-|-----------|--------|-------|
-| Alpha features | `alpha` | PR → main when stable |
-| Bug fixes | `fix/name` | PR → alpha or main |
-| Features | `feat/name` | PR → alpha |
+| Work Type | Branch | PR base |
+|-----------|--------|---------|
+| Anything (feature, fix, refactor, docs) | `feat/*` or `fix/*` | **always `--base alpha`** |
+| Stable cut | `alpha` | `--base main` (rare, deliberate, by /release-alpha or similar) |
+
+`gh pr create` defaults to the repo's default branch (`main`) — that default is the bug. You MUST pass `--base alpha` explicitly:
+
+```bash
+gh pr create --base alpha --head feat/my-thing --title "..."
+```
+
+A PreToolUse safety hook at `~/.claude/hooks/safety-pr-base.sh` blocks any `gh pr create` against this repo that targets `main` or omits `--base`. If the hook fires, fix the flag — don't bypass it.
 
 ```bash
 # Alpha work (default)
 git checkout alpha
-# ... work, commit, push ...
-# Tag alpha releases from alpha branch
-git tag v3.3.0-alpha.N
+# ... work, commit, push, PR → alpha ...
 
-# Stable release
-gh pr create --base main --head alpha
-# Merge PR → tag stable
+# Stable release (rare)
+gh pr create --base main --head alpha --title "release: vYY.M.D"
 ```
 
 **`/alpha-feature`** commits to `alpha` branch.
-**`/release-alpha`** tags from `alpha` branch.
+**`/release-alpha`** tags from `alpha` branch (and only it should ever target main).
 
 ## Version Workflow
 

--- a/__tests__/codex-plugin.test.ts
+++ b/__tests__/codex-plugin.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for Codex 0.128.0+ plugin marketplace support (issue #278).
+ *
+ * Verifies that installCodexPluginMarketplace():
+ *   1. Creates manifest.toml at the correct marketplace dir
+ *   2. Creates per-skill plugin.toml descriptors
+ *   3. Copies skill body as prompt.md
+ *   4. Updates config.toml with [marketplaces.*] and [plugins.*] entries
+ *   5. Skips hidden skills in plugin registration
+ *   6. Is idempotent (re-running does not duplicate config.toml sections)
+ *
+ * isCodexPluginMarketplace() and getCodexMarketplaceDir() are also exercised.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { readFile, mkdir, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import {
+  isCodexPluginMarketplace,
+  getCodexMarketplaceDir,
+  installCodexPluginMarketplace,
+} from "../src/cli/installer";
+import { discoverSkills } from "../src/cli/installer";
+import type { Skill } from "../src/cli/types";
+
+// ── Test directories ──────────────────────────────────────────────────────────
+
+const TEST_HOME = join(tmpdir(), `arra-codex-plugin-${Date.now()}`);
+const CODEX_DIR = join(TEST_HOME, ".codex");
+const CONFIG_PATH = join(CODEX_DIR, "config.toml");
+const MARKETPLACE_DIR = join(
+  TEST_HOME,
+  ".codex",
+  ".tmp",
+  "bundled-marketplaces",
+  "arra-oracle-skills"
+);
+
+// Minimal mock skills for unit tests (no disk I/O needed for descriptor tests)
+const MOCK_SKILLS: Skill[] = [
+  {
+    name: "rrr",
+    description: "Session retrospective with AI diary",
+    path: join(TEST_HOME, "skills", "rrr"), // non-existent path — prompt.md copy is skipped gracefully
+  },
+  {
+    name: "recap",
+    description: "Session orientation and awareness",
+    path: join(TEST_HOME, "skills", "recap"),
+  },
+  {
+    name: "secret-internal",
+    description: "Internal hidden skill",
+    path: join(TEST_HOME, "skills", "secret-internal"),
+    hidden: true,
+  },
+];
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await mkdir(CODEX_DIR, { recursive: true });
+  // Simulate Codex 0.128.0+ by creating a config.toml with existing marketplace entries
+  await writeFile(
+    CONFIG_PATH,
+    [
+      `[marketplaces.openai-bundled]`,
+      `source_type = "bundled"`,
+      ``,
+      `[marketplaces.openai-primary-runtime]`,
+      `source_type = "runtime"`,
+      ``,
+    ].join("\n")
+  );
+});
+
+afterAll(async () => {
+  if (existsSync(TEST_HOME)) await rm(TEST_HOME, { recursive: true });
+});
+
+// ── isCodexPluginMarketplace ──────────────────────────────────────────────────
+
+describe("isCodexPluginMarketplace", () => {
+  it("returns true when ~/.codex/config.toml exists", () => {
+    expect(isCodexPluginMarketplace(TEST_HOME)).toBe(true);
+  });
+
+  it("returns false for a home dir without config.toml", () => {
+    expect(isCodexPluginMarketplace(join(tmpdir(), "nonexistent-home-99999"))).toBe(false);
+  });
+});
+
+// ── getCodexMarketplaceDir ────────────────────────────────────────────────────
+
+describe("getCodexMarketplaceDir", () => {
+  it("returns path under the given homeDir", () => {
+    const dir = getCodexMarketplaceDir(TEST_HOME);
+    expect(dir).toBe(
+      join(TEST_HOME, ".codex", ".tmp", "bundled-marketplaces", "arra-oracle-skills")
+    );
+  });
+});
+
+// ── installCodexPluginMarketplace ─────────────────────────────────────────────
+
+describe("installCodexPluginMarketplace", () => {
+  // Run the installer once and test the results
+  beforeAll(async () => {
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
+      marketplaceDir: MARKETPLACE_DIR,
+      configPath: CONFIG_PATH,
+    });
+  });
+
+  it("creates the marketplace directory", () => {
+    expect(existsSync(MARKETPLACE_DIR)).toBe(true);
+  });
+
+  it("creates manifest.toml with correct name and version", async () => {
+    const manifestPath = join(MARKETPLACE_DIR, "manifest.toml");
+    expect(existsSync(manifestPath)).toBe(true);
+
+    const content = await readFile(manifestPath, "utf-8");
+    expect(content).toContain(`name = "arra-oracle-skills"`);
+    expect(content).toContain(`version = "26.5.0-test"`);
+    expect(content).toContain(`description =`);
+  });
+
+  it("creates plugins/ subdirectory", () => {
+    expect(existsSync(join(MARKETPLACE_DIR, "plugins"))).toBe(true);
+  });
+
+  it("creates a plugin.toml for each non-hidden skill", async () => {
+    for (const skill of MOCK_SKILLS) {
+      const pluginTomlPath = join(MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
+      expect(existsSync(pluginTomlPath)).toBe(true);
+
+      const content = await readFile(pluginTomlPath, "utf-8");
+      expect(content).toContain(`name = "${skill.name}"`);
+      expect(content).toContain(`command = "/${skill.name}"`);
+      expect(content).toContain(`version = "26.5.0-test"`);
+    }
+  });
+
+  it("plugin.toml includes the skill description", async () => {
+    const pluginTomlPath = join(MARKETPLACE_DIR, "plugins", "rrr", "plugin.toml");
+    const content = await readFile(pluginTomlPath, "utf-8");
+    expect(content).toContain("Session retrospective");
+  });
+
+  it("adds [marketplaces.arra-oracle-skills] to config.toml", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[marketplaces.arra-oracle-skills]`);
+    expect(content).toContain(`source_type = "local"`);
+    expect(content).toContain(`source = "${MARKETPLACE_DIR}"`);
+  });
+
+  it("preserves existing marketplace entries in config.toml", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[marketplaces.openai-bundled]`);
+    expect(content).toContain(`[marketplaces.openai-primary-runtime]`);
+  });
+
+  it("enables non-hidden skills as [plugins.*@arra-oracle-skills]", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[plugins."rrr@arra-oracle-skills"]`);
+    expect(content).toContain(`[plugins."recap@arra-oracle-skills"]`);
+    // Each enabled plugin should have enabled = true
+    expect(content).toContain(`enabled = true`);
+  });
+
+  it("does NOT register hidden skills as plugins in config.toml", async () => {
+    const content = await readFile(CONFIG_PATH, "utf-8");
+    expect(content).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
+  });
+
+  it("is idempotent — re-running does not duplicate config.toml sections", async () => {
+    // Run again
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
+      marketplaceDir: MARKETPLACE_DIR,
+      configPath: CONFIG_PATH,
+    });
+
+    const content = await readFile(CONFIG_PATH, "utf-8");
+
+    // Count occurrences of the marketplace section header
+    const marketplaceCount = (content.match(/\[marketplaces\.arra-oracle-skills\]/g) || []).length;
+    expect(marketplaceCount).toBe(1);
+
+    // Count occurrences of the rrr plugin section header
+    const rrrPluginCount = (content.match(/\[plugins\."rrr@arra-oracle-skills"\]/g) || []).length;
+    expect(rrrPluginCount).toBe(1);
+  });
+});
+
+// ── Integration: uses real skills ─────────────────────────────────────────────
+
+describe("installCodexPluginMarketplace (real skills)", () => {
+  const REAL_MARKETPLACE_DIR = join(TEST_HOME, "real-marketplace");
+  const REAL_CONFIG_PATH = join(TEST_HOME, "real-config.toml");
+
+  beforeAll(async () => {
+    // Seed a minimal config.toml
+    await writeFile(
+      REAL_CONFIG_PATH,
+      `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`
+    );
+
+    const skills = await discoverSkills();
+    expect(skills.length).toBeGreaterThan(0);
+
+    await installCodexPluginMarketplace(
+      skills.slice(0, 3), // Use first 3 skills to keep the test fast
+      "26.5.0-integ",
+      "no-shell",
+      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH }
+    );
+  });
+
+  it("creates plugin.toml files for real skills", async () => {
+    const skills = await discoverSkills();
+    const tested = skills.slice(0, 3);
+
+    for (const skill of tested) {
+      const pluginToml = join(REAL_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
+      expect(existsSync(pluginToml)).toBe(true);
+      const content = await readFile(pluginToml, "utf-8");
+      expect(content).toContain(`name = "${skill.name}"`);
+    }
+  });
+
+  it("registers real skills in config.toml", async () => {
+    const skills = await discoverSkills();
+    const tested = skills.slice(0, 3);
+
+    const config = await readFile(REAL_CONFIG_PATH, "utf-8");
+    expect(config).toContain(`[marketplaces.arra-oracle-skills]`);
+
+    for (const skill of tested) {
+      if (skill.hidden) continue;
+      expect(config).toContain(`[plugins."${skill.name}@arra-oracle-skills"]`);
+    }
+  });
+});

--- a/__tests__/dig-skill.test.ts
+++ b/__tests__/dig-skill.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for fix #274 — /dig --deep must scan subagent session files.
+ *
+ * Root cause: dig.py only scanned depth-1 *.jsonl files.
+ * The --deep flag was parsed by SKILL.md but silently ignored by the script,
+ * causing 17,798 subagent sessions (~95% of Jan-Feb 2026 history) to be missed.
+ *
+ * Fix: dig.py v3 scans <project>/<uuid>/subagents/*.jsonl when --deep is passed.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { spawnSync } from "child_process";
+
+const FIXTURE_DIR = join(tmpdir(), `dig-test-${Date.now()}`);
+const DIG_PY = join(process.cwd(), "src/skills/dig/scripts/dig.py");
+
+// Minimal valid JSONL session entry
+function makeSession(id: string, ts: string, summary: string): string {
+  const lines = [
+    JSON.stringify({
+      type: "user",
+      timestamp: ts,
+      message: { content: [{ type: "text", text: summary }] },
+    }),
+    JSON.stringify({
+      type: "assistant",
+      timestamp: ts,
+      message: { content: [{ type: "text", text: "OK" }] },
+    }),
+  ];
+  return lines.join("\n") + "\n";
+}
+
+beforeAll(async () => {
+  // Create fixture directory structure:
+  //
+  //   FIXTURE_DIR/
+  //     top-session-aaa.jsonl          ← top-level session (always visible)
+  //     some-uuid-1234/
+  //       subagents/
+  //         subagent-bbb.jsonl         ← subagent session (only visible with --deep)
+  //         empty-file.jsonl           ← should be skipped (size 0)
+
+  await mkdir(FIXTURE_DIR, { recursive: true });
+
+  // Top-level session
+  await writeFile(
+    join(FIXTURE_DIR, "top-session-aaaaaaaaaaaa.jsonl"),
+    makeSession("aaaaaaaaaaaa", "2026-02-01T08:00:00Z", "Top-level session")
+  );
+
+  // Subagent session dir
+  const subDir = join(FIXTURE_DIR, "some-uuid-1234", "subagents");
+  await mkdir(subDir, { recursive: true });
+
+  await writeFile(
+    join(subDir, "subagent-bbbbbbbbbbbb.jsonl"),
+    makeSession("bbbbbbbbbbbb", "2026-02-01T09:00:00Z", "Subagent session")
+  );
+
+  // Empty file — should be skipped
+  await writeFile(join(subDir, "empty-cccccccccccc.jsonl"), "");
+});
+
+afterAll(async () => {
+  if (existsSync(FIXTURE_DIR)) {
+    await rm(FIXTURE_DIR, { recursive: true });
+  }
+});
+
+function runDig(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync("python3", [DIG_PY, ...args], {
+    env: {
+      ...process.env,
+      PROJECT_DIRS: FIXTURE_DIR,
+      // Force UTC so timestamps are deterministic
+      MAW_DISPLAY_TZ: "0",
+    },
+    encoding: "utf-8",
+    timeout: 15_000,
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    exitCode: result.status ?? -1,
+  };
+}
+
+// ── Source file checks ─────────────────────────────────────────────────────────
+
+describe("fix #274 — dig.py source", () => {
+  it("dig.py exists at expected path", () => {
+    expect(existsSync(DIG_PY)).toBe(true);
+  });
+
+  it("dig.py contains --deep handling", async () => {
+    const content = await Bun.file(DIG_PY).text();
+    expect(content).toContain("--deep");
+    expect(content).toContain("subagents");
+  });
+
+  it("dig.py contains timezone detection", async () => {
+    const content = await Bun.file(DIG_PY).text();
+    expect(content).toContain("detect_tz");
+    expect(content).toContain("MAW_DISPLAY_TZ");
+  });
+});
+
+// ── Default mode (no --deep) — backward compatibility ─────────────────────────
+
+describe("fix #274 — default mode (no --deep) backward compatible", () => {
+  it("exits with code 0", () => {
+    const { exitCode } = runDig(["10"]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("outputs valid JSON array", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  it("finds the top-level session", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    expect(sessions.length).toBeGreaterThanOrEqual(1);
+    const found = sessions.find((s) => s.summary?.includes("Top-level"));
+    expect(found).toBeDefined();
+  });
+
+  it("does NOT find subagent sessions (--deep not passed)", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    const subagentSessions = sessions.filter((s) => s.summary?.includes("Subagent"));
+    expect(subagentSessions.length).toBe(0);
+  });
+
+  it("output does NOT have isSubagent field in default mode", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    sessions.forEach((s) => {
+      expect(s.isSubagent).toBeUndefined();
+    });
+  });
+
+  it("session entries have required fields", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    expect(sessions.length).toBeGreaterThan(0);
+    const s = sessions[0];
+    expect(s).toHaveProperty("sessionId");
+    expect(s).toHaveProperty("startGMT7");
+    expect(s).toHaveProperty("endGMT7");
+    expect(s).toHaveProperty("durationMin");
+    expect(s).toHaveProperty("repoName");
+    expect(s).toHaveProperty("realHumanMessages");
+    expect(s).toHaveProperty("assistantMessages");
+    expect(s).toHaveProperty("gitBranch");
+    expect(s).toHaveProperty("summary");
+    expect(s).toHaveProperty("isSidechain");
+  });
+
+  it("output starts with a gap entry (sleeping/offline)", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed: any[] = JSON.parse(stdout);
+    expect(parsed[0]).toMatchObject({ type: "gap" });
+  });
+
+  it("output ends with a gap entry (no session yet)", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const last = parsed[parsed.length - 1];
+    expect(last).toMatchObject({ type: "gap" });
+  });
+
+  it("does NOT include coverage metadata entry", () => {
+    const { stdout } = runDig(["10"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const coverage = parsed.find((e) => e.type === "coverage");
+    expect(coverage).toBeUndefined();
+  });
+});
+
+// ── Deep mode (--deep) — subagent scanning ────────────────────────────────────
+
+describe("fix #274 — deep mode (--deep) scans subagent sessions", () => {
+  it("exits with code 0", () => {
+    const { exitCode } = runDig(["--deep", "0"]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("outputs valid JSON array", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  it("finds both top-level AND subagent sessions", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    const top = sessions.find((s) => s.summary?.includes("Top-level"));
+    const sub = sessions.find((s) => s.summary?.includes("Subagent"));
+    expect(top).toBeDefined();
+    expect(sub).toBeDefined();
+  });
+
+  it("skips empty subagent files", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    // Should have 2 sessions (top + 1 subagent) — not 3 (empty file skipped)
+    expect(sessions.length).toBe(2);
+  });
+
+  it("subagent sessions have isSubagent: true", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    const sub = sessions.find((s) => s.summary?.includes("Subagent"));
+    expect(sub?.isSubagent).toBe(true);
+  });
+
+  it("top-level sessions have isSubagent: false in deep mode", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    const top = sessions.find((s) => s.summary?.includes("Top-level"));
+    expect(top?.isSubagent).toBe(false);
+  });
+
+  it("deep mode sessions have toolCalls field", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    sessions.forEach((s) => {
+      expect(typeof s.toolCalls).toBe("number");
+    });
+  });
+
+  it("deep mode sessions have fileSizeKB field", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    sessions.forEach((s) => {
+      expect(typeof s.fileSizeKB).toBe("number");
+    });
+  });
+
+  it("deep mode appends coverage metadata entry", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const coverage = parsed.find((e) => e.type === "coverage");
+    expect(coverage).toBeDefined();
+    expect(coverage).toHaveProperty("totalFound");
+    expect(coverage).toHaveProperty("returned");
+    expect(coverage.deep).toBe(true);
+    expect(coverage).toHaveProperty("timezone");
+  });
+
+  it("coverage metadata totalFound >= returned", () => {
+    const { stdout } = runDig(["--deep", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const coverage = parsed.find((e) => e.type === "coverage");
+    expect(coverage.totalFound).toBeGreaterThanOrEqual(coverage.returned);
+  });
+});
+
+// ── --subagents flag ───────────────────────────────────────────────────────────
+
+describe("fix #274 — --subagents flag", () => {
+  it("--subagents also discovers subagent sessions", () => {
+    const { stdout } = runDig(["--subagents", "0"]);
+    const parsed: any[] = JSON.parse(stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    const sub = sessions.find((s) => s.summary?.includes("Subagent"));
+    expect(sub).toBeDefined();
+  });
+});
+
+// ── Timezone detection ────────────────────────────────────────────────────────
+
+describe("fix #274 — timezone detection", () => {
+  it("respects MAW_DISPLAY_TZ env var", () => {
+    // MAW_DISPLAY_TZ=0 → UTC; timestamps should show UTC times
+    const result = spawnSync("python3", [DIG_PY, "10"], {
+      env: { ...process.env, PROJECT_DIRS: FIXTURE_DIR, MAW_DISPLAY_TZ: "0" },
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    const parsed: any[] = JSON.parse(result.stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    // 2026-02-01T08:00:00Z with offset 0 → 2026-02-01 08:00
+    const top = sessions.find((s) => s.summary?.includes("Top-level"));
+    expect(top?.startGMT7).toBe("2026-02-01 08:00");
+  });
+
+  it("timezone offset shifts timestamps correctly", () => {
+    // MAW_DISPLAY_TZ=7 → GMT+7; 08:00Z + 7h = 15:00
+    const result = spawnSync("python3", [DIG_PY, "10"], {
+      env: { ...process.env, PROJECT_DIRS: FIXTURE_DIR, MAW_DISPLAY_TZ: "7" },
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    const parsed: any[] = JSON.parse(result.stdout);
+    const sessions = parsed.filter((e) => !e.type);
+    const top = sessions.find((s) => s.summary?.includes("Top-level"));
+    expect(top?.startGMT7).toBe("2026-02-01 15:00");
+  });
+});

--- a/__tests__/installer-scripts-copy.test.ts
+++ b/__tests__/installer-scripts-copy.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for fix #275 — installer must copy scripts/ subdirectories and
+ * sibling files (DEEP.md, etc.) alongside SKILL.md when installing skills.
+ *
+ * Root cause: src/skills/skills-list/ had SKILL.md but no scripts/ subdir,
+ * so skills-list.py was never installed, leaving the skill broken.
+ *
+ * Fix: add scripts/skills-list.py to src/skills/skills-list/scripts/ so that
+ * cpr() (fs mode) and writeSkillToDir() (VFS mode) both pick it up.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { agents } from "../src/cli/agents";
+import { installSkills } from "../src/cli/installer";
+import type { AgentConfig } from "../src/cli/types";
+
+const TEST_DIR = join(tmpdir(), `arra-scripts-copy-${Date.now()}`);
+const SKILLS_DIR = join(TEST_DIR, "skills");
+const COMMANDS_DIR = join(TEST_DIR, "commands");
+const TEST_AGENT_GLOBAL = "test-scripts-global" as any;
+const TEST_AGENT_LOCAL = "test-scripts-local" as any;
+
+const globalAgentConfig: AgentConfig = {
+  name: TEST_AGENT_GLOBAL,
+  displayName: "Test Scripts Global",
+  skillsDir: "test-scripts-skills",
+  globalSkillsDir: SKILLS_DIR,
+  commandsDir: "test-scripts-commands",
+  globalCommandsDir: COMMANDS_DIR,
+  useFlatFiles: false,
+  detectInstalled: () => true,
+};
+
+// For local install, installer uses join(process.cwd(), agent.skillsDir)
+// So skillsDir must be a relative-style path that will resolve under cwd
+const LOCAL_RELATIVE_SKILLS = join(TEST_DIR, "local-project", "test-scripts-skills");
+const localAgentConfig: AgentConfig = {
+  name: TEST_AGENT_LOCAL,
+  displayName: "Test Scripts Local",
+  // Use a path relative to cwd — we set globalSkillsDir to the same absolute
+  // path and force global: false so the installer uses `join(cwd, skillsDir)`.
+  // Instead, use globalSkillsDir and global:true for the local test to keep it simple.
+  skillsDir: "test-scripts-local-skills",
+  globalSkillsDir: LOCAL_RELATIVE_SKILLS,
+  commandsDir: "test-scripts-local-commands",
+  globalCommandsDir: join(TEST_DIR, "local-project", "test-scripts-commands"),
+  detectInstalled: () => true,
+};
+
+async function cleanup() {
+  if (existsSync(SKILLS_DIR)) await rm(SKILLS_DIR, { recursive: true });
+  if (existsSync(COMMANDS_DIR)) await rm(COMMANDS_DIR, { recursive: true });
+  await mkdir(SKILLS_DIR, { recursive: true });
+  await mkdir(COMMANDS_DIR, { recursive: true });
+}
+
+beforeAll(async () => {
+  await mkdir(TEST_DIR, { recursive: true });
+  await mkdir(join(TEST_DIR, "local-project"), { recursive: true });
+  (agents as any)[TEST_AGENT_GLOBAL] = globalAgentConfig;
+  (agents as any)[TEST_AGENT_LOCAL] = localAgentConfig;
+});
+
+afterAll(async () => {
+  delete (agents as any)[TEST_AGENT_GLOBAL];
+  delete (agents as any)[TEST_AGENT_LOCAL];
+  if (existsSync(TEST_DIR)) await rm(TEST_DIR, { recursive: true });
+});
+
+describe("fix #275 — scripts-list skill has scripts/ in source", () => {
+  it("src/skills/skills-list/scripts/skills-list.py exists in source", () => {
+    const scriptPath = join(
+      process.cwd(),
+      "src/skills/skills-list/scripts/skills-list.py"
+    );
+    expect(existsSync(scriptPath)).toBe(true);
+  });
+
+  it("skills-list.py is executable Python script", async () => {
+    const scriptPath = join(
+      process.cwd(),
+      "src/skills/skills-list/scripts/skills-list.py"
+    );
+    const content = await Bun.file(scriptPath).text();
+    expect(content).toContain("#!/usr/bin/env python3");
+    expect(content).toContain("skills");
+  });
+});
+
+describe("fix #275 — installer copies scripts/ subdirectory (global install)", () => {
+  beforeEach(cleanup);
+
+  it("installs scripts/skills-list.py alongside SKILL.md", async () => {
+    await installSkills([TEST_AGENT_GLOBAL], {
+      global: true,
+      skills: ["skills-list"],
+      yes: true,
+    });
+
+    const skillDir = join(SKILLS_DIR, "skills-list");
+    const skillMd = join(skillDir, "SKILL.md");
+    const scriptFile = join(skillDir, "scripts", "skills-list.py");
+
+    expect(existsSync(skillMd)).toBe(true);
+    expect(existsSync(scriptFile)).toBe(true);
+  });
+
+  it("installed scripts/skills-list.py has correct content", async () => {
+    await installSkills([TEST_AGENT_GLOBAL], {
+      global: true,
+      skills: ["skills-list"],
+      yes: true,
+    });
+
+    const scriptFile = join(SKILLS_DIR, "skills-list", "scripts", "skills-list.py");
+    const content = await Bun.file(scriptFile).text();
+    expect(content).toContain("#!/usr/bin/env python3");
+    expect(content).toContain("List all skills");
+  });
+
+  it("other skills with scripts/ also get scripts/ installed", async () => {
+    // team-agents has scripts/ — verify it installs correctly
+    await installSkills([TEST_AGENT_GLOBAL], {
+      global: true,
+      skills: ["team-agents"],
+      yes: true,
+    });
+
+    const skillDir = join(SKILLS_DIR, "team-agents");
+    const scriptsDir = join(skillDir, "scripts");
+    expect(existsSync(scriptsDir)).toBe(true);
+
+    // Should have at least one script file
+    const { readdirSync } = await import("fs");
+    const files = readdirSync(scriptsDir);
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("dig skill scripts/ subdir is also installed", async () => {
+    await installSkills([TEST_AGENT_GLOBAL], {
+      global: true,
+      skills: ["dig"],
+      yes: true,
+    });
+
+    const scriptFile = join(SKILLS_DIR, "dig", "scripts", "dig.py");
+    expect(existsSync(scriptFile)).toBe(true);
+  });
+
+  it("SKILL.md content is modified (version injected) but script files are copied verbatim", async () => {
+    await installSkills([TEST_AGENT_GLOBAL], {
+      global: true,
+      skills: ["skills-list"],
+      yes: true,
+    });
+
+    // SKILL.md should have the installer marker (modified)
+    const skillMd = await Bun.file(join(SKILLS_DIR, "skills-list", "SKILL.md")).text();
+    expect(skillMd).toContain("installer: arra-oracle-skills-cli");
+
+    // Script should be unmodified (verbatim copy)
+    const installedScript = await Bun.file(
+      join(SKILLS_DIR, "skills-list", "scripts", "skills-list.py")
+    ).text();
+    const sourceScript = await Bun.file(
+      join(process.cwd(), "src/skills/skills-list/scripts/skills-list.py")
+    ).text();
+    expect(installedScript).toBe(sourceScript);
+  });
+});
+
+describe("fix #275 — installer copies scripts/ subdirectory (local project install)", () => {
+  beforeEach(async () => {
+    if (existsSync(LOCAL_RELATIVE_SKILLS)) await rm(LOCAL_RELATIVE_SKILLS, { recursive: true });
+    await mkdir(LOCAL_RELATIVE_SKILLS, { recursive: true });
+  });
+
+  it("installs scripts/skills-list.py on local project install (via globalSkillsDir)", async () => {
+    // Use global: true with the local agent's globalSkillsDir pointing to our test dir
+    await installSkills([TEST_AGENT_LOCAL], {
+      global: true,
+      skills: ["skills-list"],
+      yes: true,
+    });
+
+    const scriptFile = join(LOCAL_RELATIVE_SKILLS, "skills-list", "scripts", "skills-list.py");
+    expect(existsSync(scriptFile)).toBe(true);
+  });
+});
+
+describe("fix #275 — sibling non-script files (DEEP.md etc.) are also copied", () => {
+  beforeEach(cleanup);
+
+  it("rrr skill DEEP.md is installed alongside SKILL.md", async () => {
+    // rrr has DEEP.md and TEAMMATE.md
+    const deepMdSrc = join(process.cwd(), "src/skills/rrr/DEEP.md");
+    if (!existsSync(deepMdSrc)) return; // Skip if DEEP.md not present in source
+
+    await installSkills([TEST_AGENT_GLOBAL], {
+      global: true,
+      skills: ["rrr"],
+      yes: true,
+    });
+
+    const deepMdDest = join(SKILLS_DIR, "rrr", "DEEP.md");
+    expect(existsSync(deepMdDest)).toBe(true);
+  });
+});

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -17,6 +17,120 @@ import {
 } from './skill-source.js';
 import pkg from '../../package.json' with { type: 'json' };
 
+// ── Codex 0.128.0+ plugin marketplace helpers ────────────────────────────────
+
+/**
+ * Detect if Codex 0.128.0+ plugin marketplace mode is active.
+ * Codex 0.128.0 creates ~/.codex/config.toml; older versions do not.
+ */
+export function isCodexPluginMarketplace(homeDir?: string): boolean {
+  const home = homeDir ?? homedir();
+  return existsSync(join(home, '.codex', 'config.toml'));
+}
+
+/** Return the arra-oracle-skills marketplace bundle directory path. */
+export function getCodexMarketplaceDir(homeDir?: string): string {
+  const home = homeDir ?? homedir();
+  return join(home, '.codex', '.tmp', 'bundled-marketplaces', 'arra-oracle-skills');
+}
+
+/**
+ * Install skills for Codex 0.128.0+ plugin marketplace.
+ *
+ * Creates:
+ *   <marketplaceDir>/manifest.toml
+ *   <marketplaceDir>/plugins/<skill>/plugin.toml
+ *   <marketplaceDir>/plugins/<skill>/prompt.md   (skill body)
+ *
+ * Then updates ~/.codex/config.toml with:
+ *   [marketplaces.arra-oracle-skills]  source_type + source
+ *   [plugins."<skill>@arra-oracle-skills"]  enabled = true
+ */
+export async function installCodexPluginMarketplace(
+  skills: Skill[],
+  version: string,
+  shellMode: ShellMode,
+  opts?: { marketplaceDir?: string; configPath?: string }
+): Promise<void> {
+  const marketplaceDir = opts?.marketplaceDir ?? getCodexMarketplaceDir();
+  const configPath = opts?.configPath ?? join(homedir(), '.codex', 'config.toml');
+
+  // ── 1. Create marketplace bundle directory ─────────────────────────────────
+  await mkdirp(marketplaceDir, shellMode);
+
+  // ── 2. Write marketplace manifest ─────────────────────────────────────────
+  const manifestContent = [
+    `name = "arra-oracle-skills"`,
+    `version = "${version}"`,
+    `description = "Oracle skills for Codex by Soul Brews Studio"`,
+    ``,
+  ].join('\n');
+  await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+
+  // ── 3. Per-skill plugin directories ───────────────────────────────────────
+  const pluginsDir = join(marketplaceDir, 'plugins');
+  await mkdirp(pluginsDir, shellMode);
+
+  for (const skill of skills) {
+    const skillPluginDir = join(pluginsDir, skill.name);
+    await mkdirp(skillPluginDir, shellMode);
+
+    // plugin.toml descriptor
+    const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const pluginToml = [
+      `name = "${skill.name}"`,
+      `description = "${escapedDesc}"`,
+      `version = "${version}"`,
+      `command = "/${skill.name}"`,
+      ``,
+    ].join('\n');
+    await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
+
+    // prompt.md — skill body for Codex to execute
+    if (isCompiled()) {
+      // VFS mode: write entire skill tree (includes SKILL.md + any extras)
+      await writeSkillToDir(skill.name, skillPluginDir);
+    } else {
+      // Filesystem mode: copy SKILL.md as prompt.md
+      const skillMdPath = join(skill.path, 'SKILL.md');
+      if (existsSync(skillMdPath)) {
+        const content = await Bun.file(skillMdPath).text();
+        await Bun.write(join(skillPluginDir, 'prompt.md'), content);
+      }
+    }
+  }
+
+  // ── 4. Update ~/.codex/config.toml ────────────────────────────────────────
+  let configContent = existsSync(configPath) ? await Bun.file(configPath).text() : '';
+
+  // Add marketplace registration if not already present
+  const marketplaceSection = `[marketplaces.arra-oracle-skills]`;
+  if (!configContent.includes(marketplaceSection)) {
+    configContent += [
+      ``,
+      `${marketplaceSection}`,
+      `source_type = "local"`,
+      `source = "${marketplaceDir}"`,
+      ``,
+    ].join('\n');
+  }
+
+  // Enable each non-hidden skill as a plugin
+  for (const skill of skills) {
+    if (skill.hidden) continue;
+    const pluginKey = `[plugins."${skill.name}@arra-oracle-skills"]`;
+    if (!configContent.includes(pluginKey)) {
+      configContent += [
+        `${pluginKey}`,
+        `enabled = true`,
+        ``,
+      ].join('\n');
+    }
+  }
+
+  await Bun.write(configPath, configContent);
+}
+
 // Re-export discoverSkills from skill-source
 export const discoverSkills = _discoverSkills;
 
@@ -523,6 +637,14 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
         await cp(hookSrc, join(pluginDir, 'arra-oracle-skills.ts'), shellMode);
         p.log.success(`OpenCode plugin: ${pluginDir}/arra-oracle-skills.ts`);
       }
+    }
+
+    // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
+    // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
+    // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
+    if (agentName === 'codex' && isCodexPluginMarketplace()) {
+      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
+      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -544,10 +544,20 @@ This does NOT re-run the wizard or rebuild structure. It refreshes identity:
    - Current date as "re-awakened" date
    - Any new insights from learnings
    - Updated family context
-5. **Log re-awakening** — write retrospective via `/rrr` and sync via `arra_learn`:
-   ```
-   arra_learn({ pattern: "Re-awakened [oracle-name]: [summary of what changed]", concepts: ["reawaken", "identity"], source: "awaken --reawaken" })
-   ```
+5. **Log re-awakening** — write retrospective via `/rrr` and save the lesson (two-layer pattern):
+   1. Write to `ψ/memory/learnings/YYYY-MM-DD_reawaken-<oracle-name>.md` with frontmatter:
+      ```yaml
+      ---
+      pattern: "Re-awakened [oracle-name]: [summary of what changed]"
+      date: <today>
+      source: awaken --reawaken
+      concepts: ["reawaken", "identity"]
+      ---
+
+      # Re-awakening: [oracle-name]
+      [summary of what changed]
+      ```
+   2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 **Output:**
 

--- a/src/skills/bampenpien/SKILL.md
+++ b/src/skills/bampenpien/SKILL.md
@@ -266,15 +266,22 @@ mkdir -p "$PSI/memory/resonance/practice"
 [one word they used, or Oracle's read]
 ```
 
-### Sync to Oracle (if available)
+### Sync to Oracle (if available, two-layer pattern)
 
-```
-arra_learn({
-  pattern: "บำเพ็ญเพียร: [human] practices with [hard thing] — believes [belief]",
-  concepts: ["bampenpien", "practice", "belief", "perseverance"],
-  source: "bampenpien: [repo-name]"
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_bampenpien-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "บำเพ็ญเพียร: [human] practices with [hard thing] — believes [belief]"
+   date: <today>
+   source: bampenpien: [repo-name]
+   concepts: ["bampenpien", "practice", "belief", "perseverance"]
+   ---
+
+   # บำเพ็ญเพียร: [hard thing]
+   <session summary from the practice log>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ---
 

--- a/src/skills/dig/scripts/dig.py
+++ b/src/skills/dig/scripts/dig.py
@@ -1,12 +1,53 @@
 #!/usr/bin/env python3
-"""Session goldminer — scan Claude Code .jsonl files for session timeline."""
+"""Session goldminer v3 — scan Claude Code .jsonl files for session timeline.
+
+Fixes (ported from home-comming-oracle/dig-deep.py):
+- --deep now scans subagent dirs: <project>/<uuid>/subagents/*.jsonl
+- --subagents alias for explicit subagent inclusion
+- Proper timezone detection (MAW_DISPLAY_TZ > TZ > system > UTC)
+- Coverage metadata entry appended to output when --deep is used
+- toolCalls, fileSizeKB, isSubagent fields added in --deep mode
+"""
 import json, os, glob, sys, subprocess, re
 from datetime import datetime, timedelta
 from pathlib import Path
 
 project_dirs = [d for d in os.environ.get('PROJECT_DIRS', '').split(':') if d]
-count = int(sys.argv[1]) if len(sys.argv) > 1 else 10  # 0 = no limit (scan all)
-bkk = timedelta(hours=7)
+
+# Parse flags and positional args
+_raw_args = sys.argv[1:]
+deep = '--deep' in _raw_args
+include_subagents = '--subagents' in _raw_args
+_positional = [a for a in _raw_args if not a.startswith('--')]
+count = int(_positional[0]) if _positional else 10  # 0 = no limit
+
+
+def detect_tz():
+    """Detect local timezone offset. Priority: MAW_DISPLAY_TZ > TZ > system > UTC."""
+    for var in ('MAW_DISPLAY_TZ', 'TZ'):
+        val = os.environ.get(var, '')
+        if val:
+            try:
+                return timedelta(hours=int(val)), f"GMT+{val}"
+            except ValueError:
+                pass
+    try:
+        r = subprocess.run(['date', '+%z'], capture_output=True, text=True, timeout=3)
+        offset_str = r.stdout.strip()
+        if offset_str and len(offset_str) >= 5:
+            sign = 1 if offset_str[0] == '+' else -1
+            hours = int(offset_str[1:3])
+            mins = int(offset_str[3:5])
+            total = sign * (hours * 60 + mins)
+            label = f"GMT{offset_str[0]}{hours:02d}:{mins:02d}"
+            return timedelta(minutes=total), label
+    except:
+        pass
+    return timedelta(hours=0), "UTC"
+
+
+tz_offset, tz_name = detect_tz()
+
 
 def build_repo_map():
     mapping = {}
@@ -15,83 +56,137 @@ def build_repo_map():
         for path in r.stdout.strip().split('\n'):
             if path:
                 mapping[path.replace('/', '-')] = path.split('/')[-1]
-    except: pass
+    except:
+        pass
     return mapping
+
 
 def get_repo_name(project_dir, repo_map):
     base = os.path.basename(project_dir.rstrip('/'))
-    clean = re.sub(r'-wt-\d+$', '', base)   # strip -wt-1, -wt-8 etc
+    clean = re.sub(r'-wt-\d+.*$', '', base)   # strip -wt-1, -wt-8 etc
     return repo_map.get(clean) or clean.split('-')[-1] or clean
+
 
 repo_map = build_repo_map()
 
-# Get .jsonl files across all project dirs, deduplicate by basename, take N most recent
-seen = {}
-for d in project_dirs:
-    for f in glob.glob(os.path.join(d, '*.jsonl')):
-        base = os.path.basename(f)
-        if base not in seen or os.path.getmtime(f) > os.path.getmtime(seen[base][0]):
-            seen[base] = (f, d)   # store (filepath, project_dir) tuple
-all_files = [(fp, d) for fp, d in seen.values()]
-files = sorted(all_files, key=lambda x: os.path.getmtime(x[0]), reverse=True)
-if count > 0:
-    files = files[:count]
+# ── Collect .jsonl files ──────────────────────────────────────────────────────
+all_files = []   # list of (filepath, project_dir, is_subagent)
+total_found = 0
 
-# Load sessions-index from all dirs
+for d in project_dirs:
+    # Top-level sessions (always included)
+    for f in glob.glob(os.path.join(d, '*.jsonl')):
+        all_files.append((f, d, False))
+        total_found += 1
+
+    # Deep scan: subagent sessions inside <uuid>/subagents/
+    if deep or include_subagents:
+        for uuid_dir in glob.glob(os.path.join(d, '*')):
+            if not os.path.isdir(uuid_dir):
+                continue
+            sub_dir = os.path.join(uuid_dir, 'subagents')
+            if os.path.isdir(sub_dir):
+                for f in glob.glob(os.path.join(sub_dir, '*.jsonl')):
+                    if os.path.getsize(f) > 0:
+                        all_files.append((f, d, True))
+                        total_found += 1
+
+# Deduplicate
+if deep or include_subagents:
+    # Deep mode: deduplicate by full path
+    seen_paths = {}
+    for fp, d, is_sub in all_files:
+        if fp not in seen_paths:
+            seen_paths[fp] = (fp, d, is_sub)
+    all_unique = list(seen_paths.values())
+else:
+    # Standard mode: deduplicate by basename (original behaviour)
+    seen_base = {}
+    for f, d, is_sub in all_files:
+        base = os.path.basename(f)
+        if base not in seen_base or os.path.getmtime(f) > os.path.getmtime(seen_base[base][0]):
+            seen_base[base] = (f, d, is_sub)
+    all_unique = list(seen_base.values())
+
+files_sorted = sorted(all_unique, key=lambda x: os.path.getmtime(x[0]), reverse=True)
+if count > 0:
+    files_sorted = files_sorted[:count]
+
+# ── Load sessions-index from all dirs ─────────────────────────────────────────
 index_map = {}
 for d in project_dirs:
     try:
         with open(os.path.join(d, 'sessions-index.json')) as f:
             for e in json.load(f).get('entries', []):
                 index_map[e['sessionId']] = e
-    except: pass
+    except:
+        pass
 
+
+def to_local(iso):
+    try:
+        dt = datetime.fromisoformat(iso.replace('Z', '+00:00'))
+        return (dt + tz_offset).strftime('%Y-%m-%d %H:%M')
+    except:
+        return iso
+
+
+# ── Parse sessions ─────────────────────────────────────────────────────────────
 sessions = []
-for fp, source_dir in files:
+for fp, source_dir, is_subagent in files_sorted:
     sid = os.path.basename(fp).replace('.jsonl', '')
     first_ts = last_ts = None
     branch = summary_text = None
     is_sidechain = False
     real_human = []
     assistant_count = 0
+    tool_calls = 0
 
-    with open(fp) as fh:
-        for line in fh:
-            try: obj = json.loads(line)
-            except: continue
-            ts = obj.get('timestamp')
-            if ts:
-                if not first_ts or ts < first_ts: first_ts = ts
-                if not last_ts or ts > last_ts: last_ts = ts
-            t = obj.get('type', '')
-            if t == 'summary':
-                summary_text = obj.get('summary', '')
-                branch = obj.get('gitBranch', '')
-                is_sidechain = obj.get('isSidechain', False)
-            elif t == 'assistant':
-                assistant_count += 1
-            elif t == 'user':
-                msg = obj.get('message', {})
-                content = msg.get('content', [])
-                text = ''
-                if isinstance(content, list):
-                    for c in content:
-                        if isinstance(c, dict) and c.get('type') == 'text':
-                            text = c.get('text', '').strip()
-                            break
-                elif isinstance(content, str):
-                    text = content.strip()
-                if text and len(text) > 5 and not text.startswith('[Request interrupted'):
-                    real_human.append(text[:80])
+    try:
+        with open(fp) as fh:
+            for line in fh:
+                try:
+                    obj = json.loads(line)
+                except:
+                    continue
+                ts = obj.get('timestamp')
+                if ts:
+                    if not first_ts or ts < first_ts:
+                        first_ts = ts
+                    if not last_ts or ts > last_ts:
+                        last_ts = ts
+                t = obj.get('type', '')
+                if t == 'summary':
+                    summary_text = obj.get('summary', '')
+                    branch = obj.get('gitBranch', '')
+                    is_sidechain = obj.get('isSidechain', False)
+                elif t == 'assistant':
+                    assistant_count += 1
+                    if deep or include_subagents:
+                        msg = obj.get('message', {})
+                        content = msg.get('content', [])
+                        if isinstance(content, list):
+                            for c in content:
+                                if isinstance(c, dict) and c.get('type') == 'tool_use':
+                                    tool_calls += 1
+                elif t == 'user':
+                    msg = obj.get('message', {})
+                    content = msg.get('content', [])
+                    text = ''
+                    if isinstance(content, list):
+                        for c in content:
+                            if isinstance(c, dict) and c.get('type') == 'text':
+                                text = c.get('text', '').strip()
+                                break
+                    elif isinstance(content, str):
+                        text = content.strip()
+                    if text and len(text) > 5 and not text.startswith('[Request interrupted'):
+                        real_human.append(text[:80])
+    except:
+        continue
 
-    if not first_ts: continue
-
-    # Convert timestamps to GMT+7
-    def to_gmt7(iso):
-        try:
-            dt = datetime.fromisoformat(iso.replace('Z', '+00:00'))
-            return (dt + bkk).strftime('%Y-%m-%d %H:%M')
-        except: return iso
+    if not first_ts:
+        continue
 
     dur_min = 0
     if first_ts and last_ts:
@@ -99,18 +194,18 @@ for fp, source_dir in files:
             t1 = datetime.fromisoformat(first_ts.replace('Z', '+00:00'))
             t2 = datetime.fromisoformat(last_ts.replace('Z', '+00:00'))
             dur_min = int((t2 - t1).total_seconds() / 60)
-        except: pass
+        except:
+            pass
 
-    # Prefer index summary over first prompt
     idx = index_map.get(sid, {})
     final_summary = idx.get('summary') or summary_text or (real_human[0] if real_human else 'No summary')
     final_branch = branch or idx.get('gitBranch') or 'unknown'
 
-    sessions.append({
+    entry = {
         'sessionId': sid[:12],
         'repoName': get_repo_name(source_dir, repo_map),
-        'startGMT7': to_gmt7(first_ts),
-        'endGMT7': to_gmt7(last_ts),
+        'startGMT7': to_local(first_ts),
+        'endGMT7': to_local(last_ts),
         'durationMin': dur_min,
         'realHumanMessages': len(real_human),
         'assistantMessages': assistant_count,
@@ -118,28 +213,52 @@ for fp, source_dir in files:
         'gitBranch': final_branch,
         'summary': final_summary[:80],
         'isSidechain': is_sidechain,
-    })
+    }
 
-sessions.sort(key=lambda s: s['startGMT7'])  # chronological (oldest first)
+    # Extra fields only in deep/subagents mode
+    if deep or include_subagents:
+        entry['toolCalls'] = tool_calls
+        entry['fileSizeKB'] = os.path.getsize(fp) // 1024
+        entry['isSubagent'] = is_subagent
+
+    sessions.append(entry)
+
+sessions.sort(key=lambda s: s['startGMT7'])
 
 GAP_THRESHOLD = 30  # minutes
 
-def parse_gmt7(s):
-    try: return datetime.strptime(s, '%Y-%m-%d %H:%M')
-    except: return None
+
+def parse_local(s):
+    try:
+        return datetime.strptime(s, '%Y-%m-%d %H:%M')
+    except:
+        return None
+
 
 with_gaps = []
 for i, s in enumerate(sessions):
     if i == 0:
         with_gaps.append({"type": "gap", "label": "sleeping / offline"})
     else:
-        prev_end = parse_gmt7(sessions[i-1]['endGMT7'])
-        curr_start = parse_gmt7(s['startGMT7'])
+        prev_end = parse_local(sessions[i - 1]['endGMT7'])
+        curr_start = parse_local(s['startGMT7'])
         if prev_end and curr_start:
             gap_min = int((curr_start - prev_end).total_seconds() / 60)
             if gap_min > GAP_THRESHOLD:
                 with_gaps.append({"type": "gap", "gapMin": gap_min, "label": f"{gap_min}m gap"})
     with_gaps.append(s)
 with_gaps.append({"type": "gap", "label": "no session yet"})
+
+# Append coverage metadata when in deep/subagents mode (as a trailing sentinel entry)
+if deep or include_subagents:
+    with_gaps.append({
+        "type": "coverage",
+        "totalFound": total_found,
+        "returned": len(sessions),
+        "deep": deep,
+        "includeSubagents": include_subagents,
+        "timezone": tz_name,
+        "projectDirs": len(project_dirs),
+    })
 
 print(json.dumps(with_gaps, indent=2))

--- a/src/skills/i-believed/SKILL.md
+++ b/src/skills/i-believed/SKILL.md
@@ -226,15 +226,22 @@ mkdir -p "$PSI/memory/resonance/beliefs"
  Connect to the larger story: what was built, what was risked, what survived.]
 ```
 
-### Sync to Oracle (if available)
+### Sync to Oracle (if available, two-layer pattern)
 
-```
-arra_learn({
-  pattern: "Belief received: [human] [believed/believes] in [target] — [context]",
-  concepts: ["belief", "trust", "resonance", target-tags],
-  source: "i-believed: [repo-name]"
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_belief-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "Belief received: [human] [believed/believes] in [target] — [context]"
+   date: <today>
+   source: i-believed: [repo-name]
+   concepts: ["belief", "trust", "resonance", <target-tags>]
+   ---
+
+   # Belief: [target]
+   [context and meaning]
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ---
 

--- a/src/skills/incubate/SKILL.md
+++ b/src/skills/incubate/SKILL.md
@@ -577,13 +577,22 @@ The pattern is auto-added to `.gitignore` on first `/incubate` run (#250). If yo
 
 After incubation work, log to Oracle so it's discoverable via `/trace`:
 
-```
-arra_learn({
-  pattern: "Incubated [REPO]: [what was done — PR#, branch, outcome]",
-  concepts: ["incubate", "development", relevant-tags],
-  source: "incubate: OWNER/REPO"
-})
-```
+### Save the lesson (two-layer pattern)
+
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_incubate-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "Incubated [REPO]: [what was done — PR#, branch, outcome]"
+   date: <today>
+   source: incubate: OWNER/REPO
+   concepts: ["incubate", "development", <relevant-tags>]
+   ---
+
+   # Incubated [REPO]
+   <body: what was done, PR#, branch, outcome>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 This connects `/incubate` to the shared knowledge layer.
 

--- a/src/skills/learn/SKILL.md
+++ b/src/skills/learn/SKILL.md
@@ -361,13 +361,22 @@ For Oracles that want to commit docs but ignore symlinks:
 
 After writing docs, log the learning to Oracle so it's discoverable via `/trace`:
 
-```
-arra_learn({
-  pattern: "Learned [REPO]: [2-3 key insights]",
-  concepts: ["learn", "codebase", relevant-tags],
-  source: "learn: OWNER/REPO"
-})
-```
+### Save the lesson (two-layer pattern)
+
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "Learned [REPO]: [2-3 key insights]"
+   date: <today>
+   source: learn: OWNER/REPO
+   concepts: ["learn", "codebase", <relevant-tags>]
+   ---
+
+   # Learned [REPO]
+   <2-3 key insights in body>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 This connects `/learn` to the shared knowledge layer — future `/trace` queries find what was learned.
 

--- a/src/skills/oracle-family-scan/SKILL.md
+++ b/src/skills/oracle-family-scan/SKILL.md
@@ -314,14 +314,22 @@ arra_trace({
 })
 ```
 
-After finding new Oracle:
+After finding new Oracle, save the lesson (two-layer pattern):
 
-```
-arra_learn({
-  pattern: "New Oracle: [NAME] — [HUMAN] — [DATE]",
-  concepts: ["oracle-family", "birth"]
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_new-oracle-<name>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "New Oracle: [NAME] — [HUMAN] — [DATE]"
+   date: <today>
+   source: oracle-family-scan
+   concepts: ["oracle-family", "birth"]
+   ---
+
+   # New Oracle: [NAME]
+   [birth story, human, theme]
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ---
 

--- a/src/skills/oracle-family-scan/scripts/fleet-scan.ts
+++ b/src/skills/oracle-family-scan/scripts/fleet-scan.ts
@@ -2,7 +2,7 @@
 // fleet-scan.ts - My Oracle fleet status via gh CLI
 // Usage: bun fleet-scan.ts
 //
-// Part 1: Oracle births from arra-oracle-v3 issues (single API call)
+// Part 1: Oracle births from arra-oracle-v3 issues (paginated — no limit cap)
 // Part 2: Open issues across orgs
 // Part 3: Recently pushed Oracle repos
 
@@ -15,7 +15,10 @@ const BIRTH_PATTERN = /awaken|born|birth|enter.*chat|hello|สวัสดี|ar
 // --- Part 1: Oracle Births from arra-oracle-v3 ---
 type Birth = { number: number; title: string; date: string; author: string };
 
-const birthIssuesRaw = await $`gh issue list --repo ${ORACLE_REPO} --state all --limit 300 --json number,title,createdAt,author --jq '.[] | "\(.number)|\(.title)|\(.createdAt | split("T")[0])|\(.author.login)"'`.text();
+// Use gh api --paginate to fetch ALL issues (no 300-cap). GitHub /issues endpoint
+// includes PRs too, but BIRTH_PATTERN naturally excludes them — PRs don't match
+// "awaken|born|birth|..." title patterns.
+const birthIssuesRaw = await $`gh api --paginate "repos/${ORACLE_REPO}/issues?state=all&per_page=100" --jq '.[] | "\(.number)|\(.title)|\(.created_at[:10])|\(.user.login)"'`.text();
 
 const allBirths: Birth[] = birthIssuesRaw.trim().split("\n").filter(Boolean)
   .map(line => {

--- a/src/skills/oracle-soul-sync-update/SKILL.md
+++ b/src/skills/oracle-soul-sync-update/SKILL.md
@@ -65,9 +65,11 @@ echo "Track: $TRACK → comparing against $LATEST"
 
 ---
 
-## Step 3: Compare Versions — date-drift, not semver-drift (#265)
+## Step 3: Compare Versions — date-drift, not semver-drift (#265, #276)
 
 CalVer tags encode the release date directly (`v26.4.18` = 2026-04-18). Staleness is more useful as "N days behind" than as a semver gap. Legacy SemVer tags (`v3.x.x`) are flagged for migration.
+
+For same-day comparisons, we compare GitHub release **publish timestamps** instead of version strings (#276). This is because semver orders `v26.4.18-alpha.22` BEFORE `v26.4.18` (pre-release < stable), but the alpha was actually cut LATER on the same day. Timestamp comparison fixes the false "alpha is stale, downgrade to stable" suggestion.
 
 ```bash
 # Helpers — parse tag → YYYY-MM-DD, diff in days
@@ -77,13 +79,21 @@ tag_era() {  # "calver" | "semver" | "unknown"
   [ "$first" -ge 25 ] 2>/dev/null && echo calver || echo semver
 }
 tag_to_date() {  # v26.4.18 → 2026-04-18
-  local core=$(echo "$1" | sed 's/^v//; s/-alpha.*$//')
+  local core=$(echo "$1" | sed 's/^v//; s/-(alpha|beta).*$//' -E)
   local yy=$(echo "$core" | cut -d. -f1)
   local m=$(echo "$core" | cut -d. -f2)
   local d=$(echo "$core" | cut -d. -f3)
   printf "%04d-%02d-%02d" "$((2000 + yy))" "$m" "$d"
 }
-alpha_hour() { echo "$1" | grep -oE 'alpha\.[0-9]+' | cut -d. -f2; }
+# Get GitHub release publish timestamp as epoch seconds (#276)
+tag_publish_epoch() {
+  local tag=$1
+  [ "${tag:0:1}" != "v" ] && tag="v$tag"
+  local iso=$(gh release view "$tag" --repo Soul-Brews-Studio/arra-oracle-skills-cli --json publishedAt --jq '.publishedAt' 2>/dev/null)
+  [ -z "$iso" ] && return 1
+  # macOS + GNU date compatibility
+  date -u -d "$iso" +%s 2>/dev/null || date -juf "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null
+}
 
 CUR_ERA=$(tag_era "$CURRENT")
 LAT_ERA=$(tag_era "$LATEST")
@@ -95,16 +105,27 @@ elif [ "$CUR_ERA" = "semver" ] && [ "$LAT_ERA" = "calver" ]; then
 else
   CUR_DATE=$(tag_to_date "$CURRENT")
   LAT_DATE=$(tag_to_date "$LATEST")
-  DAYS=$(( ( $(date -d "$LAT_DATE" +%s) - $(date -d "$CUR_DATE" +%s) ) / 86400 ))
+  DAYS=$(( ( $(date -d "$LAT_DATE" +%s 2>/dev/null || date -juf "%Y-%m-%d" "$LAT_DATE" +%s) - \
+            $(date -d "$CUR_DATE" +%s 2>/dev/null || date -juf "%Y-%m-%d" "$CUR_DATE" +%s) ) / 86400 ))
   if [ "$DAYS" -eq 0 ]; then
-    CUR_H=$(alpha_hour "$CURRENT")
-    LAT_H=$(alpha_hour "$LATEST")
-    if [ -n "$CUR_H" ] || [ -n "$LAT_H" ]; then
-      HOURS=$(( ${LAT_H:-0} - ${CUR_H:-0} ))
-      [ "$HOURS" -lt 0 ] && HOURS=$(( -HOURS ))
-      echo "⚠️ ${HOURS}h stale: $CURRENT → $LATEST ($CUR_DATE, same day)"
+    # Same calendar day — use release publish timestamps (#276 fix)
+    # Semver says alpha < stable, but on the same day alpha may be cut LATER.
+    # Always trust the GitHub publish_at timestamp as ground truth.
+    CUR_TS=$(tag_publish_epoch "$CURRENT")
+    LAT_TS=$(tag_publish_epoch "$LATEST")
+    if [ -n "$CUR_TS" ] && [ -n "$LAT_TS" ]; then
+      if [ "$CUR_TS" -ge "$LAT_TS" ]; then
+        echo "✅ Local ($CURRENT) was published at-or-after latest tag ($LATEST) — no update needed"
+        echo "   (semver would say 'alpha < stable' but timestamps say otherwise; trusting timestamps)"
+      else
+        SECS=$(( LAT_TS - CUR_TS ))
+        HOURS=$(( SECS / 3600 ))
+        MINS=$(( (SECS % 3600) / 60 ))
+        echo "⚠️ ${HOURS}h${MINS}m stale: $CURRENT → $LATEST ($CUR_DATE, same day)"
+      fi
     else
-      echo "⚠️ Same day, different tag: $CURRENT → $LATEST"
+      # Fallback if GitHub API unreachable: report same-day, no decision
+      echo "⚠️ Same day, different tag: $CURRENT → $LATEST (timestamp lookup failed; verify manually)"
     fi
   else
     echo "Current installed: $CURRENT   ($CUR_DATE)"

--- a/src/skills/philosophy/SKILL.md
+++ b/src/skills/philosophy/SKILL.md
@@ -41,7 +41,7 @@ date "+🕐 %H:%M %Z (%A %d %B %Y)"
 
 - Archive, don't erase
 - Use `arra_trace()` for searches
-- Use `arra_learn()` for findings
+- Write to `ψ/memory/learnings/` (two-layer pattern) for findings
 - Use `arra_supersede()` to mark outdated (preserves chain)
 - Git history preserves evolution
 
@@ -188,7 +188,7 @@ Layer 4: PRINCIPLES    → Core wisdom (awakening)
 2. Dig into results
 3. `/rrr` to reflect
 4. Pattern emerges → **Awakening**
-5. `arra_learn()` to preserve
+5. Write to `ψ/memory/learnings/` (two-layer pattern) to preserve
 
 ### The Insight
 

--- a/src/skills/project/project-manager.md
+++ b/src/skills/project/project-manager.md
@@ -122,7 +122,7 @@ laris-co/arra-oracle-v3: ~/Code/github.com/laris-co/arra-oracle-v3
 2. **Score** → Rank files by type (retrospectives=10, docs=5, CLAUDE.md=0)
 3. **Filter** → Skip i18n, CLAUDE.md, low-value files
 4. **Extract** → Get key content from high-value files
-5. **Learn** → Call `arra_learn` with source attribution
+5. **Learn** → Write to `ψ/memory/learnings/` (two-layer pattern: learning file + auto-memory)
 
 ## Offload Pattern
 

--- a/src/skills/recap/SKILL.md
+++ b/src/skills/recap/SKILL.md
@@ -120,6 +120,52 @@ Script outputs git status + focus state (~0.1s). Then LLM adds:
 1. **ONE bash call** — never multiple parallel calls (adds latency)
 2. **No subagents** — everything in main agent
 3. **Ask, don't suggest** — "What next?" not "You should..."
+4. **Verify pending before reporting** — see "Verify Before Reporting" section below. This is NON-NEGOTIABLE.
+
+---
+
+## Verify Before Reporting (MANDATORY)
+
+Handoffs, retros, and memory files are **point-in-time claims**, not live state. Between the previous session ending and this one starting, work may have been done, PRs may have merged, files may have been copied. **Echoing a stale pending list as if it were current is a lie by omission** — the human ends up chasing items that are already done.
+
+### The rule
+
+Before outputting any "Pending" table or "Next action" suggestion, you MUST verify each claimed pending item against current reality:
+
+| Claim type | How to verify |
+|---|---|
+| "Copy file X to path Y" | `ls path/Y` — is it already there? |
+| "PR #N open/merged" | `gh pr view N --json state` |
+| "Branch X needs push" | `git log origin/X..X` — any commits? |
+| "Apply pattern P to file F" | `grep` for the pattern in F |
+| "Issue #N pending" | `gh issue view N --json state` |
+| "Migration ready to run" | check migrations table or list |
+
+### What to do with each verified item
+
+- **Already done** → drop from pending, note in "Actually done since handoff"
+- **Still pending** → keep, show in table
+- **Partially done** → split into remaining sub-items
+- **Can't verify** (offline/ambiguous) → mark `⚠️ unverified` in the table, do not assert state
+
+### The correction pattern
+
+If the handoff pending list and reality diverge (>1 item stale), show the correction explicitly so the human sees the drift:
+
+```
+| Item | Handoff said | Reality |
+|------|--------------|---------|
+| Copy cache/ to maw-ui | pending | DONE (Apr 20 04:16) |
+| PR #4 merge | open | MERGED |
+```
+
+### Why this is non-negotiable
+
+- Handoffs are written before work stops, but work often continues between sessions (other Oracles, scheduled tasks, user actions).
+- Memory files age — an older memory claiming "feature X is broken" may be stale if a fix shipped.
+- Humans trust recap output as ground truth. An unverified echo breaks that trust fast.
+
+**Patterns over intentions** — the code is the truth, the handoff is an intention. Always verify.
 
 ---
 
@@ -182,6 +228,15 @@ Same as `--now` but adds bigger picture context.
 3. Git status: git status --short
 4. Tracks: cat ψ/inbox/tracks/INDEX.md 2>/dev/null
 ```
+
+### Step 1.5: VERIFY pending from handoff
+
+Before outputting, run verification checks against each pending item (see "Verify Before Reporting" above). Batch checks in parallel:
+- `gh pr list --state all` for PR claims
+- `ls path/to/file` for "copy X" claims
+- `grep` for "apply pattern" claims
+
+If any diverge from the handoff, show the correction table.
 
 ### Step 2: Output
 

--- a/src/skills/resonance/SKILL.md
+++ b/src/skills/resonance/SKILL.md
@@ -65,15 +65,22 @@ Write to: `$PSI/memory/resonance/YYYY-MM-DD_HHMM_slug.md`
 [concept tags for future search]
 ```
 
-### 3. Sync to Oracle (if available)
+### 3. Sync to Oracle (if available, two-layer pattern)
 
-```
-arra_learn({
-  pattern: "[resonance title]: [what resonated]",
-  concepts: ["resonance", ...tags],
-  source: "resonance: [repo-name]"
-})
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_resonance-<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: "[resonance title]: [what resonated]"
+   date: <today>
+   source: resonance: [repo-name]
+   concepts: ["resonance", <tags>]
+   ---
+
+   # [resonance title]
+   [what resonated and why]
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ### 4. Output
 

--- a/src/skills/retrospective/SKILL.md
+++ b/src/skills/retrospective/SKILL.md
@@ -32,11 +32,22 @@ Include:
 - Lessons Learned
 - Next Steps
 
-### 3. Sync to Oracle
+### 3. Sync to Oracle (two-layer pattern)
 
-```
-arra_learn({ pattern: [lesson], concepts: [tags], source: "retrospective: REPO" })
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: <lesson in one line>
+   date: <today>
+   source: retrospective: REPO
+   concepts: [<tags>]
+   ---
+
+   # <lesson title>
+   <body>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 Do NOT git add ψ/ — vault is shared state.
 

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -98,11 +98,57 @@ Write immediately, no prompts. Include:
 
 **Path**: `$PSI/memory/learnings/YYYY-MM-DD_slug.md`
 
+### 3.5. Append Session-Metrics Row (REQUIRED)
+
+**Path**: `$PSI/memory/learnings/session-metrics.md`
+
+If the file doesn't exist, create with this header:
+
+```markdown
+# Oracle Session Metrics
+
+Rule (parent CLAUDE.md §"Self-Evaluation Loop"): same friction 3 sessions → fix root cause, not another workaround.
+
+| when | session | done | stuck | win | friction |
+|---|---|---|---|---|---|
+```
+
+Then append ONE row:
+
+| Column | Content |
+|---|---|
+| `when` | `YYYY-MM-DD HH:MM` in GMT+7 |
+| `session` | first 8 chars of `SESSION_ID` (from Step 1.5). If detection failed, write `unknown` |
+| `done` | tasks/items completed this session (comma-separated, terse) |
+| `stuck` | items blocked, deferred, or dropped — or `n/a` |
+| `win` | biggest unlock or ship this session (one line) |
+| `friction` | biggest drag, wall, or recurring pain (one line) |
+
+**Rule**: never skip. Trivial session? Still append with `trivial` in win/friction. Gaps break the pattern-detection value of the file.
+
 ### 4. Oracle Sync
 
 ```
 arra_learn({ pattern: [lesson content], concepts: [tags], source: "rrr: REPO" })
 ```
+
+### 4.5. Pattern Check (last 7 rows)
+
+Read the last 7 rows (or all rows if fewer) of `$PSI/memory/learnings/session-metrics.md`.
+
+Count keyword themes in the `friction` column. If any theme appears **≥3 times** in the window, append this section to the retrospective:
+
+```markdown
+## 🔁 Recurring Pattern Detected
+
+"<theme>" appeared in <N> of last 7 sessions (<session IDs>). Per parent CLAUDE.md §"Self-Evaluation Loop" — consider root-cause fix instead of another workaround.
+
+Suggested: open issue `root-cause: <theme>` or raise with Boss during next standup.
+```
+
+If no theme reaches ≥3 → skip this section silently.
+
+**Rule**: surface only. Do NOT auto-open issues or take action beyond flagging. Principle 3 (External Brain, Not Command) — Boss decides.
 
 ### 5. Save
 

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -126,11 +126,22 @@ Then append ONE row:
 
 **Rule**: never skip. Trivial session? Still append with `trivial` in win/friction. Gaps break the pattern-detection value of the file.
 
-### 4. Oracle Sync
+### 4. Oracle Sync (two-layer pattern)
 
-```
-arra_learn({ pattern: [lesson content], concepts: [tags], source: "rrr: REPO" })
-```
+1. Write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
+   ```yaml
+   ---
+   pattern: <lesson learned in one line>
+   date: <today>
+   source: rrr: REPO
+   concepts: [<tags>]
+   ---
+
+   # <lesson title>
+   <body>
+   ```
+
+2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
 
 ### 4.5. Pattern Check (last 7 rows)
 

--- a/src/skills/skills-list/scripts/skills-list.py
+++ b/src/skills/skills-list/scripts/skills-list.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""List all skills with profile tier, type, and script status.
+Usage: python3 skills-list.py [--json]
+"""
+import os, re, sys, json
+
+# Find repo root — try multiple paths
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+profiles_path = None
+skills_dir = None
+
+for candidate in [
+    os.path.join(SCRIPT_DIR, '..', '..'),           # .claude/scripts → repo root
+    os.path.join(SCRIPT_DIR, '..', '..', '..'),      # src/skills/X/scripts → repo root
+    os.path.join(SCRIPT_DIR, '..', '..'),             # src/skills/X → repo/src
+    os.getcwd(),                                       # current directory
+]:
+    p = os.path.join(candidate, 'src', 'profiles.ts')
+    s = os.path.join(candidate, 'src', 'skills')
+    if os.path.exists(p) and os.path.isdir(s):
+        profiles_path = p
+        skills_dir = s
+        break
+
+if not profiles_path:
+    # Fallback: scan installed skills
+    skills_dir = os.path.expanduser('~/.claude/skills')
+    profiles_path = None
+
+# Read profile constants from profiles.ts
+std_skills = []
+lab_skills = []
+zombie_skills = []
+if profiles_path and os.path.exists(profiles_path):
+    with open(profiles_path) as f:
+        content = f.read()
+    std_match = re.search(r'STANDARD_SKILLS = \[(.*?)\]', content, re.DOTALL)
+    if std_match:
+        std_skills = re.findall(r"'([^']+)'", std_match.group(1))
+    lab_match = re.search(r'LAB_SKILLS = \[(.*?)\]', content, re.DOTALL)
+    if lab_match:
+        lab_skills = re.findall(r"'([^']+)'", lab_match.group(1))
+    zombie_match = re.search(r'ZOMBIE_SKILLS = \[(.*?)\]', content, re.DOTALL)
+    if zombie_match:
+        zombie_skills = re.findall(r"'([^']+)'", zombie_match.group(1))
+
+std_set = set(std_skills)
+lab_set = set(lab_skills)
+zombie_set = set(zombie_skills)
+
+# Discover all skills
+all_skills = []
+if os.path.isdir(skills_dir):
+    for name in sorted(os.listdir(skills_dir)):
+        skill_dir = os.path.join(skills_dir, name)
+        if not os.path.isdir(skill_dir) or name.startswith('.'):
+            continue
+
+        skill_md = os.path.join(skill_dir, 'SKILL.md')
+        if not os.path.exists(skill_md):
+            continue
+
+        desc = ''
+        skill_type = 'skill'
+        hidden = False
+
+        if True:
+            with open(skill_md) as f:
+                content = f.read()
+            # Extract description
+            m = re.search(r'description:\s*["\']?(.+?)["\']?\s*$', content, re.MULTILINE)
+            if m:
+                desc = m.group(1).strip("'\"")[:60]
+            # Detect type
+            if 'subagent' in content.lower() or 'Agent(' in content:
+                skill_type = 'skill+agent'
+            if os.path.isdir(os.path.join(skill_dir, 'scripts')):
+                skill_type = 'skill+code'
+            # Hidden?
+            if re.search(r'hidden:\s*(true|yes)', content, re.IGNORECASE):
+                hidden = True
+
+        # Zombie?
+        zombie = False
+        if re.search(r'zombie:\s*(true|yes)', content if os.path.exists(skill_md) else '', re.IGNORECASE):
+            zombie = True
+
+        # Profile tier
+        if name in zombie_set or zombie:
+            profile = 'zombie'
+        elif name in std_set:
+            profile = 'standard'
+        elif name in lab_set:
+            profile = 'lab'
+        else:
+            profile = 'full'
+
+        all_skills.append({
+            'name': name,
+            'profile': profile,
+            'type': skill_type,
+            'description': desc,
+            'hidden': hidden,
+            'zombie': zombie,
+            'has_scripts': os.path.isdir(os.path.join(skill_dir, 'scripts')),
+        })
+
+# Output
+visible_skills = [s for s in all_skills if s['profile'] != 'zombie']
+zombie_only = [s for s in all_skills if s['profile'] == 'zombie']
+
+if '--json' in sys.argv:
+    print(json.dumps({
+        'total': len(all_skills),
+        'visible': len(visible_skills),
+        'standard': len(std_skills),
+        'full': len(visible_skills) - len(lab_skills),
+        'lab': len(visible_skills),
+        'zombie': len(zombie_only),
+        'skills': all_skills,
+    }, indent=2))
+else:
+    full_only = [s for s in all_skills if s['profile'] == 'full']
+    lab_only = [s for s in all_skills if s['profile'] == 'lab']
+    std_only = [s for s in all_skills if s['profile'] == 'standard']
+
+    print()
+    print(f'📦 Oracle Skills — {len(visible_skills)} skills ({len(zombie_only)} zombie)')
+    print()
+
+    # Standard
+    print(f'  ── Standard ({len(std_only)}) ── /go standard ──────────────────────')
+    for s in std_only:
+        scripts = ' ✓' if s['has_scripts'] else ''
+        print(f"     /{s['name']:24s} {s['type']:12s}{scripts}")
+
+    # Full
+    print()
+    print(f'  ── Full (+{len(full_only)}) ── /go full ─────────────────────────')
+    for s in full_only:
+        scripts = ' ✓' if s['has_scripts'] else ''
+        hidden = ' [hidden]' if s['hidden'] else ''
+        print(f"     /{s['name']:24s} {s['type']:12s}{scripts}{hidden}")
+
+    # Lab
+    print()
+    print(f'  ── Lab (+{len(lab_only)}) ── /go lab ──────────────────────────')
+    for s in lab_only:
+        scripts = ' ✓' if s['has_scripts'] else ''
+        print(f"     /{s['name']:24s} {s['type']:12s}{scripts}")
+
+    # Zombie (only show with --zombie flag)
+    if '--zombie' in sys.argv and zombie_only:
+        print()
+        print(f'  ── Zombie ({len(zombie_only)}) ── internal only ───────────────────')
+        for s in zombie_only:
+            scripts = ' ✓' if s['has_scripts'] else ''
+            print(f"     /{s['name']:24s} {s['type']:12s}{scripts} [zombie]")
+    elif zombie_only:
+        print()
+        print(f'  + {len(zombie_only)} zombie skills (internal dev — use --zombie to show)')
+
+    print()
+    print(f'  standard={len(std_only)} | full={len(std_only)+len(full_only)} | lab={len(visible_skills)} | zombie={len(zombie_only)}')
+    print()


### PR DESCRIPTION
## Summary

Today I opened 5 PRs against \`main\` before the user re-asserted "we are always alpha please" — had to retarget all 5 via \`gh pr edit --base alpha\`. The root cause was the existing CLAUDE.md table:

> \`Bug fixes | \`fix/name\` | PR → alpha or main\`

That "or main" was the loophole.

## Change

Tighten the Branch Strategy section to remove the ambiguity. Now: **every PR targets \`alpha\`**. \`main\` is reserved for alpha → main stable cuts only.

## Mechanism (already shipped locally, this PR documents it)

A PreToolUse safety hook at \`~/.claude/hooks/safety-pr-base.sh\` (in user's global config, not this repo) blocks \`gh pr create\` against \`main\` for this repo. The hook fires on:
- \`--base main\` → blocked with helpful diff
- No \`--base\` flag → blocked (gh defaults to main)
- Allowed: \`--base alpha\` (or any non-main base)

Self-tested green. Memory + CLAUDE.md describe the rule; the hook enforces it.

## Test plan

- [x] Hook self-test: blocks --base main, blocks no --base, allows --base alpha
- [x] This PR itself respects the new rule (targets alpha)
- [ ] After merge: alpha → main on next stable cut bundles this with the rest

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle