### PR TITLE
fix: stale comments, wrong URLs, missing zombie overlap tests

### DIFF
--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -74,9 +74,13 @@ describe("profiles", () => {
   it("no overlap between ZOMBIE_SKILLS and other tiers", () => {
     const standardSet = new Set(STANDARD_SKILLS);
     const labSet = new Set(LAB_SKILLS);
+    const minimalSet = new Set<string>(MINIMAL_SKILLS);
+    const minimalOnlySet = new Set<string>(MINIMAL_ONLY_SKILLS);
     for (const skill of ZOMBIE_SKILLS) {
       expect(standardSet.has(skill)).toBe(false);
       expect(labSet.has(skill)).toBe(false);
+      expect(minimalSet.has(skill)).toBe(false);
+      expect(minimalOnlySet.has(skill)).toBe(false);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "url": "git+https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli.git"
   },
   "bugs": {
-    "url": "https://github.com/Soul-Brews-Studio/oracle-skills-cli/issues"
+    "url": "https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli/issues"
   },
-  "homepage": "https://github.com/Soul-Brews-Studio/oracle-skills-cli#readme",
+  "homepage": "https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli#readme",
   "engines": {
     "node": ">=18"
   },

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,8 +1,8 @@
 /**
  * Skill profiles — 3 tiers, single source of truth.
  *
- * minimal: newcomer essentials — 7 skills (lifecycle + trace + update + upgrade)
- * standard: daily driver — 13 essential skills (data-driven, session 8+9)
+ * minimal: newcomer essentials — 6 skills (lifecycle + trace + update + upgrade)
+ * standard: daily driver — 12 essential skills (data-driven, session 8+9)
  * full: all stable skills (excludes lab-only experiments AND minimal-only lite variants)
  * lab: everything including experimental / bleeding edge (still excludes minimal-only lite variants)
  *
@@ -55,7 +55,7 @@ export const ZOMBIE_SKILLS = [
   'list-issues-pr-pulse', 'mine', 'new-issue', 'oracle-manage',
   'speak', 'what-we-done', 'whats-next', 'workon',
   // 2026-05-13 cull (#327): 13 zombies based on usage audit (3,685 sessions).
-  // Kept active by explicit user request: bampenpien (standard), feel + morpheus (lab),
+  // Kept active by explicit user request: bampenpien (standard), feel (lab),
   // fyi (lab, imported from oracle-proof-of-concept-skills), resonance (implicit-full).
   'i-believed', 'work-with', 'morpheus',
   'retrospective', 'skills-list',


### PR DESCRIPTION
## Summary
- Fix stale doc comments in profiles.ts (header said 7/13, actual 6/12)
- Remove stale morpheus "kept in lab" reference (morpheus is now zombie)
- Fix package.json bugs.url + homepage pointing to old repo name (missing `arra-` prefix)
- Add zombie ∩ minimal/minimal_only overlap test (catch accidental zombie-revival)

## Found by
Scout agent during `/team-agents` brainstorm scan — 0 critical, 4 medium findings addressed.

## Test plan
- [x] `bun test` — 267 pass, 0 fail, 1463 expects (+56 new from overlap test)

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle