### PR TITLE
release: v26.5.14 stable (alpha.1617 → main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.1154 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.1154 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14-alpha.1154 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14-alpha.1154 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.1617 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14-alpha.1154 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.1617 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -74,9 +74,13 @@ describe("profiles", () => {
   it("no overlap between ZOMBIE_SKILLS and other tiers", () => {
     const standardSet = new Set(STANDARD_SKILLS);
     const labSet = new Set(LAB_SKILLS);
+    const minimalSet = new Set<string>(MINIMAL_SKILLS);
+    const minimalOnlySet = new Set<string>(MINIMAL_ONLY_SKILLS);
     for (const skill of ZOMBIE_SKILLS) {
       expect(standardSet.has(skill)).toBe(false);
       expect(labSet.has(skill)).toBe(false);
+      expect(minimalSet.has(skill)).toBe(false);
+      expect(minimalOnlySet.has(skill)).toBe(false);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "url": "git+https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli.git"
   },
   "bugs": {
-    "url": "https://github.com/Soul-Brews-Studio/oracle-skills-cli/issues"
+    "url": "https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli/issues"
   },
-  "homepage": "https://github.com/Soul-Brews-Studio/oracle-skills-cli#readme",
+  "homepage": "https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli#readme",
   "engines": {
     "node": ">=18"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14",
+  "version": "26.5.14-alpha.1154",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14-alpha.1154",
+  "version": "26.5.14-alpha.1617",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -287,6 +287,35 @@ export async function installSkills(
     }
   }
 
+  // Auto-remove minimal-only lite variants when cherry-picking their full counterparts.
+  // forward-lite is redundant when forward is installed, same for recap-lite/rrr-lite.
+  // Only triggers on -s (cherry-pick) without --profile — profile alignment handles the rest.
+  const liteToFull: Record<string, string> = {
+    'forward-lite': 'forward',
+    'recap-lite': 'recap',
+    'rrr-lite': 'rrr',
+  };
+  const isCherryPick = options.skills && options.skills.length > 0 && !options.profileExplicit;
+  if (isCherryPick) {
+    const installing = new Set(skillsToInstall.map((s) => s.name));
+    for (const agentName of targetAgents) {
+      const agent = agents[agentName as keyof typeof agents];
+      if (!agent) continue;
+      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
+      for (const [lite, full] of Object.entries(liteToFull)) {
+        // Remove lite only if: 1) its full version is being installed or already exists, 2) lite is not being installed
+        const fullInstalling = installing.has(full) || existsSync(join(skillsDir, full));
+        const liteInstalling = installing.has(lite);
+        if (fullInstalling && !liteInstalling && existsSync(join(skillsDir, lite))) {
+          if (await isOurSkill(join(skillsDir, lite))) {
+            await rm(join(skillsDir, lite), { recursive: true, force: true });
+            p.log.info(`Auto-removed ${lite} (${full} is installed — lite variant redundant)`);
+          }
+        }
+      }
+    }
+  }
+
   // Confirm installation
   if (!options.yes) {
     const agentList = targetAgents.map((a) => agents[a as keyof typeof agents]?.displayName || a).join(', ');

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,8 +1,8 @@
 /**
  * Skill profiles — 3 tiers, single source of truth.
  *
- * minimal: newcomer essentials — 7 skills (lifecycle + trace + update + upgrade)
- * standard: daily driver — 13 essential skills (data-driven, session 8+9)
+ * minimal: newcomer essentials — 6 skills (lifecycle + trace + update + upgrade)
+ * standard: daily driver — 12 essential skills (data-driven, session 8+9)
  * full: all stable skills (excludes lab-only experiments AND minimal-only lite variants)
  * lab: everything including experimental / bleeding edge (still excludes minimal-only lite variants)
  *
@@ -55,7 +55,7 @@ export const ZOMBIE_SKILLS = [
   'list-issues-pr-pulse', 'mine', 'new-issue', 'oracle-manage',
   'speak', 'what-we-done', 'whats-next', 'workon',
   // 2026-05-13 cull (#327): 13 zombies based on usage audit (3,685 sessions).
-  // Kept active by explicit user request: bampenpien (standard), feel + morpheus (lab),
+  // Kept active by explicit user request: bampenpien (standard), feel (lab),
   // fyi (lab, imported from oracle-proof-of-concept-skills), resonance (implicit-full).
   'i-believed', 'work-with', 'morpheus',
   'retrospective', 'skills-list',

--- a/src/skills/dig/SKILL.md
+++ b/src/skills/dig/SKILL.md
@@ -44,13 +44,28 @@ Output metadata includes detected timezone name and offset.
 ## Step 0: Timestamp
 
 ```bash
-date "+🕐 %H:%M %Z (%A %d %B %Y)" && ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
-for wt in "$HOME/.claude/projects/${ENCODED_PWD}"-wt*; do [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"; done
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
 ```
 
-Encodes `pwd` the same way Claude does (replace `/` and `.` with `-`, prepend `-`) to match the `.claude/projects/` directory naming (e.g. `github.com` → `github-com`). Also picks up worktree dirs (`-wt`, `-wt-1`, etc.).
+Encodes `pwd` the same way Claude does (replace `/` and `.` with `-`, prepend `-`) to match the `.claude/projects/` directory naming (e.g. `github.com` → `github-com`). Detects parent project from worktree dirs (strips `-wt-*` suffix) and includes both parent and self worktrees. The `(N)` qualifier prevents zsh crashes when no worktrees exist.
 
 **With `--all`** (all repos):
 ```bash

--- a/src/skills/recap/SKILL.md
+++ b/src/skills/recap/SKILL.md
@@ -76,6 +76,22 @@ ORACLE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
+
 python3 ~/.claude/skills/dig/scripts/dig.py 1
 ```
 

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -228,7 +228,21 @@ Discover project dirs using full-path encoding (same as Claude's `.claude/projec
 ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
-for wt in "${PROJECT_BASE}"-wt*; do [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"; done
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
 ```
 
 Then run dig.py to get session JSON:

--- a/src/skills/trace/SKILL.md
+++ b/src/skills/trace/SKILL.md
@@ -208,7 +208,21 @@ Run the dig script to get all sessions:
 ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
 export PROJECT_DIRS="$PROJECT_BASE"
-for wt in "${PROJECT_BASE}"-wt*; do [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"; done
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan (both parent and self)
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
 
 python3 ~/.claude/skills/dig/scripts/dig.py 0
 


### PR DESCRIPTION
## Summary
Promote alpha.1617 to main (stable release).

### Changes since last stable (v26.5.14)
- #368: auto-remove lite variants when full counterpart installed
- #370: fix(#351) worktree detection + nullglob crash (dig, recap, trace, rrr)
- #371: fix stale comments, wrong URLs, missing zombie overlap tests
- #373: release alpha.1617

## Test plan
- [x] All CI checks pass on alpha
- [x] 267 tests, 1463 expects, 0 failures

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle