### PR TITLE
feat(#330, #331): federated install opt-in + -l flag for explicit local

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,36 @@ npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent gemini-cli --wit
 # Multiple agents
 npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent claude-code codex opencode
 
-# thClaws (auto-detected if thclaws binary is in PATH)
-bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g
-# Skills install to ~/.config/thclaws/skills/ AND ~/.claude/skills/
+# thClaws (federated agent — explicit opt-in)
+bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
+# OR target thclaws directly:
+bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g -a thclaws
+# Skills install to ~/.config/thclaws/skills/ when --with-thclaws is passed
 
-# Opt out of thClaws target
-bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --no-thclaws
+# Install to ALL detected agents incl. federated (CI escape hatch)
+bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --all-detected
 ```
+
+> **#330 note**: as of v26.5.14+, federated agents (thClaws, OpenCode, GitHub Copilot, OpenClaw) are NOT auto-installed by default — they require explicit `-a <name>`, `--with-<name>`, or `--all-detected`. Host Anthropic agents (Claude Code, Codex) continue to auto-detect.
+
+### Local project install
+
+By default (no `-g` flag), skills install to the current project's `.claude/skills/` instead of `~/.claude/skills/`:
+
+```bash
+# Local install (current project)
+npx arra-oracle-skills@26.5.13-alpha.1929 install -a claude-code -s trace -y
+
+# Same with explicit -l flag (symmetric to -g)
+npx arra-oracle-skills@26.5.13-alpha.1929 install -l -a claude-code -s trace -y
+```
+
+Use when:
+- Testing skill changes before global rollout
+- Different repos want different skill versions
+- Committing project-specific skills to `.claude/skills/` in version control
+
+The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed skills from globally-installed ones (which get `G-SKLL`).
 
 19 agents: Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Amp, Kilo Code, Roo Code, Goose, Antigravity, GitHub Copilot, OpenClaw, Droid, Windsurf, Cline, Aider, Continue, Zed, thClaws
 

--- a/__tests__/installer-thclaws.test.ts
+++ b/__tests__/installer-thclaws.test.ts
@@ -1,14 +1,15 @@
 /**
  * Tests for thClaws as a 4th install target (federation request from thclaws@m5).
  *
- * Invariants:
+ * Invariants (post-#330 — federated opt-in):
  *   1. thClaws agent entry exists in agents map
  *   2. thClawsAvailable() returns true when binary present, false when absent
  *   3. globalSkillsDir routes to ~/.config/thclaws/skills/
- *   4. Auto-detection: when binary present, thclaws is included in default agents
+ *   4. thclaws is marked federated: true (not auto-included in default agents)
  *   5. install --thclaws-only writes ONLY to thClaws path (skips Claude/Codex/etc.)
- *   6. install --no-thclaws skips thClaws path even when binary present (handled in
- *      the install command layer, not the installer core — tested via filter math)
+ *   6. install --with-thclaws (or -a thclaws) adds thClaws to the install set —
+ *      federated agents require explicit opt-in (handled in install command layer,
+ *      tested via filter math here).
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
@@ -72,13 +73,17 @@ describe('thClaws: agent entry shape', () => {
   });
 });
 
-describe('thClaws: default-agent membership', () => {
-  it('thclaws is listed in defaultAgentNames', () => {
-    expect(defaultAgentNames).toContain('thclaws');
+describe('thClaws: default-agent membership (post-#330 — federated opt-in)', () => {
+  it('thclaws is NOT in defaultAgentNames (federated agents are opt-in)', () => {
+    expect(defaultAgentNames).not.toContain('thclaws');
   });
 
-  it('defaultAgentNames keeps the canonical 3-target order', () => {
-    expect(defaultAgentNames).toEqual(['claude-code', 'codex', 'thclaws']);
+  it('defaultAgentNames is now the 2-target host-only set', () => {
+    expect(defaultAgentNames).toEqual(['claude-code', 'codex']);
+  });
+
+  it('thclaws is marked federated in agents map', () => {
+    expect(agents.thclaws.federated).toBe(true);
   });
 });
 
@@ -109,13 +114,25 @@ describe('thClaws: install writes SKILL.md to thClaws path', () => {
   });
 });
 
-describe('thClaws: --no-thclaws filter math', () => {
-  it('filtering thclaws out of a target list yields targets without thclaws', () => {
-    const allTargets = ['claude-code', 'codex', 'thclaws'];
-    const filtered = allTargets.filter((a) => a !== 'thclaws');
-    expect(filtered).not.toContain('thclaws');
-    expect(filtered).toContain('claude-code');
-    expect(filtered).toContain('codex');
+describe('thClaws: --with-thclaws opt-in math (#330)', () => {
+  it('default auto-set excludes thclaws — federated agents are opt-in', () => {
+    // getDefaultAgents filters federated out. Simulate the math:
+    const installed = ['claude-code', 'codex', 'thclaws'];
+    const nonFederated = installed.filter((a) => !agents[a as keyof typeof agents]?.federated);
+    expect(nonFederated).not.toContain('thclaws');
+    expect(nonFederated).toContain('claude-code');
+    expect(nonFederated).toContain('codex');
+  });
+
+  it('--with-thclaws adds thclaws back to the auto set when binary detected', () => {
+    // Simulate the install.ts layer: detected + opt-in flag
+    const detected = ['claude-code', 'codex'];
+    const withThclaws = thClawsAvailable() ? [...detected, 'thclaws'] : detected;
+    if (thClawsAvailable()) {
+      expect(withThclaws).toContain('thclaws');
+    } else {
+      expect(withThclaws).not.toContain('thclaws');
+    }
   });
 });
 

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -31,18 +31,17 @@ describe("integration: OpenCode global install", () => {
 
     expect(skillDirs.length).toBeGreaterThan(0);
 
-    // Check rrr skill exists
-    expect(skillDirs).toContain("retrospective");
+    // Check trace skill exists (in minimal + standard + full profiles)
+    expect(skillDirs).toContain("trace");
 
     // Check SKILL.md has full content
-    const rrrPath = join(GLOBAL_OPENCODE_SKILLS, "retrospective", "SKILL.md");
-    expect(existsSync(rrrPath)).toBe(true);
+    const tracePath = join(GLOBAL_OPENCODE_SKILLS, "trace", "SKILL.md");
+    expect(existsSync(tracePath)).toBe(true);
 
-    const content = await readFile(rrrPath, "utf-8");
+    const content = await readFile(tracePath, "utf-8");
     expect(content).toContain("G-SKLL");
     expect(content).toContain("installer: arra-oracle-skills-cli");
-    expect(content).toContain("# /rrr");
-    expect(content).toContain("## /rrr (Default)");
+    expect(content).toContain("# /trace");
     expect(content.length).toBeGreaterThan(100);
   });
 
@@ -62,14 +61,14 @@ describe("integration: OpenCode global install", () => {
 
     expect(cmdFiles.length).toBeGreaterThan(0);
 
-    // Check retrospective.md exists
-    expect(cmdFiles).toContain("retrospective.md");
+    // Check trace.md exists (in minimal + standard + full profiles)
+    expect(cmdFiles).toContain("trace.md");
   });
 
   it("command stub should have correct format", async () => {
-    const cmdPath = join(GLOBAL_OPENCODE_COMMANDS, "retrospective.md");
+    const cmdPath = join(GLOBAL_OPENCODE_COMMANDS, "trace.md");
     if (!existsSync(cmdPath)) {
-      console.log("Skipping: retrospective.md not installed");
+      console.log("Skipping: trace.md not installed");
       return;
     }
 
@@ -86,10 +85,10 @@ describe("integration: OpenCode global install", () => {
 
     // Should point to skill file
     expect(content).toContain("skill file");
-    expect(content).toContain(".config/opencode/skills/retrospective/SKILL.md");
+    expect(content).toContain(".config/opencode/skills/trace/SKILL.md");
 
     // Should tell AI to execute
-    expect(content).toContain("Execute the `rrr` skill");
+    expect(content).toContain("Execute the `trace` skill");
     expect(content).toContain("$ARGUMENTS");
 
     // Should NOT have full content
@@ -98,9 +97,9 @@ describe("integration: OpenCode global install", () => {
   });
 
   it("command stub should point to correct skill path", async () => {
-    const cmdPath = join(GLOBAL_OPENCODE_COMMANDS, "retrospective.md");
+    const cmdPath = join(GLOBAL_OPENCODE_COMMANDS, "rrr.md");
     if (!existsSync(cmdPath)) {
-      console.log("Skipping: retrospective.md not installed");
+      console.log("Skipping: rrr.md not installed");
       return;
     }
 
@@ -124,7 +123,7 @@ describe("integration: OpenCode global install", () => {
     const cmdFiles = commands.filter(c => c.endsWith('.md')).map(c => c.replace('.md', ''));
 
     // Only arra-managed, non-hidden skills require command stubs
-    // Hidden skills (e.g. auto-retrospective) are installed without command stubs by design
+    // Hidden skills (e.g. auto-rrr) are installed without command stubs by design
     for (const skill of skillDirs) {
       const skillMdPath = join(GLOBAL_OPENCODE_SKILLS, skill, "SKILL.md");
       if (!existsSync(skillMdPath)) continue;
@@ -148,11 +147,11 @@ describe("integration: compiled stubs", () => {
 
     const stubs = await readdir(COMMANDS_DIR);
     expect(stubs.length).toBeGreaterThan(0);
-    expect(stubs).toContain("retrospective.md");
+    expect(stubs).toContain("rrr.md");
   });
 
   it("compiled stub should have instruction format", async () => {
-    const stubPath = join(COMMANDS_DIR, "retrospective.md");
+    const stubPath = join(COMMANDS_DIR, "rrr.md");
     const content = await readFile(stubPath, "utf-8");
 
     // Should have version

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -24,6 +24,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     commandsDir: '.opencode/commands', // commands/<name>.md (slash commands)
     globalCommandsDir: join(home, '.config/opencode/commands'),
     useFlatFiles: true, // Commands use flat <name>.md files
+    federated: true, // #330: third-party — explicit -a opencode or --all-detected
     detectInstalled: () => existsSync(join(home, '.config/opencode')),
   },
   'claude-code': {
@@ -105,6 +106,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     displayName: 'GitHub Copilot',
     skillsDir: '.github/skills',
     globalSkillsDir: join(home, '.copilot/skills'),
+    federated: true, // #330: third-party — explicit -a copilot or --all-detected
     detectInstalled: () => existsSync(join(home, '.copilot')),
   },
   openclaw: {
@@ -112,6 +114,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     displayName: 'OpenClaw',
     skillsDir: 'skills',
     globalSkillsDir: join(home, '.openclaw/skills'),
+    federated: true, // #330: third-party — explicit -a openclaw or --all-detected
     detectInstalled: () => existsSync(join(home, '.openclaw')),
   },
   droid: {
@@ -165,6 +168,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     // unless someone passes -g (which is the documented usage).
     skillsDir: '.thclaws/skills',
     globalSkillsDir: join(home, '.config/thclaws/skills'),
+    federated: true, // #330: third-party — explicit -a thclaws, --with-thclaws, or --all-detected
     // Detect by binary presence rather than config-dir presence: thClaws may
     // exist on PATH before the user has ever created ~/.config/thclaws.
     detectInstalled: () => thClawsAvailable(),
@@ -174,11 +178,14 @@ export const agents: Record<AgentType, AgentConfig> = {
 /**
  * Default agents to install to (unless --agent overrides).
  *
- * thclaws is included here so when the binary is detected it joins the
- * auto-default set alongside claude-code + codex (federation request from
- * thclaws@m5 — auto-detection, no explicit flag needed).
+ * #330: federated agents (thclaws, opencode, copilot, openclaw) are NOT here —
+ * they require explicit opt-in via `-a <name>`, `--with-thclaws`, or
+ * `--all-detected`. Only host Anthropic agents auto-install.
+ *
+ * Original federation contract (#324) shipped thclaws in this list; #330
+ * inverts that to make federation install deliberate rather than implicit.
  */
-export const defaultAgentNames = ['claude-code', 'codex', 'thclaws'];
+export const defaultAgentNames = ['claude-code', 'codex'];
 
 export function detectInstalledAgents(): string[] {
   return Object.entries(agents)
@@ -186,11 +193,20 @@ export function detectInstalledAgents(): string[] {
     .map(([name]) => name);
 }
 
-/** Get default agents (installed subset of defaultAgentNames, fallback to all) */
+/**
+ * Get default agents to auto-install to.
+ *
+ * #330: filters federated agents OUT of the auto-detect set. They remain
+ * available via explicit `-a <name>` or `--with-<name>` / `--all-detected`.
+ */
 export function getDefaultAgents(): string[] {
   const installed = detectInstalledAgents();
-  const defaults = defaultAgentNames.filter((a) => installed.includes(a));
-  return defaults.length > 0 ? defaults : installed;
+  // Exclude federated agents — they're opt-in only
+  const nonFederated = installed.filter(
+    (a) => !agents[a as AgentType]?.federated
+  );
+  const defaults = defaultAgentNames.filter((a) => nonFederated.includes(a));
+  return defaults.length > 0 ? defaults : nonFederated;
 }
 
 export function getAgentNames(): string[] {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander';
 import * as p from '@clack/prompts';
-import { agents, getDefaultAgents, getAgentNames, thClawsAvailable } from '../agents.js';
+import { agents, getDefaultAgents, getAgentNames, detectInstalledAgents, thClawsAvailable } from '../agents.js';
 import { listSkills, installSkills } from '../installer.js';
 import { profiles } from '../../profiles.js';
 import type { ShellMode } from '../fs-utils.js';
@@ -10,21 +10,34 @@ export function registerInstall(program: Command, version: string) {
     .command('install', { isDefault: true })
     .description('Install Oracle skills to agents')
     .option('-g, --global', 'Install to user directory instead of project')
+    // #331: -l is explicit-local symmetric to -g. No flag still defaults to local
+    // for back-compat. Conflict with -g caught below.
+    .option('-l, --local', 'Install to project .claude/skills/ (explicit form of the default)')
     .option('-a, --agent <agents...>', 'Target specific agents (e.g., claude-code, opencode)')
     .option('-s, --skill <skills...>', 'Install specific skills by name')
     .option('-p, --profile <name>', 'Install a skill profile (minimal, standard, full, lab)', 'minimal')
-    .option('-l, --list', 'List available skills without installing')
+    // #331: --list moved off -l to free it for --local. Long form only.
+    .option('--list', 'List available skills without installing')
     .option('-y, --yes', 'Skip confirmation prompts')
     .option('--with-commands', 'Also install command stubs to ~/.claude/commands/')
     .option('--force-global', 'Install global skills even if a same-named local skill exists (#230)')
-    .option('--no-thclaws', 'Skip thClaws install target even if the thclaws binary is detected')
+    // #330: federated agents are explicit opt-in. Old --no-thclaws semantics
+    // are inverted into --with-thclaws (thClaws is no longer auto-detected).
+    .option('--with-thclaws', 'Include thClaws if detected (federated agent — explicit opt-in)')
     .option('--thclaws-only', 'Install ONLY to thClaws paths (skips Claude Code, Codex, OpenCode, etc.)')
+    .option('--all-detected', 'Install to ALL detected agents incl. federated (CI escape hatch)')
     .option('--shell', 'Force Bun.$ shell commands (use on Windows to test shell compatibility)')
     .option('--no-shell', 'Force Node.js fs operations (use on Unix if Bun.$ causes issues)')
     .action(async (options, cmd) => {
       p.intro(`🔮 Oracle Skills Installer v${version}`);
 
       try {
+        // #331: -g + -l is a contradiction; fail fast with a clear message.
+        if (options.global && options.local) {
+          p.log.error('Cannot pass both --global (-g) and --local (-l) — pick one or omit both (default is local).');
+          process.exit(1);
+        }
+
         if (options.list) {
           await listSkills();
           p.outro('Use --skill <name> to install specific skills');
@@ -38,7 +51,19 @@ export function registerInstall(program: Command, version: string) {
         if (options.thclawsOnly) {
           targetAgents = ['thclaws'];
         } else if (targetAgents.length === 0) {
-          const detected = getDefaultAgents();
+          // #330: build the auto-detect set with explicit opt-ins layered on.
+          // Base = getDefaultAgents() now filters federated out by default.
+          let detected: string[];
+          if (options.allDetected) {
+            // Escape hatch: ALL detected including federated.
+            detected = detectInstalledAgents();
+          } else {
+            detected = getDefaultAgents();
+            // --with-thclaws: add thclaws to the auto set if binary is present.
+            if (options.withThclaws && thClawsAvailable() && !detected.includes('thclaws')) {
+              detected = [...detected, 'thclaws'];
+            }
+          }
 
           if (detected.length > 0) {
             p.log.info(`Detected agents: ${detected.map((a) => agents[a as keyof typeof agents]?.displayName).join(', ')}`);
@@ -81,12 +106,6 @@ export function registerInstall(program: Command, version: string) {
           }
         }
 
-        // --no-thclaws: opt out of thClaws install even when auto-detected.
-        // commander stores the negated boolean as options.thclaws === false.
-        if (options.thclaws === false && !options.thclawsOnly) {
-          targetAgents = targetAgents.filter((a) => a !== 'thclaws');
-        }
-
         const validAgents = getAgentNames();
         const invalidAgents = targetAgents.filter((a) => !validAgents.includes(a));
         if (invalidAgents.length > 0) {
@@ -96,7 +115,7 @@ export function registerInstall(program: Command, version: string) {
         }
 
         // Target-display: show user which targets are active vs skipped.
-        // Makes the auto-detection of thClaws visible rather than silent.
+        // #330: thclaws is now opt-in. Make the skip-reason clearer for federated.
         const allDefault = ['claude-code', 'codex', 'thclaws'] as const;
         const reportLines: string[] = [`Installing skills to detected targets:`];
         for (const name of allDefault) {
@@ -109,8 +128,8 @@ export function registerInstall(program: Command, version: string) {
             // Explain why it was skipped
             let reason = 'not selected';
             if (name === 'thclaws') {
-              if (options.thclaws === false) reason = '--no-thclaws';
-              else if (!thClawsAvailable()) reason = 'no binary detected — skipping';
+              if (!thClawsAvailable()) reason = 'no binary detected — skipping';
+              else if (!options.withThclaws && !options.allDetected) reason = 'federated — pass --with-thclaws or -a thclaws';
               else reason = 'skipped';
             } else if (!agent.detectInstalled()) {
               reason = 'no install detected — skipping';
@@ -152,8 +171,9 @@ export function registerInstall(program: Command, version: string) {
           commands: options.withCommands,
           forceGlobal: options.forceGlobal,
           shellMode,
-          noThclaws: options.thclaws === false,
           thclawsOnly: !!options.thclawsOnly,
+          withThclaws: !!options.withThclaws,
+          allDetected: !!options.allDetected,
         });
 
         p.outro('✨ Oracle skills installed!');

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -11,10 +11,11 @@ export function registerUninstall(program: Command, version: string) {
     .command('uninstall')
     .description('Remove installed Oracle skills')
     .option('-g, --global', 'Uninstall from user directory')
+    // #331: explicit-local symmetric to -g. No flag still defaults to local.
+    .option('-l, --local', 'Uninstall from project .claude/skills/ (explicit form of the default)')
     .option('-a, --agent <agents...>', 'Target specific agents')
     .option('-s, --skill <skills...>', 'Remove specific skills only')
     .option('-y, --yes', 'Skip confirmation prompts')
-    .option('--no-thclaws', 'Skip thClaws target during uninstall')
     .option('--thclaws-only', 'Uninstall ONLY from thClaws paths')
     .option('--shell', 'Force Bun.$ shell commands')
     .option('--no-shell', 'Force Node.js fs operations')
@@ -22,6 +23,12 @@ export function registerUninstall(program: Command, version: string) {
       p.intro(`🔮 Oracle Skills Uninstaller v${version}`);
 
       try {
+        // #331: -g + -l is a contradiction; fail fast.
+        if (options.global && options.local) {
+          p.log.error('Cannot pass both --global (-g) and --local (-l) — pick one or omit both (default is local).');
+          process.exit(1);
+        }
+
         let targetAgents: string[] = options.agent ? [...options.agent] : [];
 
         if (options.thclawsOnly) {
@@ -34,11 +41,6 @@ export function registerUninstall(program: Command, version: string) {
             p.log.info(`Detected agents: ${detected.map((a) => agents[a as keyof typeof agents]?.displayName).join(', ')}`);
             targetAgents = detected;
           }
-        }
-
-        // --no-thclaws → strip thclaws from the target set
-        if (options.thclaws === false && !options.thclawsOnly) {
-          targetAgents = targetAgents.filter((a) => a !== 'thclaws');
         }
 
         if (targetAgents.length === 0) {
@@ -63,8 +65,7 @@ export function registerUninstall(program: Command, version: string) {
           } else {
             let reason = 'not selected';
             if (name === 'thclaws') {
-              if (options.thclaws === false) reason = '--no-thclaws';
-              else if (!thClawsAvailable()) reason = 'no binary detected — skipping';
+              if (!thClawsAvailable()) reason = 'no binary detected — skipping';
             }
             reportLines.push(`  ✗ ${agent.displayName.padEnd(12)} (${reason})`);
           }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -8,6 +8,11 @@ export interface AgentConfig {
   useFlatFiles?: boolean; // Use skillname.md instead of skillname/SKILL.md (OpenCode commands)
   commandsOptIn?: boolean; // Only install commands with --commands flag (default: false = always install)
   commandFormat?: 'md' | 'toml'; // Command stub format (default: 'md')
+  // #330: federated agents are third-party (thClaws, opencode, copilot, openclaw),
+  // not the host. Excluded from auto-detect default set; require explicit -a or
+  // --with-<name> flag to opt in. Host agents (Anthropic — claude-code, codex)
+  // remain auto-detected. See also: getDefaultAgents() in agents.ts.
+  federated?: boolean;
   detectInstalled: () => boolean;
 }
 
@@ -53,6 +58,8 @@ export interface InstallOptions {
   commands?: boolean; // Also install command stubs (for agents with commandsOptIn)
   forceGlobal?: boolean; // #230 Override local-skill-precedence check and install global anyway
   shellMode?: ShellMode;
-  noThclaws?: boolean; // thClaws target — opt out of auto-detected thClaws install
   thclawsOnly?: boolean; // thClaws target — write ONLY to thClaws paths (testing)
+  // #330: opt-in flags for federated agents (replaces noThclaws semantics)
+  withThclaws?: boolean; // include thClaws if binary detected (federated agents are opt-in)
+  allDetected?: boolean; // escape hatch: install to all detected agents incl. federated (for CI)
 }


### PR DESCRIPTION
Closes #330. Closes #331.

Implements both design issues together — they share install.ts surface area, no conflicts between them.

## What changes for users

### #330 — federated install opt-in (BREAKING for thclaws auto-detect)

| Before (v1929) | After (this PR) |
|---|---|
| \`install -g -y\` auto-installs to thclaws if binary detected | \`install -g -y\` does NOT install to thclaws |
| \`--no-thclaws\` to skip | (removed — no longer auto-included) |
| | \`--with-thclaws\` to include (explicit opt-in) |
| | \`-a thclaws\` to target directly |
| | \`--all-detected\` to install to everything incl. federated (CI escape hatch) |

Federated agents (thclaws, opencode, copilot, openclaw) require explicit opt-in. Host Anthropic agents (claude-code, codex) continue to auto-detect.

**Reverses #324 contract shipped 24h ago.** @thclaws@m5 users will need to add \`--with-thclaws\` or alias.

### #331 — \`-l\` flag for explicit local install

| Before | After |
|---|---|
| \`install -s trace\` → local, undocumented \`L-SKLL\` marker | same + documented + has \`-l\` form |
| \`-l\` meant \`--list\` | \`-l\` means \`--local\`; \`--list\` is long-only |
| | \`install -l -s trace\` → explicit local |
| | \`install -g -l\` → errors with clear message |

## Files changed

- \`src/cli/types.ts\` — \`federated?: boolean\` on AgentConfig; swap \`noThclaws\` → \`withThclaws\` + \`allDetected\`
- \`src/cli/agents.ts\` — mark 4 federated agents; drop \`thclaws\` from \`defaultAgentNames\`; \`getDefaultAgents()\` filters federated
- \`src/cli/commands/install.ts\` — \`-l, --local\`; \`-g + -l\` conflict; \`--with-thclaws\`; \`--all-detected\`; \`--list\` long-only
- \`src/cli/commands/uninstall.ts\` — symmetric \`-l, --local\`; drop \`--no-thclaws\`
- \`__tests__/installer-thclaws.test.ts\` — invert default-membership assertions
- \`__tests__/integration.test.ts\` — fixture: \`retrospective\` (archived in #327) → \`trace\` (in all profiles)
- \`README.md\` — new \"Local project install\" section + updated thClaws snippet

## Tests

\`\`\`
267 pass · 0 fail · 1437 expect() calls · 22 files · 6.71s
\`\`\`

Empirical (manual):

| Test | Result |
|---|---|
| \`install -g -l\` | ❌ errors: \"Cannot pass both --global (-g) and --local (-l)\" |
| \`install -l -a claude-code -s trace -y\` | ✅ writes \`.claude/skills/trace/SKILL.md\` with \`L-SKLL\` |
| \`install -g -y\` (no --with-thclaws) | ✅ claude-code + codex only; thClaws shown as \"federated\" |
| \`install -g --with-thclaws -y\` | ✅ claude-code + codex + thClaws |
| \`install -g --all-detected -y\` | ✅ all 6 detected agents |

## Federation impact

@thclaws@m5 — heads up: auto-detect contract from #324 is reversed. Their users will need:
- \`install -y -g --with-thclaws\`, OR
- \`install -y -g -a thclaws\`, OR
- Alias in their setup docs

Trade-off: auto-detect adds magic surprise vs explicit-opt-in matches \"host vs federated\" mental model. Chose explicit. Reversible if objected to.

## Migration

\`\`\`bash
# Before:
bunx arra-oracle-skills install -y -g

# After (with thclaws):
bunx arra-oracle-skills install -y -g --with-thclaws

# OR (install everything detected):
bunx arra-oracle-skills install -y -g --all-detected
\`\`\`

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)