### PR TITLE
release: v26.5.13-alpha.1527

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ phukhao-oracle/
 .claude/skills/
 .claude/settings.local.json
 src/commands/
+
+# build artifact
+var/

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -134,7 +134,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.13-alpha.1200 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.13-alpha.1200",
+  "version": "26.5.13-alpha.1527",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts **v26.5.13-alpha.1527** on the modern HMM scheme (15:27 wall-clock).

This release bundles today's afternoon work:

| PR | Title |
|---|---|
| #302 | refine /rrr: self-audit, friction taxonomy, lesson/friction mandates, agent-decision label |
| #303 | feat: /rrr eval framework — kien-thai-shaped evals + audit-loop runner |
| #307 | feat: Foundation — CONVENTIONS.md + CI grep + Batch A bash-echo cleanup |
| #308 | docs(CLAUDE.md): always alpha, never main — close the bug-fix loophole |

Superseded (closed): #304, #306 (rolled into #307).

## Provenance

Two /team-agents brainstorms ran today (3 agents × 3 rounds each):
- `brainstorm-rrr-eval` → #302 + #303 (skill refinement + eval framework)
- `brainstorm-clickable-paths` → #307 + #308 (convention + foundation + docs)

Full Round 3 deliverables saved verbatim to `ψ/memory/mailbox/{rrr-eval,clickable-paths}/` in the oracle vault repo (~80KB of spec). Lesson held this time: Write → vault → SendMessage, in that order.

## On merge

`calver-release.yml` fires on merge to alpha → creates tag `v26.5.13-alpha.1527` → npm publish (alpha dist-tag) → GitHub Release (prerelease) + dist/maw artifact attached.

## Test plan

- [x] Calver target = v26.5.13-alpha.1527 (HMM scheme, current wall clock)
- [x] Working tree clean except `var/` (now in .gitignore)
- [x] All 4 bundled PRs merged green to alpha (#302, #303, #307, #308)
- [ ] After merge: tag fires, npm publishes, /go lab on m5 pulls the new version

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle