### PR TITLE
fix(oracle-family-scan): sync.ts lives in laris-co/mother-oracle, not brain repo

### DIFF
--- a/src/skills/oracle-family-scan/SKILL.md
+++ b/src/skills/oracle-family-scan/SKILL.md
@@ -28,16 +28,21 @@ Scan, query, and welcome the Oracle family. Powered by `registry/` in mother-ora
 
 ## Step 0: Locate Registry
 
-The registry lives in the opensource-nat-brain-oracle repo (public). Resolve the path:
+The registry's canonical home is `laris-co/mother-oracle/registry/` (where `sync.ts` + `oracles.json` actually live). The legacy `opensource-nat-brain-oracle` repo back-symlinks to it for back-compat. Resolve the path:
 
 ```bash
-# Try brain repo first (ghq-managed)
-MOTHER="$HOME/Code/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle"
+# Try laris-co/mother-oracle (canonical home of sync.ts + oracles.json)
+MOTHER="$HOME/Code/github.com/laris-co/mother-oracle"
 if [ ! -d "$MOTHER/registry" ]; then
-  MOTHER="$(ghq root)/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle"
+  MOTHER="$(ghq root)/github.com/laris-co/mother-oracle"
+fi
+# Fallback: legacy brain repo (back-symlinks to laris-co/mother-oracle)
+if [ ! -f "$MOTHER/registry/oracles.json" ]; then
+  MOTHER="$HOME/Code/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle"
+  [ ! -d "$MOTHER/registry" ] && MOTHER="$(ghq root)/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle"
 fi
 if [ ! -f "$MOTHER/registry/oracles.json" ]; then
-  echo "Registry not found. Run: ghq get -u Soul-Brews-Studio/opensource-nat-brain-oracle && bun $MOTHER/registry/sync.ts"
+  echo "Registry not found. Run: ghq get -u laris-co/mother-oracle && bun \$MOTHER/registry/sync.ts"
   exit 1
 fi
 ```


### PR DESCRIPTION
## Summary

One-file doc fix. /oracle-family-scan SKILL.md Step 0 said the registry's sync.ts lives in `Soul-Brews-Studio/opensource-nat-brain-oracle/registry/` — it actually lives in `laris-co/mother-oracle/registry/`. The brain repo only back-symlinks; it's not the authoritative location.

## What changed

- Try `laris-co/mother-oracle` FIRST in path resolution
- Fall back to `opensource-nat-brain-oracle` for legacy users who already have it cloned
- Updated error message + ghq get hint

## Why

Surfaced by timeline-miner during brainstorm-family-timeline (`ψ/memory/mailbox/family-timeline/`). When the brainstorm tried to read sync.ts to design extensions, the path in SKILL.md returned "not found" until cross-checking with `find ~/Code -name "sync.ts"`.

## Test plan

- [x] grep confirms laris-co references present
- [x] check_skill_convention.sh passes
- [x] bun run compile succeeds
- [ ] After merge: fresh `/oracle-family-scan` invocation correctly locates the registry on first try

🤖 ตอบโดย skill-path-fix จาก Nat → arra-oracle-skills-cli-oracle (brainstorm-family-timeline R3)