### PR TITLE
fix(#305,#301): Batch B — clickable paths + date-stamp for 5 heavy-touch skills

### DIFF
--- a/src/commands/awaken.md
+++ b/src/commands/awaken.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v3.3.1 | Guided Oracle birth and awakening ritual. Default is Full Soul Sync (~20min), or --fast (~5min). Use when creating a new Oracle in a fresh repo, when user says "awaken", "birth oracle", "create oracle", "new oracle", or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context.'
+description: '[core] v26.5.13-alpha.1527 | "Guided Oracle birth and awakening ritual. Default is Soul Sync (~20min), or --fast (~5min). Use when creating a new Oracle in a fresh repo, when user says ''awaken'', ''birth oracle'', ''create oracle'', ''new oracle'', or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context."'
 argument-hint: "[--fast | --soul-sync | --reawaken]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `awaken` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "awaken" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.3.1*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/skills/awaken/SKILL.md
+++ b/src/skills/awaken/SKILL.md
@@ -99,8 +99,15 @@ If `--reawaken` argument passed, skip wizard entirely — go to --reawaken flow 
 Before system check, detect if the session is under context pressure:
 
 ```bash
+# Step 0 date-stamp: ground the AI in the current moment per invocation (#301).
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Capture oracle root for absolute-path announce sites (CONVENTIONS.md).
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+PSI="$ORACLE_ROOT/ψ"
+
 # Check if this session has been running long (many messages processed)
-ENCODED_PWD=$(echo "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" | sed 's|^/|-|; s|[/.]|-|g')
+ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_DIR="$HOME/.claude/projects/${ENCODED_PWD}"
 LATEST_JSONL=$(ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1)
 if [ -n "$LATEST_JSONL" ]; then
@@ -714,8 +721,12 @@ gh issue create \
 
 **If `family_join: true` BUT `gh` is NOT available**:
 
-```
-📤 Saved to ψ/outbox/. Forward to family later when gh is ready.
+announce-mode → emit via bash echo so `$PSI` substitutes to the absolute
+outbox path (CONVENTIONS.md — never print bare `ψ/`).
+
+```bash
+echo "📤 Saved to: $PSI/outbox/awaken_$(date +%Y-%m-%d)_${MODE:-full}.md"
+echo "    Forward to family later when gh is ready."
 ```
 
 Do NOT warn or nag. The outbox file is there — they can forward it whenever they install gh.

--- a/src/skills/contacts/SKILL.md
+++ b/src/skills/contacts/SKILL.md
@@ -8,6 +8,18 @@ argument-hint: "[list | add <name> | remove <name> | show <name>]"
 
 Manage contacts for `/talk-to` routing. Stored in repo at `ψ/contacts.json` — committable, shareable.
 
+## Step 0: Ground (date-stamp + root capture)
+
+Run before any mode — current-time reference for the AI (#301) plus absolute
+`$PSI` so announce-mode writes show clickable paths (CONVENTIONS.md).
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+PSI="$ORACLE_ROOT/ψ"
+CONTACTS_FILE="$PSI/contacts.json"
+```
+
 ## File Location
 
 ```
@@ -115,8 +127,7 @@ Skip interactive for provided flags. Still ask for missing ones.
 ### Save
 
 ```bash
-# Read existing
-CONTACTS_FILE="$(pwd)/ψ/contacts.json"
+# Read existing — $CONTACTS_FILE comes from Step 0 (absolute, via $PSI).
 mkdir -p "$(dirname "$CONTACTS_FILE")"
 
 # If file doesn't exist, create empty

--- a/src/skills/incubate/SKILL.md
+++ b/src/skills/incubate/SKILL.md
@@ -510,18 +510,22 @@ Append new sessions. Never overwrite existing entries (Nothing is Deleted).
 ## Output Summary
 
 ### Default mode
-```
-🌱 Incubating: [REPO]
 
-  Mode:     default (long-term dev)
-  Location: ψ/incubate/OWNER/REPO/
-  Working:  ~/Code/github.com/OWNER/REPO/
-  Branch:   [current-branch]
-  Remote:   [origin-url]
-  Status:   [N] changed files
+announce-mode → bash substitutes $ROOT/$OWNER/$REPO/$WORK_DIR to absolute paths;
+never print "Location: ψ/..." literally. See CONVENTIONS.md.
 
-  Next: make changes, commit, push, create PR
-  Done: /incubate --offload OWNER/REPO
+```bash
+echo "🌱 Incubating: $REPO"
+echo ""
+echo "  Mode:     default (long-term dev)"
+echo "  Location: $ROOT/ψ/incubate/$OWNER/$REPO/"
+echo "  Working:  $WORK_DIR"
+echo "  Branch:   $(git -C "$WORK_DIR" branch --show-current)"
+echo "  Remote:   $(git -C "$WORK_DIR" remote get-url origin)"
+echo "  Status:   $(git -C "$WORK_DIR" status --short | wc -l) changed files"
+echo ""
+echo "  Next: make changes, commit, push, create PR"
+echo "  Done: /incubate --offload $OWNER/$REPO"
 ```
 
 ### --flash mode
@@ -537,24 +541,32 @@ Append new sessions. Never overwrite existing entries (Nothing is Deleted).
 ```
 
 ### --contribute mode
-```
-🤝 Contributing: [REPO]
 
-  Location: ψ/incubate/OWNER/REPO/
-  Fork:     [fork-url if forked]
-  Branches: [list]
-  PRs:      [list]
+announce-mode → bash substitutes; never print "Location: ψ/..." literally.
 
-  Next: continue working, or /incubate --offload when done
+```bash
+echo "🤝 Contributing: $REPO"
+echo ""
+echo "  Location: $ROOT/ψ/incubate/$OWNER/$REPO/"
+echo "  Fork:     ${FORK_URL:-[none]}"
+echo "  Branches: ${BRANCHES:-[list]}"
+echo "  PRs:      ${PRS:-[list]}"
+echo ""
+echo "  Next: continue working, or /incubate --offload when done"
 ```
 
 ### --status mode
+
+The actual emission lives in the bash block under `Mode: --status` above —
+`echo "    Path:   $TARGET"` resolves `$TARGET` via `readlink`, so paths are
+absolute. Example rendering:
+
 ```
 🌱 Active Incubations
 
   OWNER/REPO
     Branch: feat/x | Changes: 3
-    Path:   ~/Code/github.com/OWNER/REPO
+    Path:   /Users/nat/ghq/github.com/OWNER/REPO
 
   Total: N active incubation(s)
 ```

--- a/src/skills/morpheus/SKILL.md
+++ b/src/skills/morpheus/SKILL.md
@@ -12,6 +12,21 @@ argument-hint: "[--pain | --plan | --gain | --all | --speculate | --between]"
 
 /dream sees the forest. /morpheus sees what the forest will look like *tomorrow*.
 
+---
+
+## Step 0: Ground (date-stamp + root capture)
+
+Run before any phase — gives the AI a current-time reference (#301) and an
+absolute `$PSI` for any announce-mode writes (CONVENTIONS.md).
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+PSI="$ORACLE_ROOT/ψ"
+```
+
+---
+
 ## What's New vs /dream
 
 | Feature | /dream (lab) | /morpheus (secret) |

--- a/src/skills/vault/SKILL.md
+++ b/src/skills/vault/SKILL.md
@@ -10,6 +10,18 @@ argument-hint: "[connect <path> | disconnect <name> | search <query> | list]"
 
 Connect external knowledge bases so Oracle can think from ALL your accumulated knowledge, not just the current repo.
 
+## Step 0: Ground (date-stamp + root capture)
+
+Run before any mode — current-time reference for the AI (#301) plus absolute
+`$PSI` for the registry path (CONVENTIONS.md).
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+PSI="$ORACLE_ROOT/ψ"
+VAULT_REGISTRY="$PSI/vault.json"
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
## Summary

Batch B of the #305 audit — applies two conventions to **5 heavy-touch skills**:
`awaken`, `morpheus`, `incubate`, `vault`, `contacts`.

### Convention 1 — clickable paths (#305 / CONVENTIONS.md)

Announce-mode print sites now use the bash-echo pattern so `$VAR` substitutes
to an absolute, ⌘-clickable path. Structure-mode tree diagrams left untouched
(they're labels, not click targets — per CONVENTIONS.md mode 2).

Highlights:

- **incubate** — The worst offender per Nat's audit: the
  `Location: ψ/incubate/OWNER/REPO/` line in the default-mode + --contribute
  Output Summary blocks was a fenced text-block mockup the AI mirrored
  literally. Rewritten as bash-echo so `$ROOT/$OWNER/$REPO` resolves to an
  absolute path the human can click. Default-mode block also surfaces the
  real `$WORK_DIR`, branch, remote, and changed-file count via the live
  values, replacing the `[current-branch]` / `[origin-url]` placeholders.
- **awaken** — `📤 Saved to ψ/outbox/.` rewritten as bash echo on `$PSI`,
  rendering the full announcement path (`awaken_YYYY-MM-DD_<mode>.md`).

### Convention 2 — date-stamp at Step 0 (#301)

Each skill now emits the current date/time at the start of its first bash
block, grounding the AI in the current moment per invocation
(matching `/rrr`, `/trace`, `/check-calver`).

| Skill | Where it landed |
|---|---|
| awaken | Inside the existing Phase 0 bash block (context-pressure detector); also captures `$PSI` for later announce sites. |
| morpheus | New "Step 0: Ground" block at top — date + `$PSI`. |
| incubate | Already had `date "+🕐 …"` at line 92 — left untouched. |
| vault | New "Step 0: Ground" block + `$VAULT_REGISTRY` derived from `$PSI`. |
| contacts | New "Step 0: Ground" block + `$CONTACTS_FILE` derived from `$PSI`; existing save block reused the new var. |

### What was deliberately NOT changed

- Tree diagrams (`ψ/inbox/`, `ψ/memory/...`) — mode 2 structure docs.
- `ψ/...` paths inside ` ```bash ` fences — bash substitutes at runtime
  (mode 3 per CONVENTIONS.md).
- Markdown headings/prose mentions like ``"## Registry: `ψ/vault.json`"`` —
  reading material, not announce-mode click targets.
- Other 4 compiled `src/commands/*.md` stubs — gitignored in this repo;
  only the `awaken.md` stub (already tracked) was committed.

## Test plan

- [x] `bash scripts/check_skill_convention.sh` → ✅ passes (0 violations)
- [x] `bun run compile` → 62 skill stubs regenerated cleanly
- [x] `git diff --stat` reviewed — only 5 SKILL.md + 1 tracked stub changed
- [ ] Manual smoke: `/incubate <slug>` shows clickable `Location:` line
- [ ] Manual smoke: `/awaken` Phase 0 prints date stamp first thing
- [ ] Manual smoke: `/morpheus`, `/vault`, `/contacts` each emit Step 0 date

Closes #301 (partial — Batches C+D handle the remaining skills). Advances #305.

🤖 ตอบโดย arra-oracle-skills-cli (batch-b) จาก [Nat] → arra-oracle-skills-cli-oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)