### PR TITLE
fix: auto-remove lite variants when full counterpart installed

### DIFF
--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -287,6 +287,35 @@ export async function installSkills(
     }
   }
 
+  // Auto-remove minimal-only lite variants when cherry-picking their full counterparts.
+  // forward-lite is redundant when forward is installed, same for recap-lite/rrr-lite.
+  // Only triggers on -s (cherry-pick) without --profile — profile alignment handles the rest.
+  const liteToFull: Record<string, string> = {
+    'forward-lite': 'forward',
+    'recap-lite': 'recap',
+    'rrr-lite': 'rrr',
+  };
+  const isCherryPick = options.skills && options.skills.length > 0 && !options.profileExplicit;
+  if (isCherryPick) {
+    const installing = new Set(skillsToInstall.map((s) => s.name));
+    for (const agentName of targetAgents) {
+      const agent = agents[agentName as keyof typeof agents];
+      if (!agent) continue;
+      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
+      for (const [lite, full] of Object.entries(liteToFull)) {
+        // Remove lite only if: 1) its full version is being installed or already exists, 2) lite is not being installed
+        const fullInstalling = installing.has(full) || existsSync(join(skillsDir, full));
+        const liteInstalling = installing.has(lite);
+        if (fullInstalling && !liteInstalling && existsSync(join(skillsDir, lite))) {
+          if (await isOurSkill(join(skillsDir, lite))) {
+            await rm(join(skillsDir, lite), { recursive: true, force: true });
+            p.log.info(`Auto-removed ${lite} (${full} is installed — lite variant redundant)`);
+          }
+        }
+      }
+    }
+  }
+
   // Confirm installation
   if (!options.yes) {
     const agentList = targetAgents.map((a) => agents[a as keyof typeof agents]?.displayName || a).join(', ');


### PR DESCRIPTION
When cherry-picking via -s, lite variants auto-removed if full counterpart exists.
267 pass, 0 fail.

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle