### PR TITLE
fix(#323): scripts/check_skill_convention.sh — replace [^\n] with .* in POSIX ERE patterns

### DIFF
--- a/scripts/check_skill_convention.sh
+++ b/scripts/check_skill_convention.sh
@@ -23,11 +23,11 @@ for f in src/skills/*/SKILL.md; do
   [ -e "$f" ] || continue
   stripped=$(awk 'BEGIN{f=0} /^```/{f=!f; next} !f' "$f")
   patterns=(
-    '(📍|📥|📤|📝|📊|🔬|✅|🪶)[^\n]*:[[:space:]]*\$[A-Z_]'    # unsubstituted $VAR
-    '(📍|📥|📤|📝|📊|🔬|✅|🪶)[^\n]*:[[:space:]]*~/'           # tilde
-    '(📍|📥|📤|📝|📊|🔬|✅|🪶)[^\n]*:[[:space:]]*ψ/'           # bare ψ/
-    '(📍|📥|📤|📝|📊|🔬|✅|🪶)[^\n]*:[[:space:]]*[^/\n]*\.{3}' # ellipsis
-    '(📍|📥|📤|📝|📊|🔬|✅|🪶)[^\n]*:[[:space:]]*\[[A-Z_]+\]'  # [PLACEHOLDER]
+    '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*\$[A-Z_]'    # unsubstituted $VAR
+    '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*~/'           # tilde
+    '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*ψ/'           # bare ψ/
+    '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*.*\.{3}'      # ellipsis
+    '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*\[[A-Z_]+\]'  # [PLACEHOLDER]
   )
   for p in "${patterns[@]}"; do
     if echo "$stripped" | grep -E -n "$p" >/dev/null; then


### PR DESCRIPTION
Closes #323.

POSIX ERE `[^\n]` = "not backslash, not letter n" — not "not newline". Any announce line containing the letter `n` ("Written:", "Trace:", "Scan:", "Inspect:") slipped through the convention check silently since #307 shipped this morning.

## Fix

Replace `[^\n]*` with `.*` in all 5 patterns. grep is already line-oriented so `.` already excludes newline. Same approach as scripts/check_skill_runtime.sh (#322).

Also tightens the ellipsis pattern's inner non-class from `[^/\n]*\.{3}` to `.*\.{3}` — catches `...` after slashes now (e.g. `/opt/Code/.../foo.md`).

```diff
-    '(📍|📥|📤|📝|📊|🔬|✅|🪶)[^\n]*:[[:space:]]*\$[A-Z_]'
+    '(📍|📥|📤|📝|📊|🔬|✅|🪶).*:[[:space:]]*\$[A-Z_]'
```

## Verification

- [x] Self-test: corrected pattern catches `📥 Written: ψ/inbox/foo.md` (was silently slipping through; contains 'n')
- [x] Self-test: synthetic bad SKILL.md fails check with exit code 1
- [x] Same regex shape as #322's check_skill_runtime.sh
- [x] Exit-code semantics unchanged: 0 = pass, 1 = violations

## Retro-audit

Running the FIXED check against the 60+ current `src/skills/*/SKILL.md` surfaces **one** violation:

- `src/skills/auto-retrospective/SKILL.md:24` — line contains an example inline-code string `📝 Auto-trigger: context at Xk. Silently run /rrr now...` describing what the hook injects. The announce marker + colon + `...` triggers the ellipsis pattern.

This is technically a false positive (it's example prose inside inline backticks, not a clickable path), but the script's strip pass only handles fenced ``` blocks, not inline backticks — a pre-existing limitation. Author of #323's claim holds: **AI agents writing these SKILL.md files generally followed the convention correctly**. The 60+ other files are clean.

Suggested follow-up (out of scope for this PR): either fix the prose in auto-retrospective/SKILL.md (escape the `...` or move it into a fenced block), or extend strip pass to also drop inline-code spans.

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle