### PR TITLE
release: v26.5.13-alpha.1726

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent claude-code codex opencode
 ```
 
 18 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed
@@ -34,7 +34,7 @@ npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y --agent claude-code code
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>62 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>49 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -126,7 +126,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.13-alpha.1626 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.13-alpha.1626",
+  "version": "26.5.13-alpha.1726",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts **v26.5.13-alpha.1726** — fourth release of the day (after 1200, 1527, 1626). Bundles the late-afternoon batch.

| PR | Title |
|---|---|
| #318 | feat(readme): collapse Skills table by default — 60-row wall becomes one-click expand |
| #319 | feat: archive ZOMBIE_SKILLS to src/skills/.archive/ — reduces clutter, preserves Nothing-is-Deleted |
| #320 | feat: /learn eval framework — 12 Q-gates + 11 registers + tiered audit-loop |

Plus the bump's lefthook auto-regen fixes the stale "62 skills installed" summary text (merge artifact from #318+#319 cascade — the actual table content was correct; only the summary count lagged).

## On merge

calver-release.yml fires → tag v26.5.13-alpha.1726 → npm publish (alpha dist-tag) → GitHub Release prerelease + dist/maw artifact.

## Today's tally with this release

- 4 releases shipped (1200 / 1527 / 1626 / 1641 if this)
- 0 open issues across both repos
- 23+ PRs merged
- 11 /team-agents teams run

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle