### PR TITLE
fix(#347): heartbeat — strict Bash:SendMessage alternation

### DIFF
--- a/src/skills/team-agents/SKILL.md
+++ b/src/skills/team-agents/SKILL.md
@@ -175,12 +175,26 @@ Instructions:
      message: "[findings, max 500 words]"
    })
 
-HEARTBEAT (mandatory):
-- Every 5 min: SendMessage PROGRESS: <what you did>
-- Blocked: SendMessage STUCK: <what you need>
-- Done: SendMessage DONE: <branch if worktree> <summary>
-- Failed: SendMessage ABORT: <reason>
-- NEVER go idle without reporting.
+HEARTBEAT — strict Bash:SendMessage alternation (1:1 ratio):
+
+After EVERY Bash tool call (whether success or failure), your VERY NEXT tool
+call MUST be SendMessage to team-lead. Pattern:
+
+  Bash(...) → tool_result → SendMessage(to: team-lead, summary: "...",
+  message: "<1-2 lines: what you did + what you saw>") → next Bash → ...
+
+This is not optional. If you call two Bash in a row without a SendMessage
+between them, the protocol is broken — self-ABORT with reason "skipped
+heartbeat" and stop.
+
+Special triggers (still subject to per-Bash heartbeat):
+- STUCK: <what blocks you>  (when blocked, before any diagnostic Bash)
+- DONE: <final summary>     (only after TaskUpdate marks task completed)
+- ABORT: <reason>           (if you cannot proceed)
+
+Avoid long shell loops inside a single Bash — prefer one Bash per iteration
+step with mandatory heartbeat between. The lead counts your Bash:SendMessage
+ratio. Silence = bug.
 
 Rules:
 - ALWAYS SendMessage BEFORE finishing


### PR DESCRIPTION
## Summary
- Replace soft behavioral heartbeat suggestions with mandatory 1:1 Bash→SendMessage alternation protocol
- After every Bash tool call, agent's next call MUST be SendMessage to team-lead
- Self-ABORT on protocol violation (two consecutive Bash without SendMessage)
- Documents anti-pattern: long shell loops inside single Bash hide progress

## Evidence
From maw-js ship-1308 team (2026-05-14):
| Agent | Prompt | Heartbeats in 20 min |
|---|---|---|
| investigator-v1 | old (behavioral) | **0** — force-killed after 22 min silence |
| investigator-v2 | strict alternation | **3 heartbeats in 4 min** |

## Test plan
- [ ] Spawn teammate with slow Bash sequence, confirm SendMessage count = Bash count
- [ ] Confirm first SendMessage arrives within ~60s of first Bash completing
- [ ] Confirm shutdown_request honored within ~1 Bash duration

Closes #347

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle