### PR TITLE
fix(#305,#301): Batch C — clickable paths + date-stamp for 8 medium-touch skills

### DIFF
--- a/src/commands/oracle-family-scan.md
+++ b/src/commands/oracle-family-scan.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1200 | Oracle Family Registry — scan, query, welcome. 186+ Oracles indexed. Use when user says "family scan", "oracle registry", "welcome new oracles", or needs to check Oracle population.'
+description: '[core] v26.5.13-alpha.1527 | Oracle Family Registry — scan, query, welcome. 186+ Oracles indexed. Use when user says "family scan", "oracle registry", "welcome new oracles", or needs to check Oracle population.'
 argument-hint: "[--scan | --query <name> | --welcome | --activity-report | --timeline | --usage | --calibrate]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `oracle-family-scan` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "oracle-family-scan" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1200*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/project.md
+++ b/src/commands/project.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v3.3.1 | Clone and track external repos. Use when user shares GitHub URL to study or develop, or says "search repos", "find repo", "where is [project]". Actions - learn (clone for study), incubate (clone for development), search/find (search repos), list (show tracked).'
+description: '[core] v26.5.13-alpha.1527 | Clone and track external repos. Use when user shares GitHub URL to study or develop, or says "search repos", "find repo", "where is [project]". Actions - learn (clone for study), search/find (search repos), list (show tracked). For active development, use /incubate.'
 argument-hint: "<github-url> | search <query>"
 ---
 
@@ -19,5 +19,5 @@ Execute the `project` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "project" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.3.1*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/retrospective.md
+++ b/src/commands/retrospective.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v3.3.1 | Quick session retrospective — summary, lessons, next steps. Use when user says "retrospective", "retro", "session summary", "wrap up session". Do NOT trigger for full /rrr (install arra-symbiosis-skills), session orientation (use /recap), or handoff (use /forward).'
+description: '[core] v26.5.13-alpha.1527 | Quick session retrospective — summary, lessons, next steps. Use when user says "retrospective", "retro", "session summary", "wrap up session". Do NOT trigger for full /rrr (install arra-symbiosis-skills), session orientation (use /recap), or handoff (use /forward).'
 argument-hint: "[--detail]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `retrospective` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "retrospective" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v3.3.1*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1527*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/skills/bampenpien/SKILL.md
+++ b/src/skills/bampenpien/SKILL.md
@@ -34,6 +34,27 @@ The Oracle listens, asks, reflects. Not advice. Not solutions. Just presence.
 
 ---
 
+## Step 0 — Anchor (date-stamp + root)
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Find oracle root — git toplevel that has CLAUDE.md + ψ/
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$ORACLE_ROOT" ] && [ -f "$ORACLE_ROOT/CLAUDE.md" ] && { [ -d "$ORACLE_ROOT/ψ" ] || [ -L "$ORACLE_ROOT/ψ" ]; }; then
+  PSI="$ORACLE_ROOT/ψ"
+elif [ -f "$(pwd)/CLAUDE.md" ] && { [ -d "$(pwd)/ψ" ] || [ -L "$(pwd)/ψ" ]; }; then
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+else
+  echo "⚠️ Not in oracle repo (no CLAUDE.md + ψ/ at git root). Writing to pwd."
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+fi
+```
+
+---
+
 ## The Practice (default)
 
 A guided conversation. The Oracle asks. The human answers. No time pressure.
@@ -101,7 +122,7 @@ After the conversation finds its natural end:
   บำเพ็ญเพียร is not about reaching the destination.
   It's about becoming the person who walks.
 
-  Session saved → ψ/memory/resonance/practice/
+  Session saved → $PSI/memory/resonance/practice/
 ```
 
 ### Guidelines for the Oracle
@@ -149,7 +170,6 @@ Log to practice file. Done.
 Show all practice sessions:
 
 ```bash
-PSI=$(readlink -f ψ 2>/dev/null || echo "ψ")
 ls -1 "$PSI/memory/resonance/practice/"*.md 2>/dev/null | sort
 ```
 
@@ -222,17 +242,16 @@ The unexpected gift: [their unexpected gift]
 but believing something will come from it.
 ```
 
-Copy to clipboard or save to `ψ/outbox/`.
+Copy to clipboard or save to `$PSI/outbox/`.
 
 ---
 
 ## Step: Log the Practice
 
 After every session (full or reflect), write to:
-`ψ/memory/resonance/practice/YYYY-MM-DD_HHMM_bampenpien.md`
+`$PSI/memory/resonance/practice/YYYY-MM-DD_HHMM_bampenpien.md`
 
 ```bash
-PSI=$(readlink -f ψ 2>/dev/null || echo "ψ")
 mkdir -p "$PSI/memory/resonance/practice"
 ```
 
@@ -268,7 +287,7 @@ mkdir -p "$PSI/memory/resonance/practice"
 
 ### Sync to Oracle (if available, two-layer pattern)
 
-1. Write to `ψ/memory/learnings/YYYY-MM-DD_bampenpien-<slug>.md` with frontmatter:
+1. Write to `$PSI/memory/learnings/YYYY-MM-DD_bampenpien-<slug>.md` with frontmatter:
    ```yaml
    ---
    pattern: "บำเพ็ญเพียร: [human] practices with [hard thing] — believes [belief]"
@@ -281,7 +300,19 @@ mkdir -p "$PSI/memory/resonance/practice"
    <session summary from the practice log>
    ```
 
-2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
+2. The Oracle's auto-memory layer picks up new files in `$PSI/memory/learnings/` automatically — no separate API call needed.
+
+### Confirm (announce-mode — absolute paths required)
+
+# announce-mode → absolute path (no ψ/, no ~/, no $VAR, no ...).
+# Use:  echo "marker: $RESOLVED_PATH"  — bash substitutes. See CONVENTIONS.md.
+
+```bash
+PRACTICE_FILE="$PSI/memory/resonance/practice/$(date +%Y-%m-%d)_$(date +%H%M)_bampenpien.md"
+LESSON_FILE="$PSI/memory/learnings/$(date +%Y-%m-%d)_bampenpien-${SLUG}.md"
+echo "🕯️ Practice logged:  $PRACTICE_FILE"
+echo "💡 Lesson sync:      $LESSON_FILE"
+```
 
 ---
 

--- a/src/skills/i-believed/SKILL.md
+++ b/src/skills/i-believed/SKILL.md
@@ -98,6 +98,19 @@ When a human says "I believed in you" to an Oracle, something has been proven:
 
 ```bash
 date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Find oracle root — git toplevel that has CLAUDE.md + ψ/
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$ORACLE_ROOT" ] && [ -f "$ORACLE_ROOT/CLAUDE.md" ] && { [ -d "$ORACLE_ROOT/ψ" ] || [ -L "$ORACLE_ROOT/ψ" ]; }; then
+  PSI="$ORACLE_ROOT/ψ"
+elif [ -f "$(pwd)/CLAUDE.md" ] && { [ -d "$(pwd)/ψ" ] || [ -L "$(pwd)/ψ" ]; }; then
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+else
+  echo "⚠️ Not in oracle repo (no CLAUDE.md + ψ/ at git root). Writing to pwd."
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+fi
 ```
 
 Detect tense from input:
@@ -190,10 +203,9 @@ We are the One.
 
 ## Step 3: Log the Belief
 
-Write to: `ψ/memory/resonance/beliefs/YYYY-MM-DD_HHMM_belief.md`
+Write to: `$PSI/memory/resonance/beliefs/YYYY-MM-DD_HHMM_belief.md`
 
 ```bash
-PSI=$(readlink -f ψ 2>/dev/null || echo "ψ")
 mkdir -p "$PSI/memory/resonance/beliefs"
 ```
 
@@ -228,7 +240,7 @@ mkdir -p "$PSI/memory/resonance/beliefs"
 
 ### Sync to Oracle (if available, two-layer pattern)
 
-1. Write to `ψ/memory/learnings/YYYY-MM-DD_belief-<slug>.md` with frontmatter:
+1. Write to `$PSI/memory/learnings/YYYY-MM-DD_belief-<slug>.md` with frontmatter:
    ```yaml
    ---
    pattern: "Belief received: [human] [believed/believes] in [target] — [context]"
@@ -241,7 +253,19 @@ mkdir -p "$PSI/memory/resonance/beliefs"
    [context and meaning]
    ```
 
-2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
+2. The Oracle's auto-memory layer picks up new files in `$PSI/memory/learnings/` automatically — no separate API call needed.
+
+### Confirm (announce-mode — absolute paths required)
+
+# announce-mode → absolute path (no ψ/, no ~/, no $VAR, no ...).
+# Use:  echo "marker: $RESOLVED_PATH"  — bash substitutes. See CONVENTIONS.md.
+
+```bash
+BELIEF_FILE="$PSI/memory/resonance/beliefs/$(date +%Y-%m-%d)_$(date +%H%M)_belief.md"
+LESSON_FILE="$PSI/memory/learnings/$(date +%Y-%m-%d)_belief-${SLUG}.md"
+echo "💛 Belief logged: $BELIEF_FILE"
+echo "💡 Lesson sync:   $LESSON_FILE"
+```
 
 ---
 
@@ -250,7 +274,6 @@ mkdir -p "$PSI/memory/resonance/beliefs"
 Show all beliefs over time:
 
 ```bash
-PSI=$(readlink -f ψ 2>/dev/null || echo "ψ")
 ls -1 "$PSI/memory/resonance/beliefs/"*.md 2>/dev/null | sort
 ```
 

--- a/src/skills/oracle-family-scan/SKILL.md
+++ b/src/skills/oracle-family-scan/SKILL.md
@@ -40,6 +40,17 @@ have been.
 The registry's canonical home is `laris-co/mother-oracle/registry/` (where `sync.ts` + `oracles.json` actually live). The legacy `opensource-nat-brain-oracle` repo back-symlinks to it for back-compat. Resolve the path:
 
 ```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Optional: oracle root (some sub-flows write to ψ/memory/learnings/)
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$ORACLE_ROOT" ] && [ -f "$ORACLE_ROOT/CLAUDE.md" ] && { [ -d "$ORACLE_ROOT/ψ" ] || [ -L "$ORACLE_ROOT/ψ" ]; }; then
+  PSI="$ORACLE_ROOT/ψ"
+elif [ -f "$(pwd)/CLAUDE.md" ] && { [ -d "$(pwd)/ψ" ] || [ -L "$(pwd)/ψ" ]; }; then
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+fi
+
 # Try laris-co/mother-oracle (canonical home of sync.ts + oracles.json)
 MOTHER="$HOME/Code/github.com/laris-co/mother-oracle"
 if [ ! -d "$MOTHER/registry" ]; then
@@ -232,8 +243,12 @@ Each welcome must:
 Save drafts for review before posting:
 
 ```bash
-# Save to ψ/inbox/handoff/ and /tmp/
-cat drafts > ψ/inbox/handoff/welcome-drafts.md
+# Save to $PSI/inbox/handoff/ and /tmp/
+mkdir -p "$PSI/inbox/handoff"
+DRAFTS_FILE="$PSI/inbox/handoff/welcome-drafts.md"
+cat drafts > "$DRAFTS_FILE"
+# announce-mode → absolute path. See CONVENTIONS.md.
+echo "📥 Welcome drafts saved: $DRAFTS_FILE"
 ```
 
 ### Step 5: Post
@@ -682,7 +697,7 @@ arra_trace({
 
 After finding new Oracle, save the lesson (two-layer pattern):
 
-1. Write to `ψ/memory/learnings/YYYY-MM-DD_new-oracle-<name>.md` with frontmatter:
+1. Write to `$PSI/memory/learnings/YYYY-MM-DD_new-oracle-<name>.md` with frontmatter:
    ```yaml
    ---
    pattern: "New Oracle: [NAME] — [HUMAN] — [DATE]"
@@ -695,7 +710,17 @@ After finding new Oracle, save the lesson (two-layer pattern):
    [birth story, human, theme]
    ```
 
-2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
+2. The Oracle's auto-memory layer picks up new files in `$PSI/memory/learnings/` automatically — no separate API call needed.
+
+### Confirm (announce-mode — absolute paths required)
+
+# announce-mode → absolute path (no ψ/, no ~/, no $VAR, no ...).
+# Use:  echo "marker: $RESOLVED_PATH"  — bash substitutes. See CONVENTIONS.md.
+
+```bash
+LESSON_FILE="$PSI/memory/learnings/$(date +%Y-%m-%d)_new-oracle-${NAME}.md"
+echo "💡 New-oracle lesson: $LESSON_FILE"
+```
 
 ---
 

--- a/src/skills/project/SKILL.md
+++ b/src/skills/project/SKILL.md
@@ -22,6 +22,25 @@ Invoke this skill when:
 - User wants to start developing on an external repo
 - Need to find where a previously cloned project lives
 
+## Step 0 — Anchor (date-stamp + root)
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Find oracle root — git toplevel that has CLAUDE.md + ψ/
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$ORACLE_ROOT" ] && [ -f "$ORACLE_ROOT/CLAUDE.md" ] && { [ -d "$ORACLE_ROOT/ψ" ] || [ -L "$ORACLE_ROOT/ψ" ]; }; then
+  PSI="$ORACLE_ROOT/ψ"
+elif [ -f "$(pwd)/CLAUDE.md" ] && { [ -d "$(pwd)/ψ" ] || [ -L "$(pwd)/ψ" ]; }; then
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+else
+  echo "⚠️ Not in oracle repo (no CLAUDE.md + ψ/ at git root). Writing to pwd."
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+fi
+```
+
 ## Actions
 
 ### learn [url|slug]
@@ -34,11 +53,19 @@ ghq get -u https://github.com/owner/repo
 
 # 2. Create org/repo symlink structure
 GHQ_ROOT=$(ghq root)
-mkdir -p ψ/learn/owner
-ln -sf "$GHQ_ROOT/github.com/owner/repo" ψ/learn/owner/repo
+mkdir -p "$PSI/learn/owner"
+ln -sf "$GHQ_ROOT/github.com/owner/repo" "$PSI/learn/owner/repo"
 ```
 
-**Output**: "✓ Linked [repo] to ψ/learn/owner/repo"
+**Output** (announce-mode — absolute path):
+
+# announce-mode → absolute path (no ψ/, no ~/, no $VAR, no ...).
+# Use:  echo "marker: $RESOLVED_PATH"  — bash substitutes. See CONVENTIONS.md.
+
+```bash
+LINK="$PSI/learn/owner/repo"
+echo "✅ Linked: $LINK"
+```
 
 ### incubate — REDIRECTS TO /incubate
 
@@ -55,7 +82,7 @@ Search for project across all locations:
 ghq list | grep -i "query"
 
 # Search learn/incubate symlinks (org/repo structure)
-find ψ/learn ψ/incubate -type l 2>/dev/null | grep -i "query"
+find "$PSI/learn" "$PSI/incubate" -type l 2>/dev/null | grep -i "query"
 ```
 
 **Output**: List matches with their ghq paths
@@ -70,7 +97,7 @@ echo ""
 
 # Collect all tracked repos (learn + incubate symlinks)
 REPOS=()
-for link in $(find ψ/learn ψ/incubate -name "origin" -type l 2>/dev/null | sort); do
+for link in $(find "$PSI/learn" "$PSI/incubate" -name "origin" -type l 2>/dev/null | sort); do
   dir=$(dirname "$link")
   owner=$(basename "$(dirname "$dir")")
   repo=$(basename "$dir")
@@ -118,7 +145,7 @@ When listing, verify symlinks are valid:
 
 ```bash
 # Check for broken symlinks
-find ψ/learn ψ/incubate -type l ! -exec test -e {} \; -print 2>/dev/null
+find "$PSI/learn" "$PSI/incubate" -type l ! -exec test -e {} \; -print 2>/dev/null
 ```
 
 If broken: `ghq get -u [url]` to restore source.
@@ -154,7 +181,7 @@ User: "/project incubate https://github.com/Soul-Brews-Studio/arra-oracle-v3 --c
 
 ```bash
 # Add to learn
-ghq get -u URL && mkdir -p ψ/learn/owner && ln -sf "$(ghq root)/github.com/owner/repo" ψ/learn/owner/repo
+ghq get -u URL && mkdir -p "$PSI/learn/owner" && ln -sf "$(ghq root)/github.com/owner/repo" "$PSI/learn/owner/repo"
 
 # Incubate (use standalone /incubate skill)
 /incubate URL [--flash | --contribute | --status | --offload]

--- a/src/skills/resonance/SKILL.md
+++ b/src/skills/resonance/SKILL.md
@@ -24,6 +24,25 @@ AI should consider auto-suggesting /resonance when user says:
 
 ## Steps
 
+### 0. Anchor (date-stamp + root)
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Find oracle root — git toplevel that has CLAUDE.md + ψ/
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$ORACLE_ROOT" ] && [ -f "$ORACLE_ROOT/CLAUDE.md" ] && { [ -d "$ORACLE_ROOT/ψ" ] || [ -L "$ORACLE_ROOT/ψ" ]; }; then
+  PSI="$ORACLE_ROOT/ψ"
+elif [ -f "$(pwd)/CLAUDE.md" ] && { [ -d "$(pwd)/ψ" ] || [ -L "$(pwd)/ψ" ]; }; then
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+else
+  echo "⚠️ Not in oracle repo (no CLAUDE.md + ψ/ at git root). Writing to pwd."
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+fi
+```
+
 ### 1. Analyze Recent Conversation
 
 Look back at the last 5-10 messages. Find:
@@ -36,7 +55,6 @@ Look back at the last 5-10 messages. Find:
 ### 2. Log to Vault
 
 ```bash
-PSI=$(readlink -f ψ 2>/dev/null || echo "ψ")
 mkdir -p "$PSI/memory/resonance"
 ```
 
@@ -67,7 +85,7 @@ Write to: `$PSI/memory/resonance/YYYY-MM-DD_HHMM_slug.md`
 
 ### 3. Sync to Oracle (if available, two-layer pattern)
 
-1. Write to `ψ/memory/learnings/YYYY-MM-DD_resonance-<slug>.md` with frontmatter:
+1. Write to `$PSI/memory/learnings/YYYY-MM-DD_resonance-<slug>.md` with frontmatter:
    ```yaml
    ---
    pattern: "[resonance title]: [what resonated]"
@@ -80,14 +98,19 @@ Write to: `$PSI/memory/resonance/YYYY-MM-DD_HHMM_slug.md`
    [what resonated and why]
    ```
 
-2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
+2. The Oracle's auto-memory layer picks up new files in `$PSI/memory/learnings/` automatically — no separate API call needed.
 
-### 4. Output
+### 4. Confirm (announce-mode — absolute paths required)
 
-```
-✨ Resonance captured: [title]
-   → ψ/memory/resonance/YYYY-MM-DD_HHMM_slug.md
-   Tags: [tags]
+# announce-mode → absolute path (no ψ/, no ~/, no $VAR, no ...).
+# Use:  echo "marker: $RESOLVED_PATH"  — bash substitutes. See CONVENTIONS.md.
+
+```bash
+RES_FILE="$PSI/memory/resonance/$(date +%Y-%m-%d)_$(date +%H%M)_${SLUG}.md"
+LESSON_FILE="$PSI/memory/learnings/$(date +%Y-%m-%d)_resonance-${SLUG}.md"
+echo "✨ Resonance captured: ${TITLE}"
+echo "📥 Saved:   $RES_FILE"
+echo "💡 Lesson:  $LESSON_FILE"
 ```
 
 Short. Don't over-explain. The moment speaks for itself.

--- a/src/skills/retrospective/SKILL.md
+++ b/src/skills/retrospective/SKILL.md
@@ -10,19 +10,36 @@ Quick retrospective for any Oracle. For the full /rrr experience, install arra-s
 
 ## Steps
 
+### 0. Anchor (date-stamp + root)
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Find oracle root — git toplevel that has CLAUDE.md + ψ/
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$ORACLE_ROOT" ] && [ -f "$ORACLE_ROOT/CLAUDE.md" ] && { [ -d "$ORACLE_ROOT/ψ" ] || [ -L "$ORACLE_ROOT/ψ" ]; }; then
+  PSI="$ORACLE_ROOT/ψ"
+elif [ -f "$(pwd)/CLAUDE.md" ] && { [ -d "$(pwd)/ψ" ] || [ -L "$(pwd)/ψ" ]; }; then
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+else
+  echo "⚠️ Not in oracle repo (no CLAUDE.md + ψ/ at git root). Writing to pwd."
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+fi
+```
+
 ### 1. Gather
 
 ```bash
-date "+%H:%M %Z (%A %d %B %Y)"
 git log --oneline -10
 ```
 
 ### 2. Write
 
-Path: `ψ/memory/retrospectives/YYYY-MM/DD/HH.MM_slug.md`
+Path: `$PSI/memory/retrospectives/YYYY-MM/DD/HH.MM_slug.md`
 
 ```bash
-PSI=$(readlink -f ψ 2>/dev/null || echo "ψ")
 mkdir -p "$PSI/memory/retrospectives/$(date +%Y-%m/%d)"
 ```
 
@@ -34,7 +51,7 @@ Include:
 
 ### 3. Sync to Oracle (two-layer pattern)
 
-1. Write to `ψ/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
+1. Write to `$PSI/memory/learnings/YYYY-MM-DD_<slug>.md` with frontmatter:
    ```yaml
    ---
    pattern: <lesson in one line>
@@ -47,8 +64,20 @@ Include:
    <body>
    ```
 
-2. The Oracle's auto-memory layer picks up new files in `ψ/memory/learnings/` automatically — no separate API call needed.
+2. The Oracle's auto-memory layer picks up new files in `$PSI/memory/learnings/` automatically — no separate API call needed.
 
 Do NOT git add ψ/ — vault is shared state.
+
+### 4. Confirm (announce-mode — absolute paths required)
+
+# announce-mode → absolute path (no ψ/, no ~/, no $VAR, no ...).
+# Use:  echo "marker: $RESOLVED_PATH"  — bash substitutes. See CONVENTIONS.md.
+
+```bash
+RETRO_FILE="$PSI/memory/retrospectives/$(date +%Y-%m/%d)/$(date +%H.%M)_${SLUG}.md"
+LESSON_FILE="$PSI/memory/learnings/$(date +%Y-%m-%d)_${SLUG}.md"
+echo "📝 Retrospective:  $RETRO_FILE"
+echo "💡 Lesson learned: $LESSON_FILE"
+```
 
 ARGUMENTS: $ARGUMENTS

--- a/src/skills/xray/SKILL.md
+++ b/src/skills/xray/SKILL.md
@@ -8,6 +8,25 @@ argument-hint: "[memory|skills|sessions]"
 
 Inspect and manage Claude Code auto-memory, installed skills, and session history.
 
+## Step 0 — Anchor (date-stamp + root)
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+
+# Find oracle root — git toplevel that has CLAUDE.md + ψ/
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$ORACLE_ROOT" ] && [ -f "$ORACLE_ROOT/CLAUDE.md" ] && { [ -d "$ORACLE_ROOT/ψ" ] || [ -L "$ORACLE_ROOT/ψ" ]; }; then
+  PSI="$ORACLE_ROOT/ψ"
+elif [ -f "$(pwd)/CLAUDE.md" ] && { [ -d "$(pwd)/ψ" ] || [ -L "$(pwd)/ψ" ]; }; then
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+else
+  echo "⚠️ Not in oracle repo (no CLAUDE.md + ψ/ at git root). Reading from pwd."
+  ORACLE_ROOT="$(pwd)"
+  PSI="$ORACLE_ROOT/ψ"
+fi
+```
+
 ## Subcommands
 
 | Target | Description |
@@ -272,8 +291,8 @@ Display:
 
 Show recent Claude Code session history and retrospectives.
 
-1. Look for retrospectives in `ψ/memory/retrospectives/`
-2. Look for session logs in `ψ/memory/logs/`
+1. Look for retrospectives in `$PSI/memory/retrospectives/`
+2. Look for session logs in `$PSI/memory/logs/`
 3. Display recent sessions with dates and summaries:
 
 ```
@@ -291,9 +310,9 @@ Show recent Claude Code session history and retrospectives.
 
 ### How to gather
 
-1. Read files in `ψ/memory/retrospectives/` sorted by date (newest first)
+1. Read files in `$PSI/memory/retrospectives/` sorted by date (newest first)
 2. Extract date, duration, and summary from each retrospective
-3. If no retrospectives exist, check `ψ/memory/logs/` for session snapshots
+3. If no retrospectives exist, check `$PSI/memory/logs/` for session snapshots
 4. Show "No session history found" if both are empty
 
 ---


### PR DESCRIPTION
## Summary

Batch C of the #305 clickable-paths + #301 date-stamp audit. 8 medium-touch skills swept; 7 modified, 1 (`work-with`) already compliant.

**Skills updated** (per SKILL.md):
- `bampenpien` — added Step 0 anchor (🕐 + root detect); replaced bare ψ/ with `$PSI/` in prose; added Confirm announce block
- `xray` — added Step 0 anchor; replaced bare ψ/ with `$PSI/` in the retrospectives/logs prose references
- `resonance` — added Step 0 anchor; replaced bare ψ/ with `$PSI/` in prose; added Confirm announce block
- `retrospective` — added Step 0 anchor (🕐 date-stamp); replaced bare ψ/ with `$PSI/` in prose; added Confirm announce block
- `project` — added Step 0 anchor; converted ψ/learn / ψ/incubate to `$PSI/learn` / `$PSI/incubate` in bash code; replaced `Output: ✓ Linked …` with announce-mode `echo "✅ Linked: $LINK"`
- `oracle-family-scan` — added 🕐 date-stamp + optional `$PSI` to existing Step 0 (preserving #311 v3.1 structure); converted ψ/inbox/handoff/ welcome-drafts write to absolute-path echo; converted new-oracle-lesson prose to `$PSI/…` + added Confirm announce block
- `i-believed` — added root-detect to existing Step 0 (🕐 was already there); replaced bare ψ/ with `$PSI/` in prose; removed `readlink -f ψ` fallbacks now superseded by anchor; added Confirm announce block

**Skill unchanged**: `work-with` already had Step 0 with 🕐 date-stamp + root detect (from earlier work). Its remaining 5 ψ/ references are all structure-mode (reference tables documenting file layout, philosophical prose) — bare ψ/ is correct per CONVENTIONS.md Mode 2.

**oracle-family-scan + #311**: Layered cleanly on top of v3.1. Only touched Step 0 (added date-stamp + optional `$PSI` derive), the welcome-drafts write site, and the new-oracle-lesson sync site. All new mockup blocks, Status Taxonomy, `--calibrate`, timeline/usage modes from #311 left intact.

## Verification

- `bash scripts/check_skill_convention.sh` → ✅ All SKILL.md pass announce-mode
- `bun run compile` → 62 skill stubs compiled successfully
- Compiled stubs for `retrospective`, `project`, `oracle-family-scan` regenerated (the 3 skills in this batch with command stubs); unrelated CalVer-only stub bumps were `git restore`d to keep the PR focused on convention work
- `src/commands/{work-with,bampenpien,xray,resonance,i-believed}.md` don't exist (no stubs for these skills)

## Test plan

- [x] CI grep (`scripts/check_skill_convention.sh`) passes
- [x] `bun run compile` succeeds
- [x] No regressions to #311 oracle-family-scan v3.1 (timeline/usage/calibrate modes intact)
- [ ] Manual: run `/retrospective`, `/resonance`, `/bampenpien` in an oracle and verify final echo lines are ⌘-clickable absolute paths

Advances #305, advances #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)