### PR TITLE
release: v26.5.13-alpha.1929

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent claude-code codex opencode
 
 # thClaws (auto-detected if thclaws binary is in PATH)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g
@@ -120,7 +120,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.13-alpha.1821 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.13-alpha.1821",
+  "version": "26.5.13-alpha.1929",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts \`v26.5.13-alpha.1929\` on merge via \`calver-release.yml\`.

## Includes
- #328 (#327): archive 14 skills to zombie tier + port \`/fyi\` active
  - Active source: 49 → 36
  - \`.archive/\` zombies: 13 → 27
  - 5 skills kept active per user pref: bampenpien (standard), feel/morpheus/fyi (lab), resonance (implicit-full)

Standard release bump — no code changes beyond \`package.json\` version.

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)