### PR TITLE
fix(#305,#301): Batch D — clickable paths + date-stamp for 9 tail skills

### DIFF
--- a/src/commands/about-oracle.md
+++ b/src/commands/about-oracle.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v3.3.1 | What is Oracle — told by the AI itself. Origin story, stats, family count, ecosystem overview. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story. Do NOT trigger for "who are you" (use /who-are-you), "philosophy" (use /philosophy), or session status questions.'
+description: '[core] v26.5.13-alpha.1527 | What is Oracle — told by the AI itself. Origin story, stats, family count, ecosystem overview. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story. Do NOT trigger for "who are you" (use /who-are-you), "philosophy" (use /philosophy), or session status questions.'
 argument-hint: "--short | --stats | --family | --th | --en/th"
 ---
 
@@ -19,5 +19,5 @@ Execute the `about-oracle` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "about-oracle" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.3.1*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/philosophy.md
+++ b/src/commands/philosophy.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v3.3.1 | Display Oracle philosophy — the 5 Principles + Rule 6. Use when user asks about principles, "nothing deleted", "patterns over intentions", Oracle philosophy, or needs alignment check. Do NOT trigger for "who are you" (use /who-are-you), "what is oracle" (use /about-oracle), or session status questions.'
+description: '[core] v26.5.13-alpha.1527 | Display Oracle philosophy — the 5 Principles + Rule 6. Use when user asks about principles, "nothing deleted", "patterns over intentions", Oracle philosophy, or needs alignment check. Do NOT trigger for "who are you" (use /who-are-you), "what is oracle" (use /about-oracle), or session status questions.'
 ---
 
 # /philosophy
@@ -18,5 +18,5 @@ Execute the `philosophy` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "philosophy" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.3.1*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/talk-to.md
+++ b/src/commands/talk-to.md
@@ -1,6 +1,6 @@
 ---
-description: '[core] v3.3.1 | Talk to another Oracle agent via threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent (e.g. "talk to pulse", "message neo"). Do NOT trigger for OracleNet social feed (use /oraclenet), skill management (use /oracle), or family registry (use /oracle-family-scan).'
-argument-hint: "<agent-name> [message]"
+description: '[core] v26.5.13-alpha.1527 | Talk to another Oracle agent via contacts + threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent (e.g. "talk to pulse", "message neo"). Do NOT trigger for OracleNet social feed (use /oraclenet), skill management (use /oracle), or family registry (use /oracle-family-scan).'
+argument-hint: "<agent-name> [message] [--maw | --thread | --inbox]"
 ---
 
 # /talk-to
@@ -19,5 +19,5 @@ Execute the `talk-to` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "talk-to" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.3.1*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/who-are-you.md
+++ b/src/commands/who-are-you.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v3.3.1 | Know ourselves — show current AI identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", "what model", or wants to check current AI identity and session context. Do NOT trigger for "what is oracle" (use /about-oracle), "philosophy" or "principles" (use /philosophy), or general project questions.'
+description: '[core] v26.5.13-alpha.1527 | Know ourselves — show current AI identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", "what model", or wants to check current AI identity and session context. Do NOT trigger for "what is oracle" (use /about-oracle), "philosophy" or "principles" (use /philosophy), or general project questions.'
 ---
 
 # /who-are-you
@@ -18,5 +18,5 @@ Execute the `who-are-you` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "who-are-you" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.3.1*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/skills/dream/SKILL.md
+++ b/src/skills/dream/SKILL.md
@@ -22,6 +22,14 @@ argument-hint: "[--pain | --plan | --gain | --all]"
 
 ---
 
+## Step 0: Timestamp
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+```
+
+---
+
 ## How It Works
 
 Launch **5 parallel agents**, each searching a different dimension:

--- a/src/skills/feel/SKILL.md
+++ b/src/skills/feel/SKILL.md
@@ -19,6 +19,14 @@ argument-hint: "[--deep | --log]"
 
 ---
 
+## Step 0: Timestamp
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+```
+
+---
+
 ## Quick Pulse (default)
 
 Read the signals and report:

--- a/src/skills/mailbox/SKILL.md
+++ b/src/skills/mailbox/SKILL.md
@@ -60,6 +60,7 @@ Claude Code's data dies with the session. Our data lives in the vault. Nothing i
 ## Step 0: Run the Script
 
 ```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
 bash ~/.claude/skills/mailbox/scripts/mailbox.sh [command] [args]
 ```
 

--- a/src/skills/talk-to/SKILL.md
+++ b/src/skills/talk-to/SKILL.md
@@ -30,6 +30,7 @@ If ARGUMENTS is empty, show usage help then run --list.
 **Always read contacts first.** This is the source of truth for agent routing.
 
 ```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
 CONTACTS="$(pwd)/ψ/contacts.json"
 if [ ! -f "$CONTACTS" ]; then
   # Fallback path

--- a/src/skills/who-are-you/SKILL.md
+++ b/src/skills/who-are-you/SKILL.md
@@ -16,7 +16,11 @@ description: Know ourselves — show current AI identity, model info, session st
 
 ## Step 0: Timestamp + Output Format
 
-_(Chain date with Step 1 bash call — don't call date alone)_
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+```
+
+_(Chained with Step 1 bash call below — single date emission, then the gather block.)_
 
 ---
 


### PR DESCRIPTION
Completes the #305 audit (22/22 skills migrated) and closes #301 (all skills print date/time at Step 0). With Batches B+C, this is the full close-out.

## Scope — 9 tail skills

- about-oracle, philosophy, calver, wormhole — already had date-stamp; clickable-paths already compliant (no changes needed in SKILL.md)
- dream, feel — added new Step 0: Timestamp section
- mailbox, talk-to — added date line to existing Step 0 bash block
- who-are-you — replaced the chain-date hint with an actual Step 0 date bash block

## Verification

- `bash scripts/check_skill_convention.sh` → ✅ All SKILL.md pass announce-mode
- `bun run compile` → ✅ 62 stubs compiled
- Compiled stubs for the 4 changed-output skills regenerated (about-oracle, philosophy, talk-to, who-are-you)

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle