### PR TITLE
feat(#355): /go list — all skills with profile tier + installed count

### DIFF
--- a/src/skills/go/SKILL.md
+++ b/src/skills/go/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go
 description: Switch skill profiles (standard/full/lab), fresh install, or enable/disable specific skills via arra-oracle-skills CLI. Destructive — modifies globally installed skills.
-argument-hint: "<standard|full|lab|cleanup|update> | enable|disable <skill...>"
+argument-hint: "[list] | <standard|full|lab|cleanup|update> | enable|disable <skill...>"
 disable-model-invocation: true
 ---
 
@@ -12,7 +12,8 @@ disable-model-invocation: true
 ## Usage
 
 ```
-/go                     # show installed skills
+/go                     # all skills — profile tier + installed status
+/go list                # same as /go (no args)
 /go minimal             # newcomer essentials (7 skills, default)
 /go standard            # daily driver (13 skills)
 /go full                # all stable (excludes lab-only experiments)
@@ -54,10 +55,63 @@ Use `$ARRA` for all commands below.
 
 Parse the user's `/go` arguments and run the matching `$ARRA` command.
 
-### `/go` (no args) — show current state
+### `/go` or `/go list` — show all skills with profile + installed status
+
+Run ONE bash call to build the full picture:
 
 ```bash
-$ARRA list -g
+SKILLS_DIR="$HOME/.claude/skills"
+VERSION=$($ARRA --version 2>/dev/null || echo "?")
+
+# All arra profile skills (read from profiles.ts constants via the CLI)
+STANDARD="awaken bampenpien bud dig forward go learn recap rrr talk-to team-agents trace"
+LAB="contacts dream feel fyi hey inbox mailbox schedule watch worktree xray"
+MINIMAL_ONLY="forward-lite recap-lite rrr-lite"
+ALL_ARRA="$STANDARD $LAB $MINIMAL_ONLY"
+
+echo "📋 Oracle Skills v$VERSION"
+echo ""
+
+NUM=0; INSTALLED=0
+for tier in STANDARD LAB MINIMAL_ONLY; do
+  case $tier in
+    STANDARD) skills="$STANDARD"; label="standard" ;;
+    LAB) skills="$LAB"; label="lab" ;;
+    MINIMAL_ONLY) skills="$MINIMAL_ONLY"; label="minimal-only" ;;
+  esac
+  echo "  ─── $label ───"
+  for name in $skills; do
+    NUM=$((NUM+1))
+    if [ -d "$SKILLS_DIR/$name" ]; then
+      mark="✓"; INSTALLED=$((INSTALLED+1))
+    else
+      mark="✗"
+    fi
+    printf "  %2d. %-28s %s\n" "$NUM" "$name" "$mark"
+  done
+  echo ""
+done
+
+# Count external (non-arra) skills
+EXT=0; EXT_NAMES=""
+for dir in "$SKILLS_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  name=$(basename "$dir"); [ "$name" = ".trash" ] && continue
+  is_arra=false
+  for a in $ALL_ARRA; do [ "$name" = "$a" ] && is_arra=true && break; done
+  if [ "$is_arra" = "false" ]; then
+    EXT=$((EXT+1)); EXT_NAMES="$EXT_NAMES $name"
+  fi
+done
+[ "$EXT" -gt 0 ] && echo "  ─── external ($EXT) ───" && for name in $EXT_NAMES; do
+  NUM=$((NUM+1)); INSTALLED=$((INSTALLED+1))
+  printf "  %2d. %-28s ✓\n" "$NUM" "$name"
+done && echo ""
+
+echo "  $INSTALLED/$NUM installed"
+echo ""
+echo "  Cherry-pick:  arra-oracle-skills install -g -s <name> -y"
+echo "  Switch:       /go standard | /go lab"
 ```
 
 ### `/go <profile>` — switch profile


### PR DESCRIPTION
## Summary
- `/go` and `/go list` now show every arra skill grouped by tier (standard/lab/minimal-only)
- Numbered rows with ✓/✗ installed status
- External skills in separate section
- Footer: `N/M installed` + cherry-pick hint

Closes #355

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle