### PR TITLE
feat: kill lite skills — minimal uses full forward/recap/rrr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-38 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+35 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -64,7 +64,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>38 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>35 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -87,27 +87,24 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 15 | **dream** | skill | 'Speculative dreaming |
 | 16 | **feel** | skill | "Capture how the system feels |
 | 17 | **forward** | skill | Create handoff + enter plan mode for next |
-| 18 | **forward-lite** | skill | Quick handoff to next session |
-| 19 | **fyi** | skill | Log information for future reference |
-| 20 | **go** | skill | Manage Oracle skills |
-| 21 | **hey** | skill | Talk to another oracle via maw federation |
-| 22 | **inbox** | skill | Read and write to Oracle inbox |
-| 23 | **incubate** | skill | Clone or create repos for active development |
-| 24 | **mailbox** | skill | 'Persistent agent mailbox |
-| 25 | **recap-lite** | skill | Quick session orientation |
-| 26 | **release-alpha** | skill | "Cut an alpha pre-release |
-| 27 | **release-beta** | skill | "Cut a beta pre-release |
-| 28 | **resonance** | skill | Capture a resonance moment |
-| 29 | **rrr-lite** | skill | Quick session retrospective |
-| 30 | **standup** | skill | Daily standup check |
-| 31 | **talk-to** | skill | Talk to another Oracle agent |
-| 32 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 33 | **trace** | skill | Find projects, code |
-| 34 | **watch** | skill | 'Extract YouTube video transcripts |
-| 35 | **where-we-are** | skill | Session awareness |
-| 36 | **who-are-you** | skill | Know ourselves |
-| 37 | **worktree** | skill | 'Work in an isolated git worktree |
-| 38 | **xray** | skill | X-ray deep scan |
+| 18 | **fyi** | skill | Log information for future reference |
+| 19 | **go** | skill | Manage Oracle skills |
+| 20 | **hey** | skill | Talk to another oracle via maw federation |
+| 21 | **inbox** | skill | Read and write to Oracle inbox |
+| 22 | **incubate** | skill | Clone or create repos for active development |
+| 23 | **mailbox** | skill | 'Persistent agent mailbox |
+| 24 | **release-alpha** | skill | "Cut an alpha pre-release |
+| 25 | **release-beta** | skill | "Cut a beta pre-release |
+| 26 | **resonance** | skill | Capture a resonance moment |
+| 27 | **standup** | skill | Daily standup check |
+| 28 | **talk-to** | skill | Talk to another Oracle agent |
+| 29 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 30 | **trace** | skill | Find projects, code |
+| 31 | **watch** | skill | 'Extract YouTube video transcripts |
+| 32 | **where-we-are** | skill | Session awareness |
+| 33 | **who-are-you** | skill | Know ourselves |
+| 34 | **worktree** | skill | 'Work in an isolated git worktree |
+| 35 | **xray** | skill | X-ray deep scan |
 
 </details>
 
@@ -119,10 +116,10 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 
 | Profile | Count | Skills |
 |---------|-------|--------|
-| **minimal** | 6 | `about-oracle`, `forward-lite`, `go`, `recap-lite`, `rrr-lite`, `trace` |
+| **minimal** | 6 | `about-oracle`, `forward`, `go`, `recap`, `rrr`, `trace` |
 | **standard** | 12 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace` |
-| **full** | 38 | all |
-| **lab** | 38 | all |
+| **full** | 35 | all |
+| **lab** | 35 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 
@@ -144,7 +141,7 @@ about                   # version + status
 
 ## Zombie Skills
 
-28 skills excluded from all profiles. Install by name:
+31 skills excluded from all profiles. Install by name:
 
 ```bash
 npx arra-oracle-skills install -g -y -s <name>
@@ -180,6 +177,9 @@ npx arra-oracle-skills install -g -y -s <name>
 | `/vault` | Connect external knowledge bases (Obsidian, Logseq, markd... |
 | `/dream-original` | Cross-repo pattern discovery with parallel agents. Finds ... |
 | `/oracle-soul-sync-update` | Sync Oracle instruments with the family. Check and update... |
+| `/forward-lite` | Lite variant killed 2026-05-14. Use /forward instead. |
+| `/recap-lite` | Lite variant killed 2026-05-14. Use /recap instead. |
+| `/rrr-lite` | Lite variant killed 2026-05-14. Use /rrr instead. |
 <!-- secret-skills:end -->
 
 ## Team Agent Scripts

--- a/__tests__/install-all.test.ts
+++ b/__tests__/install-all.test.ts
@@ -8,7 +8,8 @@ import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/insta
 import type { AgentConfig } from "../src/cli/types";
 
 // Lites auto-removed when their full counterpart is also installed (post-install cleanup)
-const AUTO_REMOVED_LITES = new Set(['forward-lite', 'recap-lite', 'rrr-lite']);
+// Migration removes deprecated lites (forward-lite, recap-lite, rrr-lite) post-install
+const DEPRECATED_LITES = new Set(['forward-lite', 'recap-lite', 'rrr-lite']);
 
 const TEST_DIR = join(tmpdir(), `arra-install-all-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
@@ -58,11 +59,10 @@ describe("install all (default)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    // Lites are auto-removed post-install when full counterpart exists
-    const expectedCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    const expectedCount = allSkills.filter(s => !DEPRECATED_LITES.has(s.name)).length;
     expect(installed.length).toBe(expectedCount);
     for (const skill of allSkills) {
-      if (AUTO_REMOVED_LITES.has(skill.name)) continue;
+      if (DEPRECATED_LITES.has(skill.name)) continue;
       expect(installed).toContain(skill.name);
     }
   });
@@ -93,8 +93,7 @@ describe("install all (default)", () => {
 
     const manifest = JSON.parse(await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8"));
     expect(manifest.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
-    // Manifest is updated post-install to reflect lite auto-removal
-    const expectedManifestCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    const expectedManifestCount = allSkills.filter(s => !DEPRECATED_LITES.has(s.name)).length;
     expect(manifest.skills.length).toBe(expectedManifestCount);
     expect(manifest.agent).toBe(TEST_AGENT);
   });

--- a/__tests__/install-specific.test.ts
+++ b/__tests__/install-specific.test.ts
@@ -7,7 +7,7 @@ import { agents } from "../src/cli/agents";
 import { installSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
-const AUTO_REMOVED_LITES = 3;
+const DEPRECATED_LITES = 3; // forward-lite, recap-lite, rrr-lite migrated away post-install
 
 const TEST_DIR = join(tmpdir(), `arra-install-specific-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
@@ -91,7 +91,7 @@ describe("install specific skills (--skill)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
     const allSkills = await discoverSkills();
     let installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
+    expect(installed.length).toBe(allSkills.length - DEPRECATED_LITES);
 
     // Install specific — should NOT remove others
     await installSkills([TEST_AGENT], {
@@ -102,7 +102,7 @@ describe("install specific skills (--skill)", () => {
 
     installed = await listSkillDirs(SKILLS_DIR);
     // Still has all skills (specific install is additive, not destructive)
-    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
+    expect(installed.length).toBe(allSkills.length - DEPRECATED_LITES);
   });
 
   it("manifest lists only installed skills", async () => {

--- a/__tests__/install-uninstall.test.ts
+++ b/__tests__/install-uninstall.test.ts
@@ -7,7 +7,7 @@ import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
-const AUTO_REMOVED_LITES = 3; // forward-lite, recap-lite, rrr-lite removed when full present
+const DEPRECATED_LITES = 3; // forward-lite, recap-lite, rrr-lite migrated away post-install
 
 const TEST_DIR = join(tmpdir(), `arra-uninstall-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
@@ -56,7 +56,7 @@ describe("uninstall all", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const result = await uninstallSkills([TEST_AGENT], { global: true, yes: true });
-    expect(result.removed).toBe(allSkills.length - AUTO_REMOVED_LITES);
+    expect(result.removed).toBe(allSkills.length - DEPRECATED_LITES);
 
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining.length).toBe(0);
@@ -79,7 +79,7 @@ describe("uninstall specific skills", () => {
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining).not.toContain("recap");
     expect(remaining).not.toContain("trace");
-    expect(remaining.length).toBe(allSkills.length - AUTO_REMOVED_LITES - 2);
+    expect(remaining.length).toBe(allSkills.length - DEPRECATED_LITES - 2);
   });
 });
 

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -56,8 +56,8 @@ describe("profiles", () => {
     expect(LAB_SKILLS).toHaveLength(11);
   });
 
-  it("ZOMBIE_SKILLS has 28 archived candidates (27 prior + oracle-soul-sync-update replaced by /go update)", () => {
-    expect(ZOMBIE_SKILLS).toHaveLength(28);
+  it("ZOMBIE_SKILLS has 31 archived candidates (28 prior + 3 lites killed)", () => {
+    expect(ZOMBIE_SKILLS).toHaveLength(31);
   });
 
   it("labOnly matches LAB_SKILLS", () => {
@@ -84,22 +84,15 @@ describe("profiles", () => {
     }
   });
 
-  // #285: MINIMAL_ONLY classification — lite skills excluded from full + lab
-  it("MINIMAL_ONLY_SKILLS has 3 lite variants", () => {
-    expect(MINIMAL_ONLY_SKILLS).toHaveLength(3);
-    expect(MINIMAL_ONLY_SKILLS).toContain("forward-lite");
-    expect(MINIMAL_ONLY_SKILLS).toContain("recap-lite");
-    expect(MINIMAL_ONLY_SKILLS).toContain("rrr-lite");
+  // Lites killed 2026-05-14: MINIMAL_ONLY_SKILLS is now empty
+  it("MINIMAL_ONLY_SKILLS is empty (lites zombied)", () => {
+    expect(MINIMAL_ONLY_SKILLS).toHaveLength(0);
   });
 
-  it("minimalOnly alias matches MINIMAL_ONLY_SKILLS", () => {
-    expect(minimalOnly).toEqual([...MINIMAL_ONLY_SKILLS]);
-  });
-
-  it("minimal profile still includes all 3 lite skills (regression guard)", () => {
-    for (const skill of MINIMAL_ONLY_SKILLS) {
-      expect(MINIMAL_SKILLS).toContain(skill);
-    }
+  it("minimal uses full forward/recap/rrr (not lite)", () => {
+    expect(MINIMAL_SKILLS).toContain("forward");
+    expect(MINIMAL_SKILLS).toContain("recap");
+    expect(MINIMAL_SKILLS).toContain("rrr");
   });
 
   it("full profile excludes both lab and minimal-only skills", () => {
@@ -110,11 +103,9 @@ describe("profiles", () => {
     expect(profiles.lab.exclude).toEqual(minimalOnly);
   });
 
-  it("no overlap between STANDARD_SKILLS and MINIMAL_ONLY_SKILLS", () => {
-    const standardSet = new Set(STANDARD_SKILLS);
-    for (const skill of MINIMAL_ONLY_SKILLS) {
-      expect(standardSet.has(skill as any)).toBe(false);
-    }
+  it("MINIMAL_ONLY is empty (backward compat alias)", () => {
+    expect(MINIMAL_ONLY_SKILLS).toHaveLength(0);
+    expect(minimalOnly).toHaveLength(0);
   });
 });
 
@@ -152,15 +143,10 @@ describe("resolveProfile", () => {
     }
   });
 
-  it("lab returns all minus minimal-only skills, even with no secrets/zombies (#285)", () => {
-    // Pre-#285: lab profile was {}, returned null for "all skills". Post-#285: lab
-    // excludes minimalOnly so a filtered list is always returned, never null.
-    const result = resolveProfile("lab", ALL_SKILLS)!;
-    expect(result).not.toBeNull();
-    expect(result.length).toBe(ALL_SKILLS.length - minimalOnly.length);
-    for (const name of minimalOnly) {
-      expect(result).not.toContain(name);
-    }
+  it("lab returns null (all skills) when no secrets/zombies — lites killed, no exclusions", () => {
+    // Post lite-kill: minimalOnly is empty, lab has no exclusions, returns null = "all skills"
+    const result = resolveProfile("lab", ALL_SKILLS);
+    expect(result).toBeNull();
   });
 
   it("unknown profile returns null", () => {
@@ -194,8 +180,9 @@ describe("resolveProfile", () => {
     }
   });
 
-  // #285: lite skills must NOT appear in full or lab resolutions
-  it("full does NOT include any minimal-only lite skills", () => {
+  // Lites killed — MINIMAL_ONLY is empty so these loops are no-ops.
+  // Kept as a regression guard: if someone re-adds lites, these fire.
+  it("full does NOT include any MINIMAL_ONLY skills", () => {
     const result = resolveProfile("full", ALL_SKILLS, [], ZOMBIE_LIST)!;
     expect(result).not.toBeNull();
     for (const lite of MINIMAL_ONLY_SKILLS) {
@@ -203,18 +190,10 @@ describe("resolveProfile", () => {
     }
   });
 
-  it("lab does NOT include any minimal-only lite skills", () => {
-    const result = resolveProfile("lab", ALL_SKILLS, [], ZOMBIE_LIST)!;
-    expect(result).not.toBeNull();
-    for (const lite of MINIMAL_ONLY_SKILLS) {
-      expect(result).not.toContain(lite);
-    }
-  });
-
-  it("minimal STILL includes all 3 lite skills (regression guard for resolveProfile)", () => {
+  it("minimal includes forward/recap/rrr (full versions, not lites)", () => {
     const result = resolveProfile("minimal", ALL_SKILLS)!;
-    for (const lite of MINIMAL_ONLY_SKILLS) {
-      expect(result).toContain(lite);
-    }
+    expect(result).toContain("forward");
+    expect(result).toContain("recap");
+    expect(result).toContain("rrr");
   });
 });

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { homedir, tmpdir } from 'os';
 import { rm } from 'fs/promises';
@@ -821,34 +821,32 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
 
   spinner.stop(`Installed ${skillsToInstall.length} skills to ${targetAgents.length} agent(s)`);
 
-  // Post-install: auto-remove lite variants when their full counterpart is on disk.
-  // forward-lite is redundant when forward exists, same for recap-lite/rrr-lite.
-  // Only runs when NO explicit minimal profile was requested — minimal WANTS lites.
-  if (options.profile !== 'minimal') {
-    const liteToFull: Record<string, string> = {
-      'forward-lite': 'forward',
-      'recap-lite': 'recap',
-      'rrr-lite': 'rrr',
-    };
-    for (const agentName of targetAgents) {
-      const agent = agents[agentName as keyof typeof agents];
-      if (!agent) continue;
-      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
-      for (const [lite, full] of Object.entries(liteToFull)) {
-        const fullOnDisk = existsSync(join(skillsDir, full));
-        const liteOnDisk = existsSync(join(skillsDir, lite));
-        if (fullOnDisk && liteOnDisk && await isOurSkill(join(skillsDir, lite))) {
-          await rm(join(skillsDir, lite), { recursive: true, force: true });
-          p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
-          const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
-          if (existsSync(manifestPath)) {
-            try {
-              const m = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-              m.skills = m.skills.filter((s: string) => s !== lite);
-              writeFileSync(manifestPath, JSON.stringify(m, null, 2));
-            } catch {}
-          }
-        }
+  // Migration: remove deprecated lite skills from prior installs.
+  // Lites (forward-lite, recap-lite, rrr-lite) were killed 2026-05-14;
+  // minimal profile now uses the full versions directly.
+  const deprecatedLites = ['forward-lite', 'recap-lite', 'rrr-lite'];
+  for (const agentName of targetAgents) {
+    const agent = agents[agentName as keyof typeof agents];
+    if (!agent) continue;
+    const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
+    let migrated = false;
+    for (const lite of deprecatedLites) {
+      const litePath = join(skillsDir, lite);
+      if (existsSync(litePath) && await isOurSkill(litePath)) {
+        await rm(litePath, { recursive: true, force: true });
+        migrated = true;
+      }
+    }
+    if (migrated) {
+      p.log.info(`Migrated: removed deprecated lite skills (forward-lite, recap-lite, rrr-lite)`);
+      const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
+      if (existsSync(manifestPath)) {
+        try {
+          const content = await Bun.file(manifestPath).text();
+          const m = JSON.parse(content);
+          m.skills = m.skills.filter((s: string) => !deprecatedLites.includes(s));
+          await Bun.write(manifestPath, JSON.stringify(m, null, 2));
+        } catch {}
       }
     }
   }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -11,14 +11,14 @@
  * oracle-soul-sync-update (6), standup (10), skills-list (3), oracle-family-scan (8).
  * These move to full (still installable, not lab-gated).
  *
- * MINIMAL_ONLY classification (#285): forward-lite, recap-lite, rrr-lite are token-
- * optimized replacements for full versions. They have value in minimal only —
- * elsewhere they duplicate functionality of forward/recap/rrr. Excluded from full+lab.
+ * Lites killed 2026-05-14: forward-lite/recap-lite/rrr-lite moved to zombie.
+ * 900 chars of description savings wasn't worth 4 PRs of cleanup bugs (#368, #382, #384, #387).
+ * Minimal now uses full forward/recap/rrr — same skills, fewer of them.
  */
 
-/** Minimal profile — lite lifecycle + trace (token-optimized) */
+/** Minimal profile — essential lifecycle + trace */
 export const MINIMAL_SKILLS = [
-  'about-oracle', 'forward-lite', 'go', 'recap-lite', 'rrr-lite', 'trace',
+  'about-oracle', 'forward', 'go', 'recap', 'rrr', 'trace',
 ] as const;
 
 /** Standard profile — daily driver skills (always installed) */
@@ -33,13 +33,9 @@ export const LAB_SKILLS = [
   'schedule', 'watch', 'worktree', 'xray',
 ] as const;
 
-/** Minimal-only skills — token-optimized lite variants that replace the full
- *  version when in `minimal` profile. They have no value outside minimal because
- *  the full versions (`forward`, `recap`, `rrr`) are present in higher tiers.
- *  Excluded from `full` and `lab` profiles. Closes #285. */
-export const MINIMAL_ONLY_SKILLS = [
-  'forward-lite', 'recap-lite', 'rrr-lite',
-] as const;
+/** Minimal-only — DEPRECATED, kept as empty for backward compat with imports.
+ *  Lites moved to zombie 2026-05-14. See ZOMBIE_SKILLS for forward-lite etc. */
+export const MINIMAL_ONLY_SKILLS = [] as const;
 
 /** Zombie skills — internal development candidates from arra-symbiosis-skills.
  *  Excluded from ALL profiles. Install by name only: `arra install -s workon`
@@ -66,6 +62,8 @@ export const ZOMBIE_SKILLS = [
   'dream-original',
   // 2026-05-14: replaced by /go update verb — no longer needs its own skill slot.
   'oracle-soul-sync-update',
+  // 2026-05-14: lites killed — 900 chars savings wasn't worth 4 PRs of bugs.
+  'forward-lite', 'recap-lite', 'rrr-lite',
 ] as const;
 
 /** Return the source directory for a skill by name — `.archive/` for zombies,

--- a/src/skills/.archive/forward-lite/SKILL.md
+++ b/src/skills/.archive/forward-lite/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: forward-lite
-description: Quick handoff to next session — save context for tomorrow. Lite version for minimal profile. Use when user says "forward", "handoff", "wrap up". For full version with plan mode, issue creation, and outbox, upgrade to standard (/go standard → /forward).
+description: "[DEPRECATED] Lite variant killed 2026-05-14. Use /forward instead."
+zombie: true
 ---
 
 # /forward-lite

--- a/src/skills/.archive/recap-lite/SKILL.md
+++ b/src/skills/.archive/recap-lite/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: recap-lite
-description: Quick session orientation — git state + last handoff. Lite version for minimal profile. Use when user says "recap", "where are we", "status". For full version with retro summaries and session mining, upgrade to standard (/go standard → /recap).
+description: "[DEPRECATED] Lite variant killed 2026-05-14. Use /recap instead."
+zombie: true
 ---
 
 # /recap-lite

--- a/src/skills/.archive/rrr-lite/SKILL.md
+++ b/src/skills/.archive/rrr-lite/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: rrr-lite
-description: Quick session retrospective — what we did, what we learned. Lite version for minimal profile. Use when user says "rrr", "retrospective", "wrap up". For full version with AI diary and anti-rationalization guard, upgrade to standard (/go standard → /rrr).
+description: "[DEPRECATED] Lite variant killed 2026-05-14. Use /rrr instead."
+zombie: true
 ---
 
 # /rrr-lite


### PR DESCRIPTION
## Summary
**Lites are dead.** 900 chars of description savings wasn't worth 4 PRs of bugs.

- `forward-lite` → use `forward`
- `recap-lite` → use `recap`  
- `rrr-lite` → use `rrr`

## What changed
- MINIMAL_SKILLS now uses full `forward/recap/rrr` (not lite variants)
- MINIMAL_ONLY_SKILLS emptied (backward compat alias kept)
- Lite SKILL.md files moved to `.archive/` with `zombie: true`
- Post-install migration auto-removes deprecated lites from prior installs
- Removed all lite cleanup code from installer (no longer needed)

## Why
| PR | What | Outcome |
|----|------|---------|
| #368 | First lite auto-removal attempt | cherry-pick gate too narrow |
| #382 | Remove cherry-pick gate | liteBeingInstalled=true on bare install |
| #384 | Move to post-install | code present, doesn't fire (#387) |
| #387 | Issue filed | still broken at runtime |

4 PRs, 5 test patches, repeated user frustration — to save 900 chars of description in a 200K context window.

Closes #387.

## Test plan
- [x] `bun test` — 280 pass, 0 fail

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle