### PR TITLE
fix: post-install lite cleanup on bare install + /go update

### DIFF
--- a/__tests__/install-all.test.ts
+++ b/__tests__/install-all.test.ts
@@ -7,6 +7,9 @@ import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
+// Lites auto-removed when their full counterpart is also installed (post-install cleanup)
+const AUTO_REMOVED_LITES = new Set(['forward-lite', 'recap-lite', 'rrr-lite']);
+
 const TEST_DIR = join(tmpdir(), `arra-install-all-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
@@ -55,8 +58,11 @@ describe("install all (default)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length);
+    // Lites are auto-removed post-install when full counterpart exists
+    const expectedCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    expect(installed.length).toBe(expectedCount);
     for (const skill of allSkills) {
+      if (AUTO_REMOVED_LITES.has(skill.name)) continue;
       expect(installed).toContain(skill.name);
     }
   });
@@ -87,7 +93,9 @@ describe("install all (default)", () => {
 
     const manifest = JSON.parse(await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8"));
     expect(manifest.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
-    expect(manifest.skills.length).toBe(allSkills.length);
+    // Manifest is updated post-install to reflect lite auto-removal
+    const expectedManifestCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    expect(manifest.skills.length).toBe(expectedManifestCount);
     expect(manifest.agent).toBe(TEST_AGENT);
   });
 

--- a/__tests__/install-specific.test.ts
+++ b/__tests__/install-specific.test.ts
@@ -7,6 +7,8 @@ import { agents } from "../src/cli/agents";
 import { installSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
+const AUTO_REMOVED_LITES = 3;
+
 const TEST_DIR = join(tmpdir(), `arra-install-specific-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
@@ -89,7 +91,7 @@ describe("install specific skills (--skill)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
     const allSkills = await discoverSkills();
     let installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length);
+    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
 
     // Install specific — should NOT remove others
     await installSkills([TEST_AGENT], {
@@ -100,7 +102,7 @@ describe("install specific skills (--skill)", () => {
 
     installed = await listSkillDirs(SKILLS_DIR);
     // Still has all skills (specific install is additive, not destructive)
-    expect(installed.length).toBe(allSkills.length);
+    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
   });
 
   it("manifest lists only installed skills", async () => {

--- a/__tests__/install-uninstall.test.ts
+++ b/__tests__/install-uninstall.test.ts
@@ -7,6 +7,8 @@ import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
+const AUTO_REMOVED_LITES = 3; // forward-lite, recap-lite, rrr-lite removed when full present
+
 const TEST_DIR = join(tmpdir(), `arra-uninstall-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
@@ -54,7 +56,7 @@ describe("uninstall all", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const result = await uninstallSkills([TEST_AGENT], { global: true, yes: true });
-    expect(result.removed).toBe(allSkills.length);
+    expect(result.removed).toBe(allSkills.length - AUTO_REMOVED_LITES);
 
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining.length).toBe(0);
@@ -77,7 +79,7 @@ describe("uninstall specific skills", () => {
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining).not.toContain("recap");
     expect(remaining).not.toContain("trace");
-    expect(remaining.length).toBe(allSkills.length - 2);
+    expect(remaining.length).toBe(allSkills.length - AUTO_REMOVED_LITES - 2);
   });
 });
 

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { homedir, tmpdir } from 'os';
 import { rm } from 'fs/promises';
@@ -354,33 +354,6 @@ export async function installSkills(
         }
       }
       p.log.info(`Alignment: removed ${toRemove.length} skill(s) not in '${options.profile}' profile`);
-    }
-  }
-
-  // Auto-remove minimal-only lite variants whenever their full counterpart is present.
-  // forward-lite is redundant when forward is installed, same for recap-lite/rrr-lite.
-  // Runs on ALL install paths: -s cherry-pick, --profile, bare install, /go update.
-  const liteToFull: Record<string, string> = {
-    'forward-lite': 'forward',
-    'recap-lite': 'recap',
-    'rrr-lite': 'rrr',
-  };
-  {
-    const installing = new Set(skillsToInstall.map((s) => s.name));
-    for (const agentName of targetAgents) {
-      const agent = agents[agentName as keyof typeof agents];
-      if (!agent) continue;
-      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
-      for (const [lite, full] of Object.entries(liteToFull)) {
-        const fullPresent = installing.has(full) || existsSync(join(skillsDir, full));
-        const liteBeingInstalled = installing.has(lite);
-        if (fullPresent && !liteBeingInstalled && existsSync(join(skillsDir, lite))) {
-          if (await isOurSkill(join(skillsDir, lite))) {
-            await rm(join(skillsDir, lite), { recursive: true, force: true });
-            p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
-          }
-        }
-      }
     }
   }
 
@@ -761,6 +734,39 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
   }
 
   spinner.stop(`Installed ${skillsToInstall.length} skills to ${targetAgents.length} agent(s)`);
+
+  // Post-install: auto-remove lite variants when their full counterpart is on disk.
+  // forward-lite is redundant when forward exists, same for recap-lite/rrr-lite.
+  // Only runs when NO explicit minimal profile was requested — minimal WANTS lites.
+  if (options.profile !== 'minimal') {
+    const liteToFull: Record<string, string> = {
+      'forward-lite': 'forward',
+      'recap-lite': 'recap',
+      'rrr-lite': 'rrr',
+    };
+    for (const agentName of targetAgents) {
+      const agent = agents[agentName as keyof typeof agents];
+      if (!agent) continue;
+      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
+      for (const [lite, full] of Object.entries(liteToFull)) {
+        const fullOnDisk = existsSync(join(skillsDir, full));
+        const liteOnDisk = existsSync(join(skillsDir, lite));
+        if (fullOnDisk && liteOnDisk && await isOurSkill(join(skillsDir, lite))) {
+          await rm(join(skillsDir, lite), { recursive: true, force: true });
+          p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
+          // Update manifest to reflect removal
+          const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
+          if (existsSync(manifestPath)) {
+            try {
+              const m = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+              m.skills = m.skills.filter((s: string) => s !== lite);
+              writeFileSync(manifestPath, JSON.stringify(m, null, 2));
+            } catch {}
+          }
+        }
+      }
+    }
+  }
 }
 
 export async function uninstallSkills(


### PR DESCRIPTION
## Summary
Fixes the lite auto-removal to actually work on `/go update` and bare `install -g -y`.

## Root cause (traced via /trace)
```
/go update → install -g -y (no --profile, no -s)
→ skillsToInstall = ALL skills (including lites)
→ installing.has('forward-lite') = TRUE
→ !liteBeingInstalled = FALSE ← cleanup skipped!
```

Previous fix (#382) removed the cherry-pick gate but both lite AND full were in the install list, so `liteBeingInstalled` was always true.

## Fix
Moved cleanup to POST-install phase. Checks **disk** for coexistence:
- If `forward` AND `forward-lite` both exist on disk → remove lite
- Updates manifest.json to reflect removal
- Skipped when `--profile minimal` (minimal WANTS lites)

## Test plan
- [x] `bun test` — 279 pass, 0 fail, 1517 expects
- [x] Updated 3 test files to account for lite auto-removal counts

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle