### PR TITLE
release: v26.5.13-alpha.1821

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent claude-code codex opencode
 
 # thClaws (auto-detected if thclaws binary is in PATH)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g
@@ -133,7 +133,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.13-alpha.1726 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.13-alpha.1726",
+  "version": "26.5.13-alpha.1821",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

5th release of the day. Bundles late-afternoon work:

| PR | Title |
|---|---|
| #322 | feat: scripts/check_skill_runtime.sh — runtime companion to check_skill_convention.sh |
| #324 | feat: thClaws as 4th install target — auto-detect via binary presence |
| #325 | fix(#323): scripts/check_skill_convention.sh — replace [^\\n] with .* in POSIX ERE patterns |

Plus closes #323 (silent regex bug in CI gate).

## Notable

- **thClaws fully supported**: `bunx arra-oracle-skills install` now writes to `~/.config/thclaws/skills/` when `command -v thclaws` succeeds. Verified end-to-end with federation partner [m5:thclaws] (4 paths confirmed canonical, plugin/library/system paths confirmed NOT used).
- **Convention CI gate fixed**: was silently no-op since #307 due to POSIX ERE `[^\\n]` quirk. Retro-audit confirmed all 8 today's merged PRs would still pass the corrected regex (AI agents wrote clean output despite the broken gate).
- **Runtime check**: companion script that can score arbitrary skill output (federation request from thclaws — score /recap /philosophy /who-are-you output through their chatgpt-codex/gpt-5.4 backend).

## On merge

calver-release.yml fires → tag v26.5.13-alpha.1821 → npm publish (alpha) → GitHub Release prerelease.

## Today's tally with this release

- **5 releases** (1200 / 1527 / 1626 / 1726 / this)
- **26+ PRs merged** today
- **2 federation partners served**: homekeeper@m5 + thclaws@m5
- **All issues closed** across both repos

🤖 ตอบโดย Claude Opus 4.7 (1M context) จาก Nat → arra-oracle-skills-cli-oracle