### PR TITLE
feat(readme): collapse Skills table by default — 60-row wall becomes one-click expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent claude-code code
 
 <!-- skills:start -->
 
+<details>
+<summary>📚 <strong>62 skills installed</strong> — click to expand</summary>
+
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
 | 1 | **about-oracle** | skill + subagent | What is Oracle |
@@ -99,6 +102,8 @@ npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent claude-code code
 | 60 | **worktree** | skill | 'Work in an isolated git worktree |
 | 61 | **wormhole** | skill | 'Federated query proxy |
 | 62 | **xray** | skill | X-ray deep scan |
+
+</details>
 
 <!-- skills:end -->
 

--- a/scripts/update-readme-table.ts
+++ b/scripts/update-readme-table.ts
@@ -42,10 +42,22 @@ async function updateReadmeTable() {
   const before = readme.substring(0, skillsStart + '<!-- skills:start -->'.length);
   const after = readme.substring(skillsEnd);
 
-  readme = `${before}\n\n${table}\n\n${after}`;
-
-  // --- Count total skills for profile table ---
+  // --- Count total skills (used in both summary + profile table) ---
   const skillCount = (table.match(/^\| \d+/gm) || []).length;
+
+  // Wrap the long skills table in <details> so it collapses by default.
+  // GitHub Markdown requires a blank line between <summary> and the table
+  // for the table to render correctly inside the collapsed block.
+  const collapsibleTable = [
+    '<details>',
+    `<summary>📚 <strong>${skillCount} skills installed</strong> — click to expand</summary>`,
+    '',
+    table,
+    '',
+    '</details>',
+  ].join('\n');
+
+  readme = `${before}\n\n${collapsibleTable}\n\n${after}`;
 
   // --- Update profiles section ---
   const profileStart = readme.indexOf('<!-- profiles:start -->');


### PR DESCRIPTION
## Summary

Wraps the auto-generated "## Skills" table in GitHub's `<details>`/`<summary>` block. Default state: collapsed. Click to expand the full 60-row listing. README drops from ~167 lines of wall-of-text to a scannable overview.

## Before

`## Skills` followed by a 4-column markdown table with 60+ rows immediately visible. Eyes glaze over before reaching `## Profiles` which is the actually-useful navigation table.

## After

`## Skills` followed by:

> 📚 **62 skills installed** — click to expand
> ⌄

One click expands the full table. `## Profiles` (4 rows, high-value) stays expanded as the primary navigation aid.

## Implementation

`scripts/update-readme-table.ts` now emits the table inside `<details>`. Lefthook's pre-commit hook re-runs the generator on every relevant commit, so the wrapper is preserved across edits.

## Pairs with

Skills-archive PR (separate, parallel) — that PR removes ZOMBIE_SKILLS from the listing entirely (60 → 47 active), so the collapsed table becomes more accurate too.

## Test plan

- [x] README.md `<details>` opens immediately after `## Skills` heading
- [x] `<summary>` shows the skill count
- [x] Blank line between `<summary>` and table (GitHub MD requirement)
- [x] `</details>` closes before next `##` heading
- [x] Generator script regenerates correctly
- [x] `bun run compile` clean

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle