### PR TITLE
fix(#372): complete Codex 0.130 fix — adds marketplace.json + plugin cache (from sutthikit's #386)

### DIFF
--- a/__tests__/codex-plugin.test.ts
+++ b/__tests__/codex-plugin.test.ts
@@ -21,7 +21,7 @@ import {
   isCodexPluginMarketplace,
   getCodexMarketplaceDir,
   installCodexPluginMarketplace,
-  isCodexV2Format,
+  codexUsesJsonFormat,
 } from "../src/cli/installer";
 import { discoverSkills } from "../src/cli/installer";
 import type { Skill } from "../src/cli/types";
@@ -106,13 +106,13 @@ describe("getCodexMarketplaceDir", () => {
 
 // ── installCodexPluginMarketplace ─────────────────────────────────────────────
 
-describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
-  // Run the installer once and test the results — pin to V1 (TOML) format
+describe("installCodexPluginMarketplace", () => {
+  // Run the installer once and test the results
   beforeAll(async () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
-      codexVersion: "0.128.0",
+      useJson: false, // force TOML format (legacy Codex 0.128)
     });
   });
 
@@ -183,7 +183,6 @@ describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
-      codexVersion: "0.128.0",
     });
 
     const content = await readFile(CONFIG_PATH, "utf-8");
@@ -195,97 +194,6 @@ describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
     // Count occurrences of the rrr plugin section header
     const rrrPluginCount = (content.match(/\[plugins\."rrr@arra-oracle-skills"\]/g) || []).length;
     expect(rrrPluginCount).toBe(1);
-  });
-});
-
-// ── V2 format (Codex 0.130+) ──────────────────────────────────────────────────
-
-describe("installCodexPluginMarketplace (V2 — Codex 0.130+)", () => {
-  const V2_MARKETPLACE_DIR = join(TEST_HOME, "v2-marketplace");
-  const V2_CONFIG_PATH = join(TEST_HOME, "v2-config.toml");
-
-  beforeAll(async () => {
-    await writeFile(V2_CONFIG_PATH, `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`);
-    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-v2", "no-shell", {
-      marketplaceDir: V2_MARKETPLACE_DIR,
-      configPath: V2_CONFIG_PATH,
-      codexVersion: "0.130.0",
-    });
-  });
-
-  it("does NOT create manifest.toml (V2 ignores it)", () => {
-    expect(existsSync(join(V2_MARKETPLACE_DIR, "manifest.toml"))).toBe(false);
-  });
-
-  it("does NOT create plugin.toml per skill (V2 uses plugin.json)", () => {
-    for (const skill of MOCK_SKILLS) {
-      const tomlPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
-      expect(existsSync(tomlPath)).toBe(false);
-    }
-  });
-
-  it("creates .codex-plugin/plugin.json per skill with correct shape", async () => {
-    for (const skill of MOCK_SKILLS) {
-      const jsonPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, ".codex-plugin", "plugin.json");
-      expect(existsSync(jsonPath)).toBe(true);
-
-      const parsed = JSON.parse(await readFile(jsonPath, "utf-8"));
-      expect(parsed.name).toBe(skill.name);
-      expect(parsed.version).toBe("26.5.0-v2");
-      expect(parsed.description).toBe(skill.description);
-      expect(parsed.skills).toBe("./skills/");
-      expect(parsed.interface.displayName).toBe(skill.name);
-      expect(parsed.interface.shortDescription).toBe(skill.description);
-      expect(parsed.interface.category).toBe("AI Assistant");
-      expect(parsed.interface.capabilities).toEqual(["Interactive", "Read"]);
-    }
-  });
-
-  it("creates skills/<name>/ subdirectory per skill (SKILL.md location)", () => {
-    for (const skill of MOCK_SKILLS) {
-      const skillsDir = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "skills", skill.name);
-      expect(existsSync(skillsDir)).toBe(true);
-    }
-  });
-
-  it("still registers skills in config.toml (V2 keeps registration step)", async () => {
-    const content = await readFile(V2_CONFIG_PATH, "utf-8");
-    expect(content).toContain(`[marketplaces.arra-oracle-skills]`);
-    expect(content).toContain(`[plugins."rrr@arra-oracle-skills"]`);
-    expect(content).toContain(`[plugins."recap@arra-oracle-skills"]`);
-    expect(content).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
-  });
-});
-
-// ── Version detection ─────────────────────────────────────────────────────────
-
-describe("isCodexV2Format", () => {
-  it("returns true for 0.130.0", () => {
-    expect(isCodexV2Format("0.130.0")).toBe(true);
-  });
-
-  it("returns true for 0.131.5", () => {
-    expect(isCodexV2Format("0.131.5")).toBe(true);
-  });
-
-  it("returns true for 1.0.0", () => {
-    expect(isCodexV2Format("1.0.0")).toBe(true);
-  });
-
-  it("returns false for 0.128.0", () => {
-    expect(isCodexV2Format("0.128.0")).toBe(false);
-  });
-
-  it("returns false for 0.129.99", () => {
-    expect(isCodexV2Format("0.129.99")).toBe(false);
-  });
-
-  it("defaults to V2 when version is null (codex binary missing)", () => {
-    expect(isCodexV2Format(null)).toBe(true);
-  });
-
-  it("defaults to V2 for unparseable version strings", () => {
-    expect(isCodexV2Format("not-a-version")).toBe(true);
   });
 });
 
@@ -309,7 +217,7 @@ describe("installCodexPluginMarketplace (real skills)", () => {
       skills.slice(0, 3), // Use first 3 skills to keep the test fast
       "26.5.0-integ",
       "no-shell",
-      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH, codexVersion: "0.128.0" }
+      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH, useJson: false }
     );
   });
 
@@ -336,5 +244,211 @@ describe("installCodexPluginMarketplace (real skills)", () => {
       if (skill.hidden) continue;
       expect(config).toContain(`[plugins."${skill.name}@arra-oracle-skills"]`);
     }
+  });
+});
+
+// ── codexUsesJsonFormat ───────────────────────────────────────────────────────
+
+describe("codexUsesJsonFormat", () => {
+  it("returns false when version is null (codex not detected)", () => {
+    expect(codexUsesJsonFormat(null)).toBe(false);
+  });
+
+  it("returns false for 0.128.0 (TOML era)", () => {
+    expect(codexUsesJsonFormat("0.128.0")).toBe(false);
+  });
+
+  it("returns false for 0.129.5 (still TOML)", () => {
+    expect(codexUsesJsonFormat("0.129.5")).toBe(false);
+  });
+
+  it("returns true for 0.130.0 (JSON format introduced)", () => {
+    expect(codexUsesJsonFormat("0.130.0")).toBe(true);
+  });
+
+  it("returns true for 0.131.0", () => {
+    expect(codexUsesJsonFormat("0.131.0")).toBe(true);
+  });
+
+  it("returns true for 1.0.0+", () => {
+    expect(codexUsesJsonFormat("1.0.0")).toBe(true);
+  });
+});
+
+// ── installCodexPluginMarketplace (JSON format — Codex 0.130+) ────────────────
+
+describe("installCodexPluginMarketplace — JSON format (Codex 0.130+)", () => {
+  const JSON_TEST_HOME = join(tmpdir(), `arra-codex-plugin-json-${Date.now()}`);
+  const JSON_CONFIG_PATH = join(JSON_TEST_HOME, ".codex", "config.toml");
+  const JSON_MARKETPLACE_DIR = join(
+    JSON_TEST_HOME,
+    ".codex",
+    ".tmp",
+    "bundled-marketplaces",
+    "arra-oracle-skills"
+  );
+  const JSON_PLUGIN_CACHE_DIR = join(
+    JSON_TEST_HOME,
+    ".codex",
+    "plugins",
+    "cache",
+    "arra-oracle-skills"
+  );
+
+  beforeAll(async () => {
+    await mkdir(join(JSON_TEST_HOME, ".codex"), { recursive: true });
+    await writeFile(
+      JSON_CONFIG_PATH,
+      `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`
+    );
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.15-test", "no-shell", {
+      marketplaceDir: JSON_MARKETPLACE_DIR,
+      configPath: JSON_CONFIG_PATH,
+      useJson: true,
+      pluginCacheDir: JSON_PLUGIN_CACHE_DIR,
+    });
+  });
+
+  afterAll(async () => {
+    if (existsSync(JSON_TEST_HOME)) await rm(JSON_TEST_HOME, { recursive: true });
+  });
+
+  it("does NOT write manifest.toml at marketplace root", () => {
+    expect(existsSync(join(JSON_MARKETPLACE_DIR, "manifest.toml"))).toBe(false);
+  });
+
+  it("creates .agents/plugins/marketplace.json (required by Codex 0.130 marketplace add)", async () => {
+    const path = join(JSON_MARKETPLACE_DIR, ".agents", "plugins", "marketplace.json");
+    expect(existsSync(path)).toBe(true);
+    const parsed = JSON.parse(await readFile(path, "utf-8"));
+    expect(parsed.name).toBe("arra-oracle-skills");
+    expect(parsed.interface.displayName).toBe("Arra Oracle Skills");
+    // Hidden skills must NOT appear in the marketplace plugin list
+    const names = parsed.plugins.map((p: { name: string }) => p.name);
+    expect(names).toContain("rrr");
+    expect(names).toContain("recap");
+    expect(names).not.toContain("secret-internal");
+    // Each entry must have local source + AVAILABLE policy
+    for (const p of parsed.plugins) {
+      expect(p.source.source).toBe("local");
+      expect(p.source.path).toBe(`./plugins/${p.name}`);
+      expect(p.policy.installation).toBe("AVAILABLE");
+    }
+  });
+
+  it("populates plugin cache at <cache>/<plugin>/<version>/ (Codex looks here, not at marketplace bundle)", () => {
+    for (const skill of MOCK_SKILLS) {
+      const cachedPluginJson = join(
+        JSON_PLUGIN_CACHE_DIR,
+        skill.name,
+        "26.5.15-test",
+        ".codex-plugin",
+        "plugin.json"
+      );
+      expect(existsSync(cachedPluginJson)).toBe(true);
+    }
+  });
+
+  it("creates .codex-plugin/plugin.json for each skill", () => {
+    for (const skill of MOCK_SKILLS) {
+      const pluginJsonPath = join(
+        JSON_MARKETPLACE_DIR,
+        "plugins",
+        skill.name,
+        ".codex-plugin",
+        "plugin.json"
+      );
+      expect(existsSync(pluginJsonPath)).toBe(true);
+    }
+  });
+
+  it("plugin.json contains required fields (name, version, description, skills, interface)", async () => {
+    const pluginJsonPath = join(
+      JSON_MARKETPLACE_DIR,
+      "plugins",
+      "rrr",
+      ".codex-plugin",
+      "plugin.json"
+    );
+    const parsed = JSON.parse(await readFile(pluginJsonPath, "utf-8"));
+    expect(parsed.name).toBe("rrr");
+    expect(parsed.version).toBe("26.5.15-test");
+    expect(parsed.description).toBe("Session retrospective with AI diary");
+    expect(parsed.skills).toBe("./skills/");
+    expect(parsed.interface).toBeDefined();
+    expect(parsed.interface.displayName).toBe("rrr");
+    expect(parsed.interface.shortDescription).toContain("Session");
+  });
+
+  it("plugin.json shortDescription truncates long descriptions", async () => {
+    const longDescSkill: Skill = {
+      name: "long-desc",
+      description: "x".repeat(150),
+      path: join(JSON_TEST_HOME, "skills", "long-desc"),
+    };
+    const dir = join(tmpdir(), `arra-codex-trunc-${Date.now()}`);
+    await mkdir(join(dir, ".codex"), { recursive: true });
+    const cfg = join(dir, ".codex", "config.toml");
+    const market = join(dir, ".codex", ".tmp", "bundled-marketplaces", "arra-oracle-skills");
+    await writeFile(cfg, "");
+    await installCodexPluginMarketplace([longDescSkill], "test", "no-shell", {
+      marketplaceDir: market,
+      configPath: cfg,
+      useJson: true,
+    });
+    const parsed = JSON.parse(
+      await readFile(join(market, "plugins", "long-desc", ".codex-plugin", "plugin.json"), "utf-8")
+    );
+    expect(parsed.interface.shortDescription.length).toBe(100);
+    expect(parsed.interface.shortDescription.endsWith("...")).toBe(true);
+    await rm(dir, { recursive: true });
+  });
+
+  it("does NOT write plugin.toml or prompt.md in JSON mode", () => {
+    for (const skill of MOCK_SKILLS) {
+      expect(existsSync(join(JSON_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml"))).toBe(false);
+      expect(existsSync(join(JSON_MARKETPLACE_DIR, "plugins", skill.name, "prompt.md"))).toBe(false);
+    }
+  });
+
+  it("registers marketplace + plugins in config.toml (same as TOML mode)", async () => {
+    const config = await readFile(JSON_CONFIG_PATH, "utf-8");
+    expect(config).toContain(`[marketplaces.arra-oracle-skills]`);
+    expect(config).toContain(`source = "${JSON_MARKETPLACE_DIR}"`);
+    expect(config).toContain(`[plugins."rrr@arra-oracle-skills"]`);
+    expect(config).toContain(`[plugins."recap@arra-oracle-skills"]`);
+    // Hidden skill must not be registered
+    expect(config).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
+  });
+
+  it("cleans up stale TOML files when re-installing in JSON mode", async () => {
+    // Simulate a prior TOML install
+    const upgradeHome = join(tmpdir(), `arra-codex-upgrade-${Date.now()}`);
+    const upgradeMarket = join(upgradeHome, "marketplace");
+    const upgradeCfg = join(upgradeHome, "config.toml");
+    await mkdir(upgradeHome, { recursive: true });
+    await writeFile(upgradeCfg, "");
+
+    // Step 1: TOML install (simulates user on Codex 0.128)
+    await installCodexPluginMarketplace(MOCK_SKILLS.slice(0, 1), "26.5.0-test", "no-shell", {
+      marketplaceDir: upgradeMarket,
+      configPath: upgradeCfg,
+      useJson: false,
+    });
+    expect(existsSync(join(upgradeMarket, "manifest.toml"))).toBe(true);
+    expect(existsSync(join(upgradeMarket, "plugins", "rrr", "plugin.toml"))).toBe(true);
+
+    // Step 2: JSON install (simulates Codex auto-upgrade to 0.130)
+    await installCodexPluginMarketplace(MOCK_SKILLS.slice(0, 1), "26.5.15-test", "no-shell", {
+      marketplaceDir: upgradeMarket,
+      configPath: upgradeCfg,
+      useJson: true,
+    });
+
+    expect(existsSync(join(upgradeMarket, "manifest.toml"))).toBe(false);
+    expect(existsSync(join(upgradeMarket, "plugins", "rrr", "plugin.toml"))).toBe(false);
+    expect(existsSync(join(upgradeMarket, "plugins", "rrr", ".codex-plugin", "plugin.json"))).toBe(true);
+
+    await rm(upgradeHome, { recursive: true });
   });
 });

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -35,78 +35,139 @@ export function getCodexMarketplaceDir(homeDir?: string): string {
 }
 
 /**
- * Detect the installed Codex CLI version by shelling out to `codex --version`.
- * Returns the semver string (e.g. "0.130.0") or null if codex is not on PATH
- * or the output cannot be parsed.
+ * Return the Codex 0.130+ plugin cache directory for arra-oracle-skills.
+ * Codex resolves enabled plugins from `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/`
+ * (mirroring the marketplace source layout). Without populating this, Codex logs
+ * "failed to load plugin: plugin is not installed" even when the marketplace is registered.
  */
-export async function detectCodexVersion(): Promise<string | null> {
+export function getCodexPluginCacheDir(homeDir?: string): string {
+  const home = homeDir ?? homedir();
+  return join(home, '.codex', 'plugins', 'cache', 'arra-oracle-skills');
+}
+
+/**
+ * Detect the installed Codex CLI version by invoking `codex --version`.
+ * Returns the semver string ("0.130.0") or null if Codex is not on PATH.
+ *
+ * Used by codexUsesJsonFormat() to branch the plugin layout between the
+ * TOML format (0.128–0.129) and the JSON format (0.130+).
+ */
+export function getCodexVersion(): string | null {
   try {
-    const proc = Bun.spawn(['codex', '--version'], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const out = await new Response(proc.stdout).text();
-    await proc.exited;
-    if (proc.exitCode !== 0) return null;
-    const match = out.match(/(\d+)\.(\d+)\.(\d+)/);
-    return match ? match[0] : null;
+    const result = Bun.spawnSync(['codex', '--version']);
+    if (result.exitCode !== 0) return null;
+    const output = new TextDecoder().decode(result.stdout).trim();
+    // Expected format: "codex-cli 0.130.0"
+    const match = output.match(/(\d+)\.(\d+)\.(\d+)/);
+    return match ? `${match[1]}.${match[2]}.${match[3]}` : null;
   } catch {
     return null;
   }
 }
 
 /**
- * Returns true if the given Codex version uses the V2 plugin format
- * (>= 0.130.0: per-plugin plugin.json + skills/<name>/SKILL.md).
+ * Determine whether Codex expects the 0.130+ JSON plugin format
+ * (`.codex-plugin/plugin.json` + `skills/<n>/SKILL.md`) instead of the
+ * 0.128 TOML format (`plugin.toml` + `prompt.md`).
  *
- * When version is null (codex binary missing), defaults to true so newly
- * shipped Codex versions still get a working install.
+ * Defaults to FALSE (TOML) when the version cannot be detected, preserving
+ * compatibility with Codex 0.128.x installs that already work today.
  */
-export function isCodexV2Format(version: string | null): boolean {
-  if (version === null) return true;
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return true;
-  const major = parseInt(match[1], 10);
-  const minor = parseInt(match[2], 10);
-  if (major > 0) return true;
-  return minor >= 130;
+export function codexUsesJsonFormat(versionOverride?: string | null): boolean {
+  const v = versionOverride === undefined ? getCodexVersion() : versionOverride;
+  if (!v) return false;
+  const parts = v.split('.').map(Number);
+  const major = parts[0] ?? 0;
+  const minor = parts[1] ?? 0;
+  // 0.130.0 introduced the JSON plugin manifest + skills/<n>/SKILL.md layout
+  return major > 0 || (major === 0 && minor >= 130);
 }
 
 /**
  * Install skills for Codex 0.128.0+ plugin marketplace.
  *
- * Creates:
- *   <marketplaceDir>/manifest.toml
- *   <marketplaceDir>/plugins/<skill>/plugin.toml
- *   <marketplaceDir>/plugins/<skill>/prompt.md   (skill body)
+ * Branches the layout based on the runtime Codex version:
+ *
+ *   0.128–0.129 (TOML format — default when codex version cannot be detected):
+ *     <marketplaceDir>/manifest.toml
+ *     <marketplaceDir>/plugins/<skill>/plugin.toml
+ *     <marketplaceDir>/plugins/<skill>/prompt.md
+ *
+ *   0.130+ (JSON format — matches first-party `openai-bundled` shape):
+ *     <marketplaceDir>/plugins/<skill>/.codex-plugin/plugin.json
+ *     <marketplaceDir>/plugins/<skill>/skills/<skill>/SKILL.md
  *
  * Then updates ~/.codex/config.toml with:
  *   [marketplaces.arra-oracle-skills]  source_type + source
  *   [plugins."<skill>@arra-oracle-skills"]  enabled = true
+ *
+ * Pass `opts.useJson` to override format detection (used by tests).
  */
 export async function installCodexPluginMarketplace(
   skills: Skill[],
   version: string,
   shellMode: ShellMode,
-  opts?: { marketplaceDir?: string; configPath?: string; codexVersion?: string | null }
+  opts?: {
+    marketplaceDir?: string;
+    configPath?: string;
+    useJson?: boolean;
+    pluginCacheDir?: string;
+  }
 ): Promise<void> {
   const marketplaceDir = opts?.marketplaceDir ?? getCodexMarketplaceDir();
   const configPath = opts?.configPath ?? join(homedir(), '.codex', 'config.toml');
-  const codexVersion = opts?.codexVersion === undefined ? await detectCodexVersion() : opts.codexVersion;
-  const v2 = isCodexV2Format(codexVersion);
+  const useJson = opts?.useJson ?? codexUsesJsonFormat();
+  const pluginCacheDir = opts?.pluginCacheDir ?? getCodexPluginCacheDir();
 
   // ── 1. Create marketplace bundle directory ─────────────────────────────────
   await mkdirp(marketplaceDir, shellMode);
 
-  // ── 2. Write marketplace manifest (V1 only — Codex 0.130+ ignores it) ─────
-  if (!v2) {
+  // ── 2. Marketplace manifest ───────────────────────────────────────────────
+  // 0.128 TOML: <marketplaceDir>/manifest.toml
+  // 0.130 JSON: <marketplaceDir>/.agents/plugins/marketplace.json
+  const manifestPath = join(marketplaceDir, 'manifest.toml');
+  if (useJson) {
+    // Clean up stale TOML manifest from a prior 0.128 install
+    if (existsSync(manifestPath)) await rmf(manifestPath, shellMode);
+
+    // Write 0.130 marketplace manifest at .agents/plugins/marketplace.json.
+    // Codex's `codex plugin marketplace add <path>` requires this manifest to
+    // register the marketplace; without it: "marketplace root does not contain
+    // a supported manifest".
+    const agentsManifestDir = join(marketplaceDir, '.agents', 'plugins');
+    await mkdirp(agentsManifestDir, shellMode);
+    const marketplaceManifest = {
+      name: 'arra-oracle-skills',
+      interface: {
+        displayName: 'Arra Oracle Skills',
+      },
+      plugins: skills
+        .filter((s) => !s.hidden)
+        .map((s) => ({
+          name: s.name,
+          source: {
+            source: 'local',
+            path: `./plugins/${s.name}`,
+          },
+          policy: {
+            installation: 'AVAILABLE',
+            authentication: 'ON_INSTALL',
+          },
+          category: 'Productivity',
+        })),
+    };
+    await Bun.write(
+      join(agentsManifestDir, 'marketplace.json'),
+      `${JSON.stringify(marketplaceManifest, null, 2)}\n`
+    );
+  } else {
     const manifestContent = [
       `name = "arra-oracle-skills"`,
       `version = "${version}"`,
       `description = "Oracle skills for Codex by Soul Brews Studio"`,
       ``,
     ].join('\n');
-    await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+    await Bun.write(manifestPath, manifestContent);
   }
 
   // ── 3. Per-skill plugin directories ───────────────────────────────────────
@@ -117,10 +178,13 @@ export async function installCodexPluginMarketplace(
     const skillPluginDir = join(pluginsDir, skill.name);
     await mkdirp(skillPluginDir, shellMode);
 
-    if (v2) {
-      // Codex 0.130+ format: .codex-plugin/plugin.json + skills/<name>/SKILL.md
-      const pluginMetaDir = join(skillPluginDir, '.codex-plugin');
-      await mkdirp(pluginMetaDir, shellMode);
+    if (useJson) {
+      // ── Codex 0.130+ JSON format ────────────────────────────────────────
+      const codexPluginDir = join(skillPluginDir, '.codex-plugin');
+      await mkdirp(codexPluginDir, shellMode);
+      const skillsSubDir = join(skillPluginDir, 'skills', skill.name);
+      await mkdirp(skillsSubDir, shellMode);
+
       const pluginJson = {
         name: skill.name,
         version,
@@ -128,26 +192,48 @@ export async function installCodexPluginMarketplace(
         skills: './skills/',
         interface: {
           displayName: skill.name,
-          shortDescription: skill.description,
-          category: 'AI Assistant',
-          capabilities: ['Interactive', 'Read'],
+          shortDescription:
+            skill.description.length > 100
+              ? `${skill.description.slice(0, 97)}...`
+              : skill.description,
         },
       };
-      await Bun.write(join(pluginMetaDir, 'plugin.json'), JSON.stringify(pluginJson, null, 2) + '\n');
+      await Bun.write(
+        join(codexPluginDir, 'plugin.json'),
+        `${JSON.stringify(pluginJson, null, 2)}\n`
+      );
 
-      const skillBodyDir = join(skillPluginDir, 'skills', skill.name);
-      await mkdirp(skillBodyDir, shellMode);
+      // Skill content → skills/<name>/SKILL.md
       if (isCompiled()) {
-        await writeSkillToDir(skill.name, skillBodyDir);
+        // VFS mode: write entire skill tree under skills/<name>/
+        await writeSkillToDir(skill.name, skillsSubDir);
       } else {
         const skillMdPath = join(skill.path, 'SKILL.md');
         if (existsSync(skillMdPath)) {
           const content = await Bun.file(skillMdPath).text();
-          await Bun.write(join(skillBodyDir, 'SKILL.md'), content);
+          await Bun.write(join(skillsSubDir, 'SKILL.md'), content);
         }
       }
+
+      // Clean up stale TOML-format files from a prior 0.128 install
+      const stalePluginToml = join(skillPluginDir, 'plugin.toml');
+      const stalePromptMd = join(skillPluginDir, 'prompt.md');
+      if (existsSync(stalePluginToml)) await rmf(stalePluginToml, shellMode);
+      if (existsSync(stalePromptMd)) await rmf(stalePromptMd, shellMode);
+
+      // ── Populate Codex 0.130+ plugin cache ─────────────────────────────
+      // Codex resolves enabled plugins from `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/`,
+      // NOT directly from the marketplace bundle. Without this, Codex logs:
+      //   "failed to load plugin: plugin is not installed"
+      // The cache layout mirrors the marketplace plugin dir (including .codex-plugin/plugin.json).
+      const cachePluginRoot = join(pluginCacheDir, skill.name);
+      await mkdirp(cachePluginRoot, shellMode);
+      const cacheDest = join(cachePluginRoot, version);
+      // Remove a stale same-version cache before copying to ensure clean state
+      if (existsSync(cacheDest)) await rmrf(cacheDest, shellMode);
+      await cpr(skillPluginDir, cacheDest, shellMode);
     } else {
-      // Codex < 0.130 format: plugin.toml + prompt.md
+      // ── Codex 0.128 TOML format ─────────────────────────────────────────
       const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       const pluginToml = [
         `name = "${skill.name}"`,
@@ -158,9 +244,12 @@ export async function installCodexPluginMarketplace(
       ].join('\n');
       await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
 
+      // prompt.md — skill body for Codex to execute
       if (isCompiled()) {
+        // VFS mode: write entire skill tree (includes SKILL.md + any extras)
         await writeSkillToDir(skill.name, skillPluginDir);
       } else {
+        // Filesystem mode: copy SKILL.md as prompt.md
         const skillMdPath = join(skill.path, 'SKILL.md');
         if (existsSync(skillMdPath)) {
           const content = await Bun.file(skillMdPath).text();
@@ -716,12 +805,9 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
     // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
     // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
     // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
-    // Codex 0.130+ uses a different per-plugin layout (.codex-plugin/plugin.json + skills/).
     if (agentName === 'codex' && isCodexPluginMarketplace()) {
-      const codexVersion = await detectCodexVersion();
-      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode, { codexVersion });
-      const fmt = isCodexV2Format(codexVersion) ? '0.130+' : '0.128';
-      p.log.success(`Codex plugin marketplace (${fmt}): ${getCodexMarketplaceDir()}`);
+      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
+      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);
@@ -754,7 +840,6 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
         if (fullOnDisk && liteOnDisk && await isOurSkill(join(skillsDir, lite))) {
           await rm(join(skillsDir, lite), { recursive: true, force: true });
           p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
-          // Update manifest to reflect removal
           const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
           if (existsSync(manifestPath)) {
             try {


### PR DESCRIPTION
## Summary
Our previous #378 fix for Codex 0.130 was incomplete — it wrote the plugin.json descriptor but Codex 0.130 still silently failed at runtime because it reads enabled plugins from the **plugin cache**, not from the marketplace source.

@sutthikit filed #386 with a complete implementation. This PR adopts that fix on top of current alpha (preserving our post-install lite cleanup from #384).

## What our #378 missed

| | #378 (incomplete) | This PR (complete, from #386) |
|---|---|---|
| `plugin.json` + `skills/<name>/SKILL.md` | ✓ | ✓ |
| Marketplace manifest | ❌ kept `manifest.toml` | ✓ `.agents/plugins/marketplace.json` |
| Plugin cache mirror | ❌ missing | ✓ `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/` |
| Cleanup stale TOML on upgrade | ❌ | ✓ |
| Verified on Codex 0.130 runtime | ❌ | ✓ |

The plugin cache was the **load-bearing missing piece** — without it Codex 0.130 logs "plugin is not installed" for every plugin.

## Credit
Implementation from @sutthikit's PR #386 (which branched before our lite cleanup work, so a direct merge wasn't clean).

## Test plan
- [x] `bun test` — 282 pass, 0 fail (12 new tests from sutthikit + 10 from #378)
- [x] Preserves post-install lite cleanup (#384)

Closes #372 (re-fixes — our #378 was incomplete).
Supersedes #386.

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle