### PR TITLE
chore(#342): auto-regenerate README on alpha merge

### DIFF
--- a/.github/workflows/readme-regen.yml
+++ b/.github/workflows/readme-regen.yml
@@ -1,0 +1,37 @@
+name: Regenerate README
+
+on:
+  push:
+    branches: [alpha]
+    paths:
+      - 'src/skills/**/SKILL.md'
+      - 'src/skills/.archive/**/SKILL.md'
+      - 'src/profiles.ts'
+      - 'scripts/update-readme-table.ts'
+      - 'scripts/generate-table.ts'
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun scripts/update-readme-table.ts
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet README.md; then
+            echo "README is up to date"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add README.md
+          git commit -m "chore(readme): regenerate skill table [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -138,24 +138,46 @@ agents                  # list 18 supported agents
 about                   # version + status
 ```
 
-## Secret Skills
+<!-- secret-skills:start -->
 
-Secret skills are excluded from all profiles. Install by name:
+## Zombie Skills
+
+27 skills excluded from all profiles. Install by name:
 
 ```bash
-npx arra-oracle-skills@26.5.14-alpha.721 install -g -y -s watch harden wormhole fleet release warp mailbox
+npx arra-oracle-skills install -g -y -s <name>
 ```
 
 | Skill | What |
 |-------|------|
-| `/watch` | YouTube CC extraction via yt-dlp |
-| `/harden` | Oracle governance audit |
-| `/wormhole` | Federated query proxy (data sovereign) |
-| `/fleet` | Deep fleet census across nodes |
-| `/release` | Automated release flow |
-| `/warp` | SSH+tmux teleport to remote nodes |
-| `/morpheus` | Archived in #333 — same content as active /dream (back-compat alias) |
-| `/mailbox` | Persistent agent memory in ψ/ |
+| `/alpha-feature` | Full skill development pipeline — create, compile, test, ... |
+| `/birth` | Prepare Oracle birth props for a new repo — Issue #1, MCP... |
+| `/deep-research` | Deep Research via Gemini — opens new tab, selects Deep Re... |
+| `/gemini` | Control Gemini browser tab via MQTT WebSocket — chat, tra... |
+| `/handover` | Transfer work to another Oracle — forward + wake + tell i... |
+| `/list-issues-pr-pulse` | Open issues, PRs, and Pulse board in one view. Use when u... |
+| `/mine` | Extract a specific topic from a single session JSONL file... |
+| `/new-issue` | Quick GitHub issue creation. Use when user says "new issu... |
+| `/oracle-manage` | Skill and profile management — prepare tools, switch prof... |
+| `/speak` | Text-to-speech using edge-tts neural voices with macOS sa... |
+| `/what-we-done` | Facts-only progress report — commits, PRs merged, issues ... |
+| `/whats-next` | Smart action suggestions — scan context, rank priorities,... |
+| `/workon` | Work on a GitHub issue with worktree isolation, or resume... |
+| `/i-believed` | Declare belief — looking back or leaping forward. 'I beli... |
+| `/work-with` | Persistent cross-oracle collaboration with synchronic sco... |
+| `/morpheus` | Speculative dreaming — background thinking, pre-computati... |
+| `/retrospective` | Quick session retrospective — summary, lessons, next step... |
+| `/skills-list` | List all Oracle skills with profile tier, type, and scrip... |
+| `/fleet` | Deep fleet census — discover all oracles across all nodes... |
+| `/machines` | Fleet machines — discover nodes from contacts, ping to pr... |
+| `/warp` | Teleport to a remote oracle node via SSH+tmux. Interactiv... |
+| `/release` | Automated release flow — bump version, changelog, tag, pu... |
+| `/philosophy` | Display Oracle philosophy — the 5 Principles + Rule 6. Us... |
+| `/wormhole` | Federated query proxy — ask questions across oracle nodes... |
+| `/harden` | Audit Oracle configuration for safety, governance, and ha... |
+| `/vault` | Connect external knowledge bases (Obsidian, Logseq, markd... |
+| `/dream-original` | Cross-repo pattern discovery with parallel agents. Finds ... |
+<!-- secret-skills:end -->
 
 ## Team Agent Scripts
 

--- a/scripts/update-readme-table.ts
+++ b/scripts/update-readme-table.ts
@@ -1,7 +1,8 @@
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { execSync } from 'child_process';
-import { profiles } from '../src/profiles.js';
+import { existsSync } from 'fs';
+import { profiles, ZOMBIE_SKILLS, skillDirFor } from '../src/profiles.js';
 
 const README_PATH = join(process.cwd(), 'README.md');
 
@@ -21,6 +22,32 @@ function generateProfileTable(totalSkills: number): string {
   }
 
   return lines.join('\n');
+}
+
+async function generateZombieTable(): Promise<string> {
+  const skillsRoot = join(process.cwd(), 'src', 'skills');
+  const rows: string[] = [];
+
+  for (const name of ZOMBIE_SKILLS) {
+    const dir = skillDirFor(name, skillsRoot);
+    const skillFile = join(dir, 'SKILL.md');
+    if (!existsSync(skillFile)) continue;
+
+    const content = await readFile(skillFile, 'utf-8');
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatterMatch) continue;
+
+    const fm = frontmatterMatch[1];
+    const descMatch = fm.match(/^description:\s*['"]?(.*?)['"]?\s*$/m);
+    let desc = descMatch ? descMatch[1] : name;
+    // Strip [core]/[lab] markers and version prefixes from description
+    desc = desc.replace(/^\[.*?\]\s*/g, '').replace(/^v[\d.]+-?\S*\s*\|\s*/, '');
+    if (desc.length > 60) desc = desc.substring(0, 57) + '...';
+
+    rows.push(`| \`/${name}\` | ${desc} |`);
+  }
+
+  return rows.join('\n');
 }
 
 async function updateReadmeTable() {
@@ -85,6 +112,36 @@ async function updateReadmeTable() {
     /arra-oracle-skills@[\w.\-]+ install/g,
     `arra-oracle-skills@${version} install`
   );
+
+  // --- Update zombie skills section ---
+  const secretStart = readme.indexOf('<!-- secret-skills:start -->');
+  const secretEnd = readme.indexOf('<!-- secret-skills:end -->');
+
+  if (secretStart !== -1 && secretEnd !== -1) {
+    const secretBefore = readme.substring(0, secretStart + '<!-- secret-skills:start -->'.length);
+    const secretAfter = readme.substring(secretEnd);
+
+    const zombieTable = await generateZombieTable();
+    const zombieCount = zombieTable.split('\n').filter(l => l.startsWith('|')).length;
+
+    const secretSection = [
+      '',
+      `## Zombie Skills`,
+      '',
+      `${zombieCount} skills excluded from all profiles. Install by name:`,
+      '',
+      '```bash',
+      'npx arra-oracle-skills install -g -y -s <name>',
+      '```',
+      '',
+      '| Skill | What |',
+      '|-------|------|',
+      zombieTable,
+      '',
+    ].join('\n');
+
+    readme = `${secretBefore}\n${secretSection}${secretAfter}`;
+  }
 
   // Check if changed
   const original = await readFile(README_PATH, 'utf-8');


### PR DESCRIPTION
## Summary
- **Layer 1**: New `readme-regen.yml` workflow fires on alpha pushes touching SKILL.md/profiles.ts/scripts
- **Layer 2**: `update-readme-table.ts` now auto-generates the Zombie Skills section from `ZOMBIE_SKILLS` in profiles.ts
- Replaces hand-maintained "Secret Skills" table (was stale after #333 moved /morpheus to zombie)
- 27 zombie skills now auto-rendered with descriptions from their `.archive/` SKILL.md files
- Bot commits use `[skip ci]` to prevent infinite loop (README.md not in paths trigger)

## Changes
- `+` `.github/workflows/readme-regen.yml` — new workflow
- `M` `scripts/update-readme-table.ts` — zombie table generation
- `M` `README.md` — markers + regenerated content

## Test plan
- [x] `bun scripts/update-readme-table.ts` runs locally, generates correct output
- [ ] Workflow fires on next alpha merge touching `src/skills/`
- [ ] No infinite loop (paths filter excludes README.md)
- [ ] Bot commit appears on alpha with correct content

Closes #342

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle