### PR TITLE
fix(#372): support Codex 0.130 plugin format

### DIFF
--- a/__tests__/codex-plugin.test.ts
+++ b/__tests__/codex-plugin.test.ts
@@ -21,6 +21,7 @@ import {
   isCodexPluginMarketplace,
   getCodexMarketplaceDir,
   installCodexPluginMarketplace,
+  isCodexV2Format,
 } from "../src/cli/installer";
 import { discoverSkills } from "../src/cli/installer";
 import type { Skill } from "../src/cli/types";
@@ -105,12 +106,13 @@ describe("getCodexMarketplaceDir", () => {
 
 // ── installCodexPluginMarketplace ─────────────────────────────────────────────
 
-describe("installCodexPluginMarketplace", () => {
-  // Run the installer once and test the results
+describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
+  // Run the installer once and test the results — pin to V1 (TOML) format
   beforeAll(async () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
+      codexVersion: "0.128.0",
     });
   });
 
@@ -181,6 +183,7 @@ describe("installCodexPluginMarketplace", () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
+      codexVersion: "0.128.0",
     });
 
     const content = await readFile(CONFIG_PATH, "utf-8");
@@ -192,6 +195,97 @@ describe("installCodexPluginMarketplace", () => {
     // Count occurrences of the rrr plugin section header
     const rrrPluginCount = (content.match(/\[plugins\."rrr@arra-oracle-skills"\]/g) || []).length;
     expect(rrrPluginCount).toBe(1);
+  });
+});
+
+// ── V2 format (Codex 0.130+) ──────────────────────────────────────────────────
+
+describe("installCodexPluginMarketplace (V2 — Codex 0.130+)", () => {
+  const V2_MARKETPLACE_DIR = join(TEST_HOME, "v2-marketplace");
+  const V2_CONFIG_PATH = join(TEST_HOME, "v2-config.toml");
+
+  beforeAll(async () => {
+    await writeFile(V2_CONFIG_PATH, `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`);
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-v2", "no-shell", {
+      marketplaceDir: V2_MARKETPLACE_DIR,
+      configPath: V2_CONFIG_PATH,
+      codexVersion: "0.130.0",
+    });
+  });
+
+  it("does NOT create manifest.toml (V2 ignores it)", () => {
+    expect(existsSync(join(V2_MARKETPLACE_DIR, "manifest.toml"))).toBe(false);
+  });
+
+  it("does NOT create plugin.toml per skill (V2 uses plugin.json)", () => {
+    for (const skill of MOCK_SKILLS) {
+      const tomlPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
+      expect(existsSync(tomlPath)).toBe(false);
+    }
+  });
+
+  it("creates .codex-plugin/plugin.json per skill with correct shape", async () => {
+    for (const skill of MOCK_SKILLS) {
+      const jsonPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, ".codex-plugin", "plugin.json");
+      expect(existsSync(jsonPath)).toBe(true);
+
+      const parsed = JSON.parse(await readFile(jsonPath, "utf-8"));
+      expect(parsed.name).toBe(skill.name);
+      expect(parsed.version).toBe("26.5.0-v2");
+      expect(parsed.description).toBe(skill.description);
+      expect(parsed.skills).toBe("./skills/");
+      expect(parsed.interface.displayName).toBe(skill.name);
+      expect(parsed.interface.shortDescription).toBe(skill.description);
+      expect(parsed.interface.category).toBe("AI Assistant");
+      expect(parsed.interface.capabilities).toEqual(["Interactive", "Read"]);
+    }
+  });
+
+  it("creates skills/<name>/ subdirectory per skill (SKILL.md location)", () => {
+    for (const skill of MOCK_SKILLS) {
+      const skillsDir = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "skills", skill.name);
+      expect(existsSync(skillsDir)).toBe(true);
+    }
+  });
+
+  it("still registers skills in config.toml (V2 keeps registration step)", async () => {
+    const content = await readFile(V2_CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[marketplaces.arra-oracle-skills]`);
+    expect(content).toContain(`[plugins."rrr@arra-oracle-skills"]`);
+    expect(content).toContain(`[plugins."recap@arra-oracle-skills"]`);
+    expect(content).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
+  });
+});
+
+// ── Version detection ─────────────────────────────────────────────────────────
+
+describe("isCodexV2Format", () => {
+  it("returns true for 0.130.0", () => {
+    expect(isCodexV2Format("0.130.0")).toBe(true);
+  });
+
+  it("returns true for 0.131.5", () => {
+    expect(isCodexV2Format("0.131.5")).toBe(true);
+  });
+
+  it("returns true for 1.0.0", () => {
+    expect(isCodexV2Format("1.0.0")).toBe(true);
+  });
+
+  it("returns false for 0.128.0", () => {
+    expect(isCodexV2Format("0.128.0")).toBe(false);
+  });
+
+  it("returns false for 0.129.99", () => {
+    expect(isCodexV2Format("0.129.99")).toBe(false);
+  });
+
+  it("defaults to V2 when version is null (codex binary missing)", () => {
+    expect(isCodexV2Format(null)).toBe(true);
+  });
+
+  it("defaults to V2 for unparseable version strings", () => {
+    expect(isCodexV2Format("not-a-version")).toBe(true);
   });
 });
 
@@ -215,7 +309,7 @@ describe("installCodexPluginMarketplace (real skills)", () => {
       skills.slice(0, 3), // Use first 3 skills to keep the test fast
       "26.5.0-integ",
       "no-shell",
-      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH }
+      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH, codexVersion: "0.128.0" }
     );
   });
 

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -35,6 +35,44 @@ export function getCodexMarketplaceDir(homeDir?: string): string {
 }
 
 /**
+ * Detect the installed Codex CLI version by shelling out to `codex --version`.
+ * Returns the semver string (e.g. "0.130.0") or null if codex is not on PATH
+ * or the output cannot be parsed.
+ */
+export async function detectCodexVersion(): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(['codex', '--version'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    if (proc.exitCode !== 0) return null;
+    const match = out.match(/(\d+)\.(\d+)\.(\d+)/);
+    return match ? match[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true if the given Codex version uses the V2 plugin format
+ * (>= 0.130.0: per-plugin plugin.json + skills/<name>/SKILL.md).
+ *
+ * When version is null (codex binary missing), defaults to true so newly
+ * shipped Codex versions still get a working install.
+ */
+export function isCodexV2Format(version: string | null): boolean {
+  if (version === null) return true;
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return true;
+  const major = parseInt(match[1], 10);
+  const minor = parseInt(match[2], 10);
+  if (major > 0) return true;
+  return minor >= 130;
+}
+
+/**
  * Install skills for Codex 0.128.0+ plugin marketplace.
  *
  * Creates:
@@ -50,22 +88,26 @@ export async function installCodexPluginMarketplace(
   skills: Skill[],
   version: string,
   shellMode: ShellMode,
-  opts?: { marketplaceDir?: string; configPath?: string }
+  opts?: { marketplaceDir?: string; configPath?: string; codexVersion?: string | null }
 ): Promise<void> {
   const marketplaceDir = opts?.marketplaceDir ?? getCodexMarketplaceDir();
   const configPath = opts?.configPath ?? join(homedir(), '.codex', 'config.toml');
+  const codexVersion = opts?.codexVersion === undefined ? await detectCodexVersion() : opts.codexVersion;
+  const v2 = isCodexV2Format(codexVersion);
 
   // ── 1. Create marketplace bundle directory ─────────────────────────────────
   await mkdirp(marketplaceDir, shellMode);
 
-  // ── 2. Write marketplace manifest ─────────────────────────────────────────
-  const manifestContent = [
-    `name = "arra-oracle-skills"`,
-    `version = "${version}"`,
-    `description = "Oracle skills for Codex by Soul Brews Studio"`,
-    ``,
-  ].join('\n');
-  await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+  // ── 2. Write marketplace manifest (V1 only — Codex 0.130+ ignores it) ─────
+  if (!v2) {
+    const manifestContent = [
+      `name = "arra-oracle-skills"`,
+      `version = "${version}"`,
+      `description = "Oracle skills for Codex by Soul Brews Studio"`,
+      ``,
+    ].join('\n');
+    await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+  }
 
   // ── 3. Per-skill plugin directories ───────────────────────────────────────
   const pluginsDir = join(marketplaceDir, 'plugins');
@@ -75,27 +117,55 @@ export async function installCodexPluginMarketplace(
     const skillPluginDir = join(pluginsDir, skill.name);
     await mkdirp(skillPluginDir, shellMode);
 
-    // plugin.toml descriptor
-    const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    const pluginToml = [
-      `name = "${skill.name}"`,
-      `description = "${escapedDesc}"`,
-      `version = "${version}"`,
-      `command = "/${skill.name}"`,
-      ``,
-    ].join('\n');
-    await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
+    if (v2) {
+      // Codex 0.130+ format: .codex-plugin/plugin.json + skills/<name>/SKILL.md
+      const pluginMetaDir = join(skillPluginDir, '.codex-plugin');
+      await mkdirp(pluginMetaDir, shellMode);
+      const pluginJson = {
+        name: skill.name,
+        version,
+        description: skill.description,
+        skills: './skills/',
+        interface: {
+          displayName: skill.name,
+          shortDescription: skill.description,
+          category: 'AI Assistant',
+          capabilities: ['Interactive', 'Read'],
+        },
+      };
+      await Bun.write(join(pluginMetaDir, 'plugin.json'), JSON.stringify(pluginJson, null, 2) + '\n');
 
-    // prompt.md — skill body for Codex to execute
-    if (isCompiled()) {
-      // VFS mode: write entire skill tree (includes SKILL.md + any extras)
-      await writeSkillToDir(skill.name, skillPluginDir);
+      const skillBodyDir = join(skillPluginDir, 'skills', skill.name);
+      await mkdirp(skillBodyDir, shellMode);
+      if (isCompiled()) {
+        await writeSkillToDir(skill.name, skillBodyDir);
+      } else {
+        const skillMdPath = join(skill.path, 'SKILL.md');
+        if (existsSync(skillMdPath)) {
+          const content = await Bun.file(skillMdPath).text();
+          await Bun.write(join(skillBodyDir, 'SKILL.md'), content);
+        }
+      }
     } else {
-      // Filesystem mode: copy SKILL.md as prompt.md
-      const skillMdPath = join(skill.path, 'SKILL.md');
-      if (existsSync(skillMdPath)) {
-        const content = await Bun.file(skillMdPath).text();
-        await Bun.write(join(skillPluginDir, 'prompt.md'), content);
+      // Codex < 0.130 format: plugin.toml + prompt.md
+      const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const pluginToml = [
+        `name = "${skill.name}"`,
+        `description = "${escapedDesc}"`,
+        `version = "${version}"`,
+        `command = "/${skill.name}"`,
+        ``,
+      ].join('\n');
+      await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
+
+      if (isCompiled()) {
+        await writeSkillToDir(skill.name, skillPluginDir);
+      } else {
+        const skillMdPath = join(skill.path, 'SKILL.md');
+        if (existsSync(skillMdPath)) {
+          const content = await Bun.file(skillMdPath).text();
+          await Bun.write(join(skillPluginDir, 'prompt.md'), content);
+        }
       }
     }
   }
@@ -675,9 +745,12 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
     // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
     // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
     // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
+    // Codex 0.130+ uses a different per-plugin layout (.codex-plugin/plugin.json + skills/).
     if (agentName === 'codex' && isCodexPluginMarketplace()) {
-      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
-      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
+      const codexVersion = await detectCodexVersion();
+      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode, { codexVersion });
+      const fmt = isCodexV2Format(codexVersion) ? '0.130+' : '0.128';
+      p.log.success(`Codex plugin marketplace (${fmt}): ${getCodexMarketplaceDir()}`);
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);


### PR DESCRIPTION
## Summary
- Detect Codex CLI version and branch the per-skill plugin output between V1 (TOML, < 0.130) and V2 (`.codex-plugin/plugin.json` + `skills/<name>/SKILL.md`, >= 0.130).
- Skip `manifest.toml` for V2; Codex 0.130+ ignores it.
- Default to V2 if `codex --version` fails or returns an unparseable string — keeps future Codex versions working out of the box.

Closes #372

## Implementation
- `detectCodexVersion()` — `Bun.spawn('codex --version')`, regex-parse semver, return null on failure.
- `isCodexV2Format(version)` — true for >= 0.130, or for null/unparseable input (future-proof default).
- `installCodexPluginMarketplace()` — accepts `codexVersion?` opt for test injection; branches the per-skill write loop.
- Install gate (`installer.ts:678-684`) — calls `detectCodexVersion()` once, passes through, logs the format tag (`0.128` vs `0.130+`).

## Test plan
- [x] `bun test __tests__/codex-plugin.test.ts` — 27 pass / 0 fail (existing V1 tests pinned with `codexVersion: \"0.128.0\"`; new describe blocks for V2 layout and `isCodexV2Format` edge cases).
- [x] `bun test` — 279 pass / 0 fail / 1526 expect calls / 22 files / 6.68s. No regressions.
- [ ] Manual: run `arra install codex` against a real Codex 0.130 install and confirm the new layout loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)