### PR TITLE
fix(#300): add scripts/heartbeat-watcher.sh stub to team-agents skill

### DIFF
--- a/src/skills/team-agents/scripts/heartbeat-watcher.sh
+++ b/src/skills/team-agents/scripts/heartbeat-watcher.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# heartbeat-watcher.sh — passive activity tracker for team-agents teammates
+#
+# Fired on UserPromptSubmit + Stop hooks (configured in ~/.claude/settings.json
+# by the team-agents skill installer). Without this script existing on disk,
+# every hook fires "No such file or directory" and pollutes the session — that
+# was issue #300.
+#
+# This is currently a STUB. The full implementation per SKILL.md derives
+# last_activity_at from four signals (max wins):
+#   1. Pane tail diff (bottom 3 lines of agent's tmux pane, cached at /tmp/maw-pane-snap/)
+#   2. CPU time delta (ps -o time snapshot, portable Mac+Linux, no /proc dependency)
+#   3. Mailbox mtime (~/.claude/teams/<team>/inboxes/<agent>.json)
+#   4. Task file mtime (~/.claude/tasks/<team>/<id>.json)
+#
+# State written to ~/.claude/teams/<team>/heartbeats/<agent>.json.
+# Real impl: detect stale (>5min) and silent (>15min) teammates, emit
+# <system-reminder> to stdout for the lead to act on.
+#
+# Until then: no-op. The hook no longer errors; the presence dots in
+# `/team-agents who` fall back to recomputing from raw signals at read
+# time. Stale/silent detection isn't enforced, but teams still work —
+# the lead checks worktree state and SendMessage flow instead.
+#
+# Args:
+#   (none)       — fire normally
+#   --silent     — print just the stale count (used by doctor.sh)
+#
+# See: https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli/issues/300
+# Spec: src/skills/team-agents/SKILL.md (Heartbeat section)
+
+# Silent mode for doctor.sh
+if [ "${1:-}" = "--silent" ]; then
+  echo "0"
+  exit 0
+fi
+
+# Normal hook fire — no-op, exit clean so the hook doesn't error
+exit 0


### PR DESCRIPTION
## Summary

The team-agents skill registers Stop + UserPromptSubmit hooks in `~/.claude/settings.json` pointing at `scripts/heartbeat-watcher.sh` — but the skill ships SKILL.md WITHOUT the script. Every hook fires `No such file or directory` and pollutes the session.

Bit us **twice today**:
1. Detected mid-morning, patched local stub at `~/.claude/skills/team-agents/scripts/heartbeat-watcher.sh`
2. Local stub got wiped by `/go lab` later in the session — re-patched
3. Foundation PR brainstorm team (`convention-author`) hit the same error mid-flight, contributing to a mid-task stall

## Fix

Ship the file in the skill so #275's installer (copies non-MD sibling files into the install dir) picks it up automatically. Combined with #300 stub, the cycle is closed: no more "wipes on /go lab", no more "another session, another patch".

## Current scope: stub only

Full implementation per `SKILL.md` Heartbeat section involves four signals (pane tail diff + CPU time delta + mailbox mtime + task file mtime) and stale/silent detection emitting `<system-reminder>` blocks. That's a 100-200 line bash script — deferred to follow-up.

This stub:
- exits 0 on normal hook fire (kills the error)
- prints "0" on `--silent` (compatible with `doctor.sh`'s contract)
- documents the gap in a header comment so the next maintainer knows what's missing and where the real impl belongs

## Test plan

- [x] Script exists, has +x, runs without error
- [x] `bash heartbeat-watcher.sh && echo $?` returns 0
- [x] `bash heartbeat-watcher.sh --silent` prints "0"
- [ ] After merge: `/go lab` on m5 + restart — no more `No such file or directory` errors in hook output

Closes #300.

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle