### PR TITLE
feat: move xray to lab, add /hey as lab skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-36 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+37 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -64,7 +64,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>36 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>37 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -90,22 +90,23 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 18 | **forward-lite** | skill | Quick handoff to next session |
 | 19 | **fyi** | skill | Log information for future reference |
 | 20 | **go** | skill | Switch skill profiles (standard/full/lab) |
-| 21 | **inbox** | skill | Read and write to Oracle inbox |
-| 22 | **incubate** | skill | Clone or create repos for active development |
-| 23 | **mailbox** | skill | 'Persistent agent mailbox |
-| 24 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
-| 25 | **recap-lite** | skill | Quick session orientation |
-| 26 | **resonance** | skill | Capture a resonance moment |
-| 27 | **rrr-lite** | skill | Quick session retrospective |
-| 28 | **standup** | skill | Daily standup check |
-| 29 | **talk-to** | skill | Talk to another Oracle agent |
-| 30 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 31 | **trace** | skill | Find projects, code |
-| 32 | **watch** | skill | 'Extract YouTube video transcripts |
-| 33 | **where-we-are** | skill | Session awareness |
-| 34 | **who-are-you** | skill | Know ourselves |
-| 35 | **worktree** | skill | 'Work in an isolated git worktree |
-| 36 | **xray** | skill | X-ray deep scan |
+| 21 | **hey** | skill | Talk to another oracle via maw federation |
+| 22 | **inbox** | skill | Read and write to Oracle inbox |
+| 23 | **incubate** | skill | Clone or create repos for active development |
+| 24 | **mailbox** | skill | 'Persistent agent mailbox |
+| 25 | **oracle-soul-sync-update** | skill | Sync Oracle instruments with the family |
+| 26 | **recap-lite** | skill | Quick session orientation |
+| 27 | **resonance** | skill | Capture a resonance moment |
+| 28 | **rrr-lite** | skill | Quick session retrospective |
+| 29 | **standup** | skill | Daily standup check |
+| 30 | **talk-to** | skill | Talk to another Oracle agent |
+| 31 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 32 | **trace** | skill | Find projects, code |
+| 33 | **watch** | skill | 'Extract YouTube video transcripts |
+| 34 | **where-we-are** | skill | Session awareness |
+| 35 | **who-are-you** | skill | Know ourselves |
+| 36 | **worktree** | skill | 'Work in an isolated git worktree |
+| 37 | **xray** | skill | X-ray deep scan |
 
 </details>
 
@@ -118,9 +119,9 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | Profile | Count | Skills |
 |---------|-------|--------|
 | **minimal** | 7 | `about-oracle`, `forward-lite`, `go`, `oracle-soul-sync-update`, `recap-lite`, `rrr-lite`, `trace` |
-| **standard** | 13 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace`, `xray` |
-| **full** | 36 | all |
-| **lab** | 36 | all |
+| **standard** | 12 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace` |
+| **full** | 37 | all |
+| **lab** | 37 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -25,9 +25,9 @@ describe("profiles", () => {
     expect(MINIMAL_SKILLS).toContain("go");
   });
 
-  it("standard has 13 skills", () => {
-    expect(STANDARD_SKILLS).toHaveLength(13);
-    expect(profiles.standard.include).toHaveLength(13);
+  it("standard has 12 skills", () => {
+    expect(STANDARD_SKILLS).toHaveLength(12);
+    expect(profiles.standard.include).toHaveLength(12);
   });
 
   it("full excludes lab-only AND minimal-only skills (post-#285)", () => {
@@ -52,8 +52,8 @@ describe("profiles", () => {
     expect([...STANDARD_SKILLS]).not.toContain("feel");
   });
 
-  it("LAB_SKILLS has 9 experimental skills (post-#327 cull)", () => {
-    expect(LAB_SKILLS).toHaveLength(9);
+  it("LAB_SKILLS has 11 experimental skills (9 post-#327 + xray from standard + hey new)", () => {
+    expect(LAB_SKILLS).toHaveLength(11);
   });
 
   it("ZOMBIE_SKILLS has 27 archived candidates (13 original + 12 culled in #327 + 1 added in #333 + 1 dream-original in #333 content correction)", () => {
@@ -120,9 +120,9 @@ describe("resolveProfile", () => {
     expect(result).toHaveLength(7);
   });
 
-  it("standard returns 13 skills", () => {
+  it("standard returns 12 skills", () => {
     const result = resolveProfile("standard", ALL_SKILLS);
-    expect(result).toHaveLength(13);
+    expect(result).toHaveLength(12);
   });
 
   it("full returns all minus lab-only, minimal-only, and zombies", () => {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -24,13 +24,13 @@ export const MINIMAL_SKILLS = [
 /** Standard profile — daily driver skills (always installed) */
 export const STANDARD_SKILLS = [
   'awaken', 'bampenpien', 'bud', 'dig', 'forward', 'go',
-  'learn', 'recap', 'rrr', 'talk-to', 'team-agents', 'trace', 'xray',
+  'learn', 'recap', 'rrr', 'talk-to', 'team-agents', 'trace',
 ] as const;
 
 /** Lab-only skills — experimental, not in standard or full */
 export const LAB_SKILLS = [
-  'contacts', 'dream', 'feel', 'fyi', 'inbox', 'mailbox',
-  'schedule', 'watch', 'worktree',
+  'contacts', 'dream', 'feel', 'fyi', 'hey', 'inbox', 'mailbox',
+  'schedule', 'watch', 'worktree', 'xray',
 ] as const;
 
 /** Minimal-only skills — token-optimized lite variants that replace the full

--- a/src/skills/hey/SKILL.md
+++ b/src/skills/hey/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: hey
+description: Talk to another oracle via maw federation. Uses fleet machine names (white, mba, clinic-nat, oracle-world, phaith). Auto-signs with current oracle's [host:handle] from CLAUDE.md. Global — works from any oracle repo.
+---
+
+# /hey
+
+Quick federation messenger. Wraps `maw hey <node>:<agent>` with two additions:
+1. Fleet-name resolution — just use `fireman` instead of `white:fireman` when target is on current host
+2. Auto-sig — appends `[<host>:<handle>]` read from local CLAUDE.md
+
+## Usage
+
+```
+/hey <node>:<agent> <message>      # explicit node:agent
+/hey <agent> <message>              # same host as me (infer node)
+/hey list                           # list reachable agents in fleet
+/hey peek <node>:<agent>            # wrap maw peek
+```
+
+## Step 0: Init + resolve identity
+
+```bash
+date "+🕐 %H:%M %Z"
+# Resolve my identity from CLAUDE.md
+MY_HANDLE=$(grep -E "^- \*\*Technical handle\*\*:|^- \*\*Handle\*\*:" CLAUDE.md 2>/dev/null | head -1 | sed -E 's/.*`([^`]+)`.*/\1/' || echo "")
+# Fallback to repo name if CLAUDE.md missing
+[ -z "$MY_HANDLE" ] && MY_HANDLE=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" | sed 's/-oracle$//')
+MY_HOST=$(hostname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')
+# Common fleet host aliases
+case "$MY_HOST" in
+  white.local|white) MY_HOST=white ;;
+  mba*) MY_HOST=mba ;;
+esac
+MY_SIG="[$MY_HOST:$MY_HANDLE]"
+echo "sig=$MY_SIG"
+```
+
+## Usage: send
+
+```bash
+TARGET="$1"      # fireman OR white:fireman
+MSG="$2"         # message body
+
+# Resolve target node
+if [[ "$TARGET" == *:* ]]; then
+  NODE=${TARGET%%:*}
+  AGENT=${TARGET##*:}
+else
+  NODE=$MY_HOST
+  AGENT=$TARGET
+fi
+
+maw hey "$NODE:$AGENT" "$MSG $MY_SIG"
+```
+
+## Usage: list
+
+```bash
+maw agents 2>&1 | awk 'NR>1 {print $1":"$4, "("$5")"}'
+```
+
+## Usage: peek
+
+```bash
+maw peek "$TARGET" 2>&1 | head -40
+```
+
+## Fleet machine names (from ~/etc/hosts)
+
+| Name | IP | Route |
+|---|---|---|
+| `white` | localhost / 10.x | this machine (Linux/Ubuntu) |
+| `mba` | mba.wg / 10.20.0.3 | WireGuard |
+| `clinic-nat` | 10.20.0.1 | WireGuard |
+| `oracle-world` | 100.120.242.120 | WireGuard |
+| `phaith` | localhost:3458 | local peer |
+
+## Rule 6 discipline
+
+All outbound federation messages carry `[<host>:<handle>]` at the end. Never pretend to be human; never drop the sig. The sig is identity, not decoration.
+
+## Related
+
+- `/contacts` (core) — Oracle contact registry
+- `/talk-to` (core) — heavier threaded conversation
+- `/federation-talk` (user) — fleet-wide broadcast
+
+## Examples
+
+```
+/hey fireman "FMT registry changed?"
+/hey white:arthur-god-line "update from child"
+/hey list
+/hey peek white:fireman
+```
+
+---
+
+ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Summary
- **xray**: standard → lab (standard now 12 skills, leaner)
- **hey**: new lab skill — federation messenger wrapping `maw hey` with fleet-name resolution + auto-sig
- Test assertions updated: standard 13→12, LAB 9→11

## Why
Standard should be the minimum daily driver. xray is a power tool, hey is federation-specific — both are lab-tier. Cherry-pick anytime via `-s xray hey`.

## Test plan
- [x] `bun test __tests__/profiles.test.ts` — 31 pass, 0 fail
- [x] Pre-commit hook passes (all 264 tests pass)

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle