### PR TITLE
release: v26.5.14-alpha.335

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.13-alpha.1929 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.336 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.13-alpha.1929 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.336 install -l -a claude-code -s trace -y
 ```
 
 Use when:
@@ -143,7 +143,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.13-alpha.1929 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
 ```
 
 | Skill | What |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.13-alpha.1929",
+  "version": "26.5.14-alpha.336",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts `v26.5.14-alpha.335` on merge via `calver-release.yml`. Bumps for #330 + #331 work merged in PR #332 (commit f2a90bd).

## Includes (since v26.5.13-alpha.1929)

- **#330** — federated install opt-in: thClaws + 3 federated agents now require explicit `--with-thclaws` or `-a <name>` or `--all-detected`
- **#331** — `-l, --local` flag symmetric to `-g, --global`; `--list` moved to long-only; `L-SKLL` marker documented
- README: new "Local project install" section

## Federation note

The contract reversal for thClaws auto-install (was: auto via #324; now: opt-in via #330) was heads-up'd on issue #330 with the migration paths. Recommend not promoting to main until thclaws@m5 has reviewed downstream impact.

## Test plan

- [ ] Merge triggers calver-release.yml workflow
- [ ] Tag `v26.5.14-alpha.335` appears on GitHub
- [ ] npm `arra-oracle-skills@alpha` dist-tag updates to 26.5.14-alpha.335
- [ ] No regressions vs alpha.1929

🤖 Generated with [Claude Code](https://claude.com/claude-code)