### PR TITLE
feat: beta release channel + /release-alpha + /release-beta skills

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -17,7 +17,7 @@ name: CalVer Release
 
 on:
   push:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
     paths:
       - package.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
   pull_request:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
 
 jobs:
   test:

--- a/.github/workflows/skill-convention.yml
+++ b/.github/workflows/skill-convention.yml
@@ -5,7 +5,7 @@ on:
       - 'src/skills/**/*.md'
       - 'scripts/check_skill_convention.sh'
   push:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
     paths:
       - 'src/skills/**/*.md'
       - 'scripts/check_skill_convention.sh'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-36 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+38 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -64,7 +64,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>36 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>38 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -95,17 +95,19 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 23 | **incubate** | skill | Clone or create repos for active development |
 | 24 | **mailbox** | skill | 'Persistent agent mailbox |
 | 25 | **recap-lite** | skill | Quick session orientation |
-| 26 | **resonance** | skill | Capture a resonance moment |
-| 27 | **rrr-lite** | skill | Quick session retrospective |
-| 28 | **standup** | skill | Daily standup check |
-| 29 | **talk-to** | skill | Talk to another Oracle agent |
-| 30 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 31 | **trace** | skill | Find projects, code |
-| 32 | **watch** | skill | 'Extract YouTube video transcripts |
-| 33 | **where-we-are** | skill | Session awareness |
-| 34 | **who-are-you** | skill | Know ourselves |
-| 35 | **worktree** | skill | 'Work in an isolated git worktree |
-| 36 | **xray** | skill | X-ray deep scan |
+| 26 | **release-alpha** | skill | "Cut an alpha pre-release |
+| 27 | **release-beta** | skill | "Cut a beta pre-release |
+| 28 | **resonance** | skill | Capture a resonance moment |
+| 29 | **rrr-lite** | skill | Quick session retrospective |
+| 30 | **standup** | skill | Daily standup check |
+| 31 | **talk-to** | skill | Talk to another Oracle agent |
+| 32 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 33 | **trace** | skill | Find projects, code |
+| 34 | **watch** | skill | 'Extract YouTube video transcripts |
+| 35 | **where-we-are** | skill | Session awareness |
+| 36 | **who-are-you** | skill | Know ourselves |
+| 37 | **worktree** | skill | 'Work in an isolated git worktree |
+| 38 | **xray** | skill | X-ray deep scan |
 
 </details>
 
@@ -119,8 +121,8 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 |---------|-------|--------|
 | **minimal** | 6 | `about-oracle`, `forward-lite`, `go`, `recap-lite`, `rrr-lite`, `trace` |
 | **standard** | 12 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace` |
-| **full** | 36 | all |
-| **lab** | 36 | all |
+| **full** | 38 | all |
+| **lab** | 38 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/src/skills/release-alpha/SKILL.md
+++ b/src/skills/release-alpha/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: release-alpha
+description: "Cut an alpha pre-release — bump CalVer, PR to alpha branch, CI auto-tags + publishes to npm @alpha. Use when user says 'release alpha', 'cut alpha', '/release-alpha', or wants to publish an alpha version."
+argument-hint: ""
+---
+
+# /release-alpha
+
+Cut an alpha pre-release for the current repo.
+
+## Assumptions
+
+- Repo has `scripts/calver.ts` that supports `--check` + apply-by-default
+- Repo has an `alpha` branch on `origin`
+- `calver-release.yml` auto-tags + publishes when a version-bump commit lands on `alpha`
+- Current branch is NOT `main`, `alpha`, or `beta`
+
+## Step 0: Detect repo + verify state
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "❌ Not in a git repo"; exit 1; }
+BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
+echo "📁 $REPO_ROOT"
+echo "🌿 $BRANCH"
+```
+
+Hard checks:
+
+```bash
+[ "$BRANCH" != "main" ] || { echo "❌ On main"; exit 1; }
+[ "$BRANCH" != "alpha" ] || { echo "❌ On alpha"; exit 1; }
+[ "$BRANCH" != "beta" ] || { echo "❌ On beta"; exit 1; }
+[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ] || { echo "❌ Working tree dirty"; exit 1; }
+git -C "$REPO_ROOT" fetch origin alpha 2>/dev/null
+```
+
+## Step 1: Locate calver script
+
+```bash
+CALVER="$REPO_ROOT/scripts/calver.ts"
+[ -f "$CALVER" ] || { echo "❌ No scripts/calver.ts"; exit 1; }
+```
+
+## Step 2: Compute target
+
+```bash
+TARGET=$(TZ=Asia/Bangkok bun "$CALVER" --check 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+' | head -1)
+```
+
+## Step 3: Confirm gate
+
+Show full plan. Wait for user `y`/`yes`. Anything else → abort.
+
+## Step 4: Execute
+
+```bash
+TZ=Asia/Bangkok bun "$CALVER"
+git -C "$REPO_ROOT" add package.json
+git -C "$REPO_ROOT" commit -m "bump: $TARGET"
+git -C "$REPO_ROOT" push -u origin "$BRANCH"
+gh pr create --base alpha --title "release: $TARGET" --body "Cuts $TARGET on merge via calver-release.yml."
+```
+
+## Step 5: Output
+
+Print PR URL. Do NOT auto-merge.
+
+```
+✅ PR opened: [URL]
+📦 On merge to alpha → calver-release.yml cuts [TARGET]
+```

--- a/src/skills/release-beta/SKILL.md
+++ b/src/skills/release-beta/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: release-beta
+description: "Cut a beta pre-release — bump CalVer with --beta, PR to beta branch, CI auto-tags + publishes to npm @beta. Use when user says 'release beta', 'cut beta', '/release-beta', or wants to publish a beta version for pre-release testing."
+argument-hint: ""
+---
+
+# /release-beta
+
+Cut a beta pre-release for the current repo.
+
+Beta sits between alpha (bleeding edge) and main (stable):
+`alpha` → `beta` → `main`
+
+## Assumptions
+
+- Repo has `scripts/calver.ts` that supports `--beta` + `--check`
+- Repo has a `beta` branch on `origin`
+- `calver-release.yml` auto-tags + publishes when a version-bump commit lands on `beta`
+- Current branch is NOT `main`, `alpha`, or `beta`
+
+## Step 0: Detect repo + verify state
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "❌ Not in a git repo"; exit 1; }
+BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
+echo "📁 $REPO_ROOT"
+echo "🌿 $BRANCH"
+```
+
+Hard checks:
+
+```bash
+[ "$BRANCH" != "main" ] || { echo "❌ On main"; exit 1; }
+[ "$BRANCH" != "alpha" ] || { echo "❌ On alpha"; exit 1; }
+[ "$BRANCH" != "beta" ] || { echo "❌ On beta"; exit 1; }
+[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ] || { echo "❌ Working tree dirty"; exit 1; }
+git -C "$REPO_ROOT" fetch origin beta 2>/dev/null
+```
+
+## Step 1: Locate calver script
+
+```bash
+CALVER="$REPO_ROOT/scripts/calver.ts"
+[ -f "$CALVER" ] || { echo "❌ No scripts/calver.ts"; exit 1; }
+```
+
+## Step 2: Compute target
+
+```bash
+TARGET=$(TZ=Asia/Bangkok bun "$CALVER" --beta --check 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+' | head -1)
+```
+
+## Step 3: Confirm gate
+
+Show full plan. Wait for user `y`/`yes`. Anything else → abort.
+
+```
+## Release plan
+
+  Repo:    [REPO_ROOT]
+  Branch:  [BRANCH]
+  Target:  [TARGET]
+  PR base: beta
+
+What will happen on confirm:
+  1. bun calver.ts --beta          # writes [TARGET] to package.json
+  2. git add package.json
+  3. git commit -m "bump: [TARGET]"
+  4. git push -u origin [BRANCH]
+  5. gh pr create --base beta
+
+Proceed? [y/N]
+```
+
+## Step 4: Execute
+
+```bash
+TZ=Asia/Bangkok bun "$CALVER" --beta
+git -C "$REPO_ROOT" add package.json
+git -C "$REPO_ROOT" commit -m "bump: $TARGET"
+git -C "$REPO_ROOT" push -u origin "$BRANCH"
+gh pr create --base beta --title "release: $TARGET" --body "Cuts $TARGET on merge via calver-release.yml."
+```
+
+## Step 5: Output
+
+Print PR URL. Do NOT auto-merge.
+
+```
+✅ PR opened: [URL]
+📦 On merge to beta → calver-release.yml cuts [TARGET]
+🔍 Install: bun add arra-oracle-skills@beta
+```
+
+## Promotion flow
+
+```
+alpha (bleeding edge) → beta (pre-release testing) → main (stable)
+
+/release-alpha   → PR to alpha → npm @alpha
+/release-beta    → PR to beta  → npm @beta
+alpha → main PR  → npm @latest (stable)
+```
+
+Beta is for features that passed alpha soak and need wider testing before stable.


### PR DESCRIPTION
## Summary
- Add `beta` branch to CI, skill-convention, and calver-release workflow triggers
- Create `/release-alpha` skill (CalVer alpha cut → PR to alpha branch)
- Create `/release-beta` skill (CalVer `--beta` cut → PR to beta branch)
- Both skills are unlisted (not in any profile) — install by name:
  `arra-oracle-skills install -s release-alpha release-beta`

## Release flow
```
alpha (bleeding edge) → beta (pre-release testing) → main (stable)
```

## Test plan
- [x] `bun test` — profiles pass (skills are unlisted, no profile changes)
- [ ] Create beta branch on GitHub after merge
- [ ] Cut first beta release to verify CI pipeline

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle