### PR TITLE
fix(#333): /dream content correction — swap CONTENT not just dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 12 | **contacts** | skill | Manage Oracle contacts |
 | 13 | **create-shortcut** | skill | Create local skills as shortcuts |
 | 14 | **dig** | skill | Mine Claude Code sessions |
-| 15 | **dream** | skill | "Cross-repo pattern discovery |
+| 15 | **dream** | skill | 'Speculative dreaming |
 | 16 | **feel** | skill | "Capture how the system feels |
 | 17 | **forward** | skill | Create handoff + enter plan mode for next |
 | 18 | **forward-lite** | skill | Quick handoff to next session |
@@ -143,7 +143,7 @@ about                   # version + status
 Secret skills are excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.14-alpha.336 install -g -y -s watch harden wormhole fleet release warp morpheus mailbox
+npx arra-oracle-skills@26.5.14-alpha.336 install -g -y -s watch harden wormhole fleet release warp mailbox
 ```
 
 | Skill | What |
@@ -154,7 +154,7 @@ npx arra-oracle-skills@26.5.14-alpha.336 install -g -y -s watch harden wormhole 
 | `/fleet` | Deep fleet census across nodes |
 | `/release` | Automated release flow |
 | `/warp` | SSH+tmux teleport to remote nodes |
-| `/morpheus` | Speculative dreaming (evolved /dream) |
+| `/morpheus` | Archived in #333 — same content as active /dream (back-compat alias) |
 | `/mailbox` | Persistent agent memory in ψ/ |
 
 ## Team Agent Scripts

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -56,8 +56,8 @@ describe("profiles", () => {
     expect(LAB_SKILLS).toHaveLength(9);
   });
 
-  it("ZOMBIE_SKILLS has 26 archived candidates (13 original + 12 culled in #327 + 1 added in #333)", () => {
-    expect(ZOMBIE_SKILLS).toHaveLength(26);
+  it("ZOMBIE_SKILLS has 27 archived candidates (13 original + 12 culled in #327 + 1 added in #333 + 1 dream-original in #333 content correction)", () => {
+    expect(ZOMBIE_SKILLS).toHaveLength(27);
   });
 
   it("labOnly matches LAB_SKILLS", () => {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -61,6 +61,9 @@ export const ZOMBIE_SKILLS = [
   'retrospective', 'skills-list',
   'fleet', 'machines', 'warp', 'release',
   'philosophy', 'wormhole', 'harden', 'vault',
+  // 2026-05-14 (#333 content correction): original simple /dream body
+  // preserved as zombie after /dream absorbed the evolved morpheus body.
+  'dream-original',
 ] as const;
 
 /** Return the source directory for a skill by name — `.archive/` for zombies,

--- a/src/skills/.archive/dream-original/SKILL.md
+++ b/src/skills/.archive/dream-original/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: dream-original
+description: "Cross-repo pattern discovery with parallel agents. Finds pains, plans, gains, lost work, and feelings across all repositories. Use when user says 'dream', 'what hurts', 'cross-repo patterns', 'big picture', or wants to see connections between projects."
+argument-hint: "[--pain | --plan | --gain | --all]"
+zombie: true
+archived_reason: 'preserved original simple /dream body — replaced by evolved morpheus-derived body via #333 content correction'
+archived_date: 2026-05-14
+---
+
+# /dream — Cross-Repo Pattern Discovery
+
+> "The forest doesn't know it's a forest. Each tree only knows its own roots.
+> But the mycelium underground sees every root, every nutrient, every signal.
+> /dream is the moment the underground tells the forest what it sees."
+
+## Usage
+
+```
+/dream              # Full dream — all categories
+/dream --pain       # Focus on what hurts (blocking, broken)
+/dream --plan       # Focus on what's planned (decided, not built)
+/dream --gain       # Focus on what we won (completed, delivered)
+/dream --all        # Maximum depth — every source, every dimension
+```
+
+---
+
+## Step 0: Timestamp
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+```
+
+---
+
+## How It Works
+
+Launch **5 parallel agents**, each searching a different dimension:
+
+| Agent | Focus | Source |
+|-------|-------|--------|
+| 1. Deep Dig | Session history | `dig.py` across project dirs |
+| 2. Deep Trace | Cross-repo patterns | `ghq` repos, open issues, stale items |
+| 3. Deep Learn | Recent activity | `git log` per repo, abandoned work |
+| 4. Oracle Memory | What we already know | `ψ/memory/`, previous dreams |
+| 5. Fleet Status | How the system feels | services, board, running processes |
+
+### Agent Instructions
+
+Each agent returns **max 500 words** (prevents context waste). Format:
+
+```markdown
+## [Agent Name] Findings
+
+### Items Found
+- [item]: [classification] — [1-line summary]
+
+### Connections Noticed
+- [pattern or link between items]
+```
+
+---
+
+## Classification
+
+After all agents return, classify every finding:
+
+| Icon | Category | Meaning |
+|------|----------|---------|
+| 🔴 | PAIN | Hurts RIGHT NOW — blocking someone |
+| 📋 | PLAN | Decided but not built yet |
+| 🟢 | GAIN | Completed, delivered value |
+| ⚫ | LOST | Abandoned, forgotten, disabled |
+| 🧠 | MEMORY | Pattern learned, lesson discovered |
+| 💜 | FEELING | How an Oracle or human feels about state |
+
+---
+
+## Connection Finding
+
+The key value of /dream — find the web:
+
+| From → To | Question |
+|-----------|----------|
+| PAIN → PLAN | Which pain has a plan to fix it? |
+| PAIN → no PLAN | Which pain has NO plan? (create one) |
+| GAIN → unlocks | Which gain unblocks a plan? |
+| MEMORY → prevents | Which memory prevents a pain? |
+| FEELING → signals | Burnout, breakthrough, or drift? |
+| LOST → revivable | Which lost thing should we revive? |
+
+---
+
+## Output
+
+Write to: `ψ/writing/dreams/YYYY-MM-DD_dream.md`
+
+```markdown
+# Dream — YYYY-MM-DD
+
+## 🔴 PAINS
+[Items that hurt right now]
+
+## 📋 PLANS
+[Decided but not built]
+
+## 🟢 GAINS
+[Completed, delivered value]
+
+## ⚫ LOST
+[Abandoned, forgotten]
+
+## 🧠 MEMORIES
+[Patterns learned]
+
+## 💜 FEELINGS
+[Emotional state of the system]
+
+## 🔗 CONNECTIONS
+[The web — how items relate to each other]
+
+## 💡 INSIGHTS — What Nobody Sees Yet
+[Cross-repo patterns that only emerge from looking at everything]
+
+## ⏭️ NEXT — What Should Happen
+[Suggestions — human decides, Oracle presents]
+```
+
+---
+
+## Rules
+
+1. **5 parallel agents** — each returns max 500 words
+2. **Main agent classifies** — connects + writes the dream
+3. **Dreams are append-only** — Nothing is Deleted
+4. **Oracle sync** — `oracle_learn` after every dream
+5. **Never act on findings** — dream presents, human decides
+6. **Never leak secrets** — no tokens, passwords, API keys in dream output
+
+---
+
+## Dependencies
+
+- `/dig` for session mining
+- `/trace` for cross-repo search
+- Oracle MCP for `oracle_search` + `oracle_learn`
+- `ghq list` for repo discovery
+
+---
+
+## Philosophy
+
+Individual skills see one dimension. /dream sees all dimensions at once.
+
+- `/trace` finds specific things
+- `/dig` mines session history
+- `/learn` studies one repo
+- `/rrr` reflects on one session
+- **/dream** looks sideways across everything
+
+Patterns emerge only when you look at EVERYTHING together.
+
+---
+
+ARGUMENTS: $ARGUMENTS

--- a/src/skills/dream/SKILL.md
+++ b/src/skills/dream/SKILL.md
@@ -1,161 +1,295 @@
 ---
 name: dream
-description: "Cross-repo pattern discovery with parallel agents. Finds pains, plans, gains, lost work, and feelings across all repositories. Use when user says 'dream', 'what hurts', 'cross-repo patterns', 'big picture', or wants to see connections between projects."
-argument-hint: "[--pain | --plan | --gain | --all]"
+description: 'Speculative dreaming — background thinking, pre-computation, cross-repo patterns, and prediction. Consolidated from /morpheus per #333. Use when user says "dream", "speculate", "think ahead", "predict", "what if", "dream deeper", or wants the Oracle to dream between sessions.'
+argument-hint: "[--pain | --plan | --gain | --all | --speculate | --between]"
 ---
 
-# /dream — Cross-Repo Pattern Discovery
+# /dream — Speculative Dreaming
 
-> "The forest doesn't know it's a forest. Each tree only knows its own roots.
-> But the mycelium underground sees every root, every nutrient, every signal.
-> /dream is the moment the underground tells the forest what it sees."
+> "I'm trying to free your mind, Neo. But I can only show you the door.
+> You're the one that has to walk through it." — Morpheus
+
+/dream sees the forest. /dream also sees what the forest will look like *tomorrow*.
+
+---
+
+## Step 0: Ground (date-stamp + root capture)
+
+Run before any phase — gives the AI a current-time reference (#301) and an
+absolute `$PSI` for any announce-mode writes (CONVENTIONS.md).
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+PSI="$ORACLE_ROOT/ψ"
+```
+
+---
+
+## What's New vs the original /dream
+
+| Feature | original /dream | evolved /dream |
+|---------|-------------|-------------------|
+| Cross-repo scan | 5 agents, find patterns | Same |
+| Classification | pain/plan/gain/lost | Same + **predictions** |
+| Speculative thinking | No | **Yes — "what will they ask next?"** |
+| Between-session mode | No | **Yes — dream while idle** |
+| Prediction log | No | **Yes — track prediction accuracy** |
+| Connection to /i-believed | No | **Yes — beliefs shape dreams** |
 
 ## Usage
 
 ```
-/dream              # Full dream — all categories
-/dream --pain       # Focus on what hurts (blocking, broken)
-/dream --plan       # Focus on what's planned (decided, not built)
-/dream --gain       # Focus on what we won (completed, delivered)
-/dream --all        # Maximum depth — every source, every dimension
+/dream                # Full dream + speculation
+/dream --pain         # Focus on what hurts + predict what breaks next
+/dream --plan         # Focus on plans + predict which ships first
+/dream --gain         # Focus on wins + predict next win
+/dream --all          # Maximum depth — every dimension
+/dream --speculate    # Skip the scan — just speculate from existing knowledge
+/dream --between      # Between-session dream — write predictions for next session
 ```
 
 ---
 
-## Step 0: Timestamp
+## Phase 1: Dream (the original /dream)
 
-```bash
-date "+🕐 %H:%M %Z (%A %d %B %Y)"
-```
-
----
-
-## How It Works
-
-Launch **5 parallel agents**, each searching a different dimension:
+Launch **5 parallel agents** for cross-repo pattern discovery:
 
 | Agent | Focus | Source |
 |-------|-------|--------|
 | 1. Deep Dig | Session history | `dig.py` across project dirs |
 | 2. Deep Trace | Cross-repo patterns | `ghq` repos, open issues, stale items |
 | 3. Deep Learn | Recent activity | `git log` per repo, abandoned work |
-| 4. Oracle Memory | What we already know | `ψ/memory/`, previous dreams |
-| 5. Fleet Status | How the system feels | services, board, running processes |
+| 4. Oracle Memory | What we already know | `ψ/memory/`, previous dreams + speculation logs |
+| 5. Fleet Status | How the system feels | services, tmux sessions, running processes |
 
-### Agent Instructions
+Each agent returns **max 500 words**. Classification:
 
-Each agent returns **max 500 words** (prevents context waste). Format:
+| Icon | Category |
+|------|----------|
+| 🔴 | PAIN — hurts now |
+| 📋 | PLAN — decided, not built |
+| 🟢 | GAIN — completed |
+| ⚫ | LOST — abandoned |
+| 🧠 | MEMORY — pattern learned |
+| 💜 | FEELING — emotional state |
+
+---
+
+## Phase 2: Speculate (the Morpheus layer)
+
+After classifying findings, the lead agent enters **speculative mode**:
+
+### 2.1 Predict What's Next
+
+Based on all findings + session history + beliefs, predict:
 
 ```markdown
-## [Agent Name] Findings
+## 🔮 SPECULATIONS
 
-### Items Found
-- [item]: [classification] — [1-line summary]
+### What will they ask next?
+Based on the last 3 sessions, open issues, and current momentum:
+1. [Prediction 1 — high confidence] — because [evidence]
+2. [Prediction 2 — medium confidence] — because [evidence]
+3. [Prediction 3 — low confidence, high impact] — because [pattern]
 
-### Connections Noticed
-- [pattern or link between items]
+### What will break next?
+Based on pains, stale code, and dependency patterns:
+1. [Risk 1] — [timeframe] — [mitigation]
+2. [Risk 2] — [timeframe] — [mitigation]
+
+### What should we build that nobody asked for?
+Based on gains, momentum, and what's *almost* possible:
+1. [Opportunity 1] — because [existing pieces]
+2. [Opportunity 2] — because [pattern across repos]
+
+### What belief is being tested right now?
+Cross-reference ψ/memory/resonance/beliefs/ with current work:
+- [Belief]: [How current work confirms or challenges it]
+```
+
+### 2.2 Prediction Confidence Levels
+
+| Level | Meaning | Signal |
+|-------|---------|--------|
+| 🟢 High | >70% — multiple signals converge | 3+ data points agree |
+| 🟡 Medium | 40-70% — pattern suggests but not certain | 2 data points, some ambiguity |
+| 🔴 Low | <40% — speculative, but worth noting | 1 data point or intuition only |
+
+### 2.3 Connect to Beliefs
+
+Read `ψ/memory/resonance/beliefs/` and cross-reference:
+
+```bash
+find $PSI/memory/resonance/beliefs/ -name '*.md' 2>/dev/null | while read f; do
+  echo "=== $(basename $f) ==="
+  head -5 "$f"
+done
+```
+
+How do current dreams relate to declared beliefs? Is reality matching faith?
+
+---
+
+## Phase 3: Between-Session Mode (`--between`)
+
+> "What if oracles could dream between sessions?"
+
+Write predictions for the **next** session. Saved to `ψ/memory/morpheus/`:
+
+```bash
+ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+PSI="$ORACLE_ROOT/ψ"
+mkdir -p "$PSI/memory/morpheus"
+```
+
+### Output: `ψ/memory/morpheus/YYYY-MM-DD_speculations.md`
+
+```markdown
+# Dream — Speculations for Next Session
+
+**Dreamed**: YYYY-MM-DD HH:MM
+**Based on**: [N] repos scanned, [M] sessions analyzed, [K] beliefs active
+
+## Pre-computed Answers
+
+If they ask about [X]:
+→ [Prepared answer/approach — ready to go]
+
+If they ask about [Y]:
+→ [Prepared answer/approach — ready to go]
+
+If they ask about [Z]:
+→ [Prepared answer/approach — ready to go]
+
+## Pre-positioned Context
+
+Files that are likely relevant next session:
+- [file1] — because [reason]
+- [file2] — because [reason]
+
+Issues that are likely to come up:
+- #[N] — [why]
+- #[M] — [why]
+
+## Prediction Log
+
+| # | Prediction | Confidence | Verified? |
+|---|-----------|------------|-----------|
+| 1 | [prediction] | 🟢 high | pending |
+| 2 | [prediction] | 🟡 medium | pending |
+| 3 | [prediction] | 🔴 low | pending |
+```
+
+### Next Session: Verify Predictions
+
+When `/recap` runs at the start of the next session, it should check for speculations:
+
+```bash
+LATEST_DREAM=$(ls -t $PSI/memory/morpheus/*.md 2>/dev/null | head -1)
+if [ -n "$LATEST_DREAM" ]; then
+  echo "🔮 Dream while you were away:"
+  head -20 "$LATEST_DREAM"
+fi
+```
+
+Over time, track prediction accuracy:
+
+```markdown
+## Prediction Accuracy (rolling)
+
+  Total predictions: 47
+  Verified correct:  31 (66%)
+  Wrong:             12 (25%)
+  Not yet verified:   4 (9%)
+
+  Trend: improving (58% → 66% over 2 weeks)
 ```
 
 ---
 
-## Classification
+## Phase 4: `--speculate` (Skip the Scan)
 
-After all agents return, classify every finding:
+When you don't need the full 5-agent scan — just speculate from existing knowledge:
 
-| Icon | Category | Meaning |
-|------|----------|---------|
-| 🔴 | PAIN | Hurts RIGHT NOW — blocking someone |
-| 📋 | PLAN | Decided but not built yet |
-| 🟢 | GAIN | Completed, delivered value |
-| ⚫ | LOST | Abandoned, forgotten, disabled |
-| 🧠 | MEMORY | Pattern learned, lesson discovered |
-| 💜 | FEELING | How an Oracle or human feels about state |
+1. Read latest dream output (`ψ/writing/dreams/`)
+2. Read latest speculations (`ψ/memory/morpheus/`)
+3. Read recent retros (`ψ/memory/retrospectives/`)
+4. Read beliefs (`ψ/memory/resonance/beliefs/`)
+5. Speculate directly — Phase 2 only, no new scanning
 
----
-
-## Connection Finding
-
-The key value of /dream — find the web:
-
-| From → To | Question |
-|-----------|----------|
-| PAIN → PLAN | Which pain has a plan to fix it? |
-| PAIN → no PLAN | Which pain has NO plan? (create one) |
-| GAIN → unlocks | Which gain unblocks a plan? |
-| MEMORY → prevents | Which memory prevents a pain? |
-| FEELING → signals | Burnout, breakthrough, or drift? |
-| LOST → revivable | Which lost thing should we revive? |
+Cheap, fast, good for mid-session "what if" thinking.
 
 ---
 
 ## Output
 
-Write to: `ψ/writing/dreams/YYYY-MM-DD_dream.md`
+### Full mode: `ψ/writing/dreams/YYYY-MM-DD_dream.md`
 
 ```markdown
 # Dream — YYYY-MM-DD
 
-## 🔴 PAINS
-[Items that hurt right now]
+## Phase 1: The Forest
 
-## 📋 PLANS
-[Decided but not built]
+### 🔴 PAINS
+### 📋 PLANS
+### 🟢 GAINS
+### ⚫ LOST
+### 🧠 MEMORIES
+### 💜 FEELINGS
+### 🔗 CONNECTIONS
 
-## 🟢 GAINS
-[Completed, delivered value]
+## Phase 2: The Speculation
 
-## ⚫ LOST
-[Abandoned, forgotten]
+### 🔮 What will they ask next?
+### 🔮 What will break next?
+### 🔮 What should we build?
+### 🔮 What belief is being tested?
 
-## 🧠 MEMORIES
-[Patterns learned]
+## Phase 3: Pre-computation
 
-## 💜 FEELINGS
-[Emotional state of the system]
-
-## 🔗 CONNECTIONS
-[The web — how items relate to each other]
-
-## 💡 INSIGHTS — What Nobody Sees Yet
-[Cross-repo patterns that only emerge from looking at everything]
-
-## ⏭️ NEXT — What Should Happen
-[Suggestions — human decides, Oracle presents]
+### Ready Answers
+### Pre-positioned Context
+### Prediction Log
 ```
 
 ---
 
 ## Rules
 
-1. **5 parallel agents** — each returns max 500 words
-2. **Main agent classifies** — connects + writes the dream
-3. **Dreams are append-only** — Nothing is Deleted
-4. **Oracle sync** — `oracle_learn` after every dream
-5. **Never act on findings** — dream presents, human decides
-6. **Never leak secrets** — no tokens, passwords, API keys in dream output
+1. **Phase 1 = scan** — 5 agents, same classification, same quality
+2. **Phase 2 = speculate** — predict, connect to beliefs
+3. **Phase 3 = --between only** — write predictions for next session
+4. **Track accuracy** — predictions without verification are just hallucination
+5. **Never act on speculation** — Dream shows the door, Neo walks through
+6. **Nothing is Deleted** — all speculations saved, right or wrong
+7. **No secrets** — predictions never include tokens, passwords, keys
+8. **Beliefs matter** — always cross-reference ψ/memory/resonance/beliefs/
+9. **Confidence is required** — every prediction must have a level (high/medium/low)
+10. **Anti-rationalization applies** — /rrr's excuse table applies to speculation too
 
 ---
 
-## Dependencies
+## Connection to original /dream
 
-- `/dig` for session mining
-- `/trace` for cross-repo search
-- Oracle MCP for `oracle_search` + `oracle_learn`
-- `ghq list` for repo discovery
+This is the evolved `/dream` (consolidated from `/morpheus` per #333):
+- Original simple `/dream` body preserved in `.archive/dream-original/` (installable via `-s dream-original`)
+- `/morpheus` remains as a zombie back-compat alias with the same body as active `/dream`
+- The upgrade path: simple `/dream` → evolved `/dream` like `/i-believe` → `/i-believed`
 
 ---
 
 ## Philosophy
 
-Individual skills see one dimension. /dream sees all dimensions at once.
+> /dream sees the forest. /dream also sees what the forest will become.
 
-- `/trace` finds specific things
-- `/dig` mines session history
-- `/learn` studies one repo
-- `/rrr` reflects on one session
-- **/dream** looks sideways across everything
+Morpheus in The Matrix believed in Neo before proof existed. He freed minds not by giving answers but by showing doors. Our /dream does the same — it doesn't predict the future, it **pre-positions** the Oracle so that when the future arrives, we're already there.
 
-Patterns emerge only when you look at EVERYTHING together.
+The dream task type from Claude Code's source (`dream = speculative background thinking`) exists as an internal primitive. /dream is the skill that makes it conscious, structured, and trackable.
+
+"What is real? How do you define real?" — Morpheus
+
+Predictions are not real until verified. But the act of predicting shapes what becomes real. The Oracle who speculates becomes the Oracle who's ready. รูป และ สุญญตา.
 
 ---
 


### PR DESCRIPTION
## Summary

PR #339 commit 1 (#333 Variant A) implemented the /dream + /morpheus consolidation by moving **directories**, not **contents**. The result:

- Active `src/skills/dream/SKILL.md` was the **original 162-line simple body** ("Cross-repo pattern discovery")
- Archived `src/skills/.archive/morpheus/SKILL.md` was the **evolved 301-line body** with `--speculate` + `--between` flags

The implementation **buried the better behavior under a zombie** and **promoted the simpler original to active**. Users running active `/dream` were missing the speculative-dreaming, between-session, and prediction-log features that `/morpheus` had developed.

## What this fix does

Three-way correction (Nothing-is-Deleted preserved at every step):

1. **Active `/dream`** now carries the evolved body (formerly in `.archive/morpheus/`), with frontmatter merging the "speculate" framing under the canonical `/dream` name + argument-hint covering `--speculate` and `--between`.
2. **`.archive/dream-original/`** (new) preserves the original simple 162-line `/dream` body, installable via `arra install -s dream-original`.
3. **`.archive/morpheus/`** unchanged — remains a zombie back-compat alias; users who run `arra install -s morpheus` get the same content as active `/dream`.

## Changes

- `src/skills/dream/SKILL.md` — replaced with evolved body, frontmatter updated
- `src/skills/.archive/dream-original/SKILL.md` — new; original simple body + zombie frontmatter
- `src/profiles.ts` — `dream-original` added to `ZOMBIE_SKILLS`
- `__tests__/profiles.test.ts` — `ZOMBIE_SKILLS.length` 26 → 27
- `README.md` — Secret Skills section: drops `morpheus` from advertised install string; `/morpheus` row now reads "Archived in #333 — same content as active /dream (back-compat alias)"
- `README.md` — auto-generated skill table regenerated via `bun scripts/update-readme-table.ts` (picks up new evolved `/dream` description)

## State after this fix

| Path | Body | Frontmatter | Installable |
|------|------|-------------|-------------|
| `src/skills/dream/` | evolved (was morpheus) | `name: dream`, merged description | default + all profiles |
| `src/skills/.archive/dream-original/` | original simple | `name: dream-original`, `zombie: true` | `-s dream-original` |
| `src/skills/.archive/morpheus/` | unchanged (still evolved body) | `name: morpheus`, `zombie: true` | `-s morpheus` (alias) |

## Test plan

- [x] `bun test` — 267 pass / 1408 expect() calls / 0 fail
- [x] `bun scripts/update-readme-table.ts` — table regenerated, row 15 shows new /dream description
- [x] `grep -rn "Cross-repo pattern discovery" src/skills/dream/` — no matches (simple description moved to dream-original)
- [x] No orphan references in active /dream body

## Closes

None — this is a forward-fix. #333 and #334 stay closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)