### PR TITLE
release: v26.5.13-alpha.1626

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -134,7 +134,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.13-alpha.1527 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.13-alpha.1527",
+  "version": "26.5.13-alpha.1626",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts **v26.5.13-alpha.1626** on the modern HMM scheme. Second release of the day (after v26.5.13-alpha.1527 at 16:03).

Bundles this afternoon's late work:

| PR | Title |
|---|---|
| #313 | Batch B — clickable paths + date-stamp (awaken, morpheus, incubate, vault, contacts) |
| #314 | Batch D — clickable paths + date-stamp (about-oracle, dream, mailbox, philosophy, talk-to, who-are-you, calver, feel, wormhole) |
| #315 | disable inbox-auto-add workflow (no self-hosted runner) |
| #316 | Batch C — clickable paths + date-stamp (work-with, bampenpien, xray, resonance, retrospective, project, oracle-family-scan, i-believed) |

Plus the prior cut bundled #302, #303, #307, #308.

## What closed today

- **#300** — heartbeat-watcher stub (fixed by #312, manual close)
- **#301** — date-stamp at Step 0 across all skills (closed via this cut's Batches B/C/D)
- **#305** — clickable-paths audit 22/22 (closed via this cut's Batches B/C/D plus prior #307)

mother-oracle (separate repo) also closed #11 + #12 in PR #13.

## On merge

calver-release.yml fires → tag v26.5.13-alpha.1626 → npm publish (alpha dist-tag) → GitHub Release prerelease + dist/maw artifact.

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle