### PR TITLE
fix(ci): disable inbox-auto-add workflow (no self-hosted runner)

### DIFF
--- a/.github/workflows/inbox-auto-add.yml
+++ b/.github/workflows/inbox-auto-add.yml
@@ -1,10 +1,20 @@
 name: Auto-add to Pulse Inbox
 
+# DISABLED 2026-05-13: runs-on: self-hosted but no self-hosted runner is
+# currently provisioned. Every fire showed as "queued forever / cancelled"
+# in PR check status, polluting the dashboard. Auto-triggers removed;
+# workflow_dispatch retained so it can be re-enabled by anyone bringing
+# back a runner (or re-targeting to ubuntu-latest + porting maw to a
+# GitHub-hosted runner).
+#
+# Original triggers (kept here for revival):
+#   issues:
+#     types: [opened, closed]
+#   pull_request:
+#     types: [opened, closed]
+
 on:
-  issues:
-    types: [opened, closed]
-  pull_request:
-    types: [opened, closed]
+  workflow_dispatch:
 
 jobs:
   add-to-inbox:


### PR DESCRIPTION
## Summary

The Auto-add to Pulse Inbox workflow has 3 jobs all declaring `runs-on: self-hosted`. There's no self-hosted runner provisioned currently, so every fire on `issues:` or `pull_request:` events showed as a blank "queued forever / cancelled" job in PR check status — visible in every PR all afternoon.

## Change

- Removed `issues:` + `pull_request:` triggers
- Kept the file with `workflow_dispatch:` only — preserves the workflow for revival per Nothing-is-Deleted
- Original triggers documented in header comment

## Result

PR check status clean going forward. No more phantom "Auto-add to Pulse Inbox" entries.

## Revival

When a self-hosted runner is brought back (or this gets ported to ubuntu-latest):
1. Restore the `on:` triggers from the header comment
2. Remove the disabled-notice comment
3. Optional: change `runs-on: self-hosted` → `runs-on: ubuntu-latest` if porting `maw` to a portable wrapper

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle