### PR TITLE
fix(#351): worktree detection + nullglob crash

### DIFF
--- a/src/skills/dig/SKILL.md
+++ b/src/skills/dig/SKILL.md
@@ -44,13 +44,28 @@ Output metadata includes detected timezone name and offset.
 ## Step 0: Timestamp
 
 ```bash
-date "+🕐 %H:%M %Z (%A %d %B %Y)" && ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
-for wt in "$HOME/.claude/projects/${ENCODED_PWD}"-wt*; do [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"; done
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
 ```
 
-Encodes `pwd` the same way Claude does (replace `/` and `.` with `-`, prepend `-`) to match the `.claude/projects/` directory naming (e.g. `github.com` → `github-com`). Also picks up worktree dirs (`-wt`, `-wt-1`, etc.).
+Encodes `pwd` the same way Claude does (replace `/` and `.` with `-`, prepend `-`) to match the `.claude/projects/` directory naming (e.g. `github.com` → `github-com`). Detects parent project from worktree dirs (strips `-wt-*` suffix) and includes both parent and self worktrees. The `(N)` qualifier prevents zsh crashes when no worktrees exist.
 
 **With `--all`** (all repos):
 ```bash

--- a/src/skills/recap/SKILL.md
+++ b/src/skills/recap/SKILL.md
@@ -76,6 +76,22 @@ ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
+
 python3 ~/.claude/skills/dig/scripts/dig.py 1
 ```
 

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -228,7 +228,21 @@ Discover project dirs using full-path encoding (same as Claude's `.claude/projec
 ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
-for wt in "${PROJECT_BASE}"-wt*; do [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"; done
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
 ```
 
 Then run dig.py to get session JSON:

--- a/src/skills/trace/SKILL.md
+++ b/src/skills/trace/SKILL.md
@@ -208,7 +208,21 @@ Run the dig script to get all sessions:
 ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
-for wt in "${PROJECT_BASE}"-wt*; do [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"; done
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
 
 python3 ~/.claude/skills/dig/scripts/dig.py 0
 


### PR DESCRIPTION
Fixes #351 — dig/recap/trace/rrr Step 0 worktree glob nullglob crash + parent-project detection from worktrees.

## Changes
- Nullglob-safe worktree scan with zsh `(N)` qualifier across:
  - `src/skills/dig/SKILL.md` Step 0
  - `src/skills/recap/SKILL.md` Step 4 (dig last session)
  - `src/skills/trace/SKILL.md` (dig agent template)
  - `src/skills/rrr/SKILL.md` (dig timeline block)
- Parent project dir detection by stripping `-wt-*` suffix — so dig invoked from a worktree picks up sessions logged against the canonical project dir too.

## Out of scope
- `/go` SKILL.md template bugs noted in original task brief were already correct on origin/alpha (lines 71/94/106 already use `$1`). No edit needed.

## Test plan
- [x] `bun test` — 267 pass / 0 fail / 1407 expects (6.28s)
- [ ] Manual: run `/dig` from a worktree dir with no peer worktrees (must not crash)
- [ ] Manual: run `/dig` from a worktree dir with sibling worktrees (must include all)

Closes #351