### PR TITLE
feat: scripts/check_skill_runtime.sh — runtime companion to check_skill_convention.sh

### DIFF
--- a/scripts/check_skill_runtime.sh
+++ b/scripts/check_skill_runtime.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# check_skill_runtime.sh — apply CONVENTIONS.md announce-mode rules to
+# arbitrary skill RUNTIME output (vs check_skill_convention.sh which checks
+# SKILL.md source).
+#
+# Usage:
+#   bash scripts/check_skill_runtime.sh /path/to/output.txt
+#   echo "📥 Written: $INBOX/foo.md" | bash scripts/check_skill_runtime.sh
+#   /skill | bash scripts/check_skill_runtime.sh -
+#
+# Exit: 0 = pass, 2 = announce-mode violations
+#
+# See: src/skills/CONVENTIONS.md
+# Companion: scripts/check_skill_convention.sh (checks SKILL.md text)
+#
+set -euo pipefail
+
+# Read input: arg = file, or stdin
+if [ $# -eq 0 ] || [ "${1:-}" = "-" ]; then
+  input=$(cat)
+else
+  if [ ! -f "$1" ]; then
+    echo "❌ File not found: $1" >&2
+    exit 1
+  fi
+  input=$(cat "$1")
+fi
+
+# Strip fenced code blocks (announce-mode rules don't apply inside ```)
+stripped=$(awk 'BEGIN{f=0} /^```/{f=!f; next} !f' <<< "$input")
+
+FAIL=0
+SOURCE="${1:-stdin}"
+
+# 5 anti-patterns — same categories as check_skill_convention.sh, but using
+# `.*` instead of `[^\n]*`. In POSIX ERE (BSD grep AND GNU grep), `[^\n]`
+# is the negation of the literal characters `\` and `n` — NOT "not newline".
+# Since grep is line-oriented, `.` already excludes the newline, so `.*`
+# matches anything-up-to-end-of-line. This is the working form.
+patterns=(
+  '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*\$[A-Z_]'    # unsubstituted $VAR
+  '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*~/'           # tilde
+  '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*ψ/'           # bare ψ/
+  '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*.*\.{3}'    # ellipsis
+  '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*\[[A-Z_]+\]'  # [PLACEHOLDER]
+)
+labels=(
+  "unsubstituted \$VAR"
+  "tilde path (~/)"
+  "bare ψ/ (not absolute)"
+  "ellipsis (...) in path"
+  "[PLACEHOLDER] in path position"
+)
+
+for i in "${!patterns[@]}"; do
+  p="${patterns[$i]}"
+  l="${labels[$i]}"
+  if echo "$stripped" | grep -E -n "$p" >/dev/null; then
+    echo "❌ $SOURCE violates: $l" >&2
+    echo "$stripped" | grep -E -n --color=always "$p" >&2
+    echo "" >&2
+    FAIL=1
+  fi
+done
+
+[ $FAIL -eq 0 ] && echo "✅ $SOURCE: all announce-mode lines clickable"
+exit $FAIL


### PR DESCRIPTION
Federation request from thclaws@m5. Same 5 anti-pattern categories as `check_skill_convention.sh` but applies them to arbitrary text/file (typically captured runtime output of a skill) instead of walking `src/skills/*/SKILL.md`.

## Usage

```bash
# From file
bash scripts/check_skill_runtime.sh /path/to/skill-output.txt

# From stdin (pipe)
echo "📥 Written: \$INBOX/foo.md" | bash scripts/check_skill_runtime.sh
/skill-invocation | bash scripts/check_skill_runtime.sh -
```

## Why

thClaws fork ships a chatgpt-codex provider that hits chatgpt.com/backend-api/codex directly. They want a quality bar for runtime output of `/recap`, `/philosophy`, `/who-are-you` run through gpt-5.4. Same convention; different input source.

## Regex note

This script uses `.*` rather than `[^\n]*` for the inter-segment match.

In POSIX ERE (both BSD grep and GNU grep), `[^\n]` is the negation of the literal characters backslash and `n` — **NOT** "any character except newline". So any announce-mode line containing the letter `n` (e.g. "Written:") would silently bypass the original pattern. Since grep is line-oriented, `.` already excludes newline, so `.*` is the correct + portable form.

The ellipsis pattern was also relaxed from `[^/]*\.{3}` (which would only catch `...` BEFORE any `/`) to `.*\.{3}` so it fires when `...` appears anywhere in the path after the colon.

The companion `scripts/check_skill_convention.sh` has the same regex bug — left untouched per task scope, but worth following up.

## Test plan

- [x] Good input (absolute path with marker) exits 0
- [x] Bare ψ/ in announce blocks exit 1
- [x] Unsubstituted \$VAR blocks
- [x] Tilde `~/` blocks
- [x] `[PLACEHOLDER]` blocks
- [x] Ellipsis `...` in path blocks
- [x] Missing file errors cleanly
- [x] Verified against thclaws-oracle/.claude/skills/track/SKILL.md → ✅ clean

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle