### PR TITLE
release: v26.5.15 stable (alpha.2328 → main)

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -17,7 +17,7 @@ name: CalVer Release
 
 on:
   push:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
     paths:
       - package.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
   pull_request:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
 
 jobs:
   test:

--- a/.github/workflows/skill-convention.yml
+++ b/.github/workflows/skill-convention.yml
@@ -5,7 +5,7 @@ on:
       - 'src/skills/**/*.md'
       - 'scripts/check_skill_convention.sh'
   push:
-    branches: [main, alpha]
+    branches: [main, alpha, beta]
     paths:
       - 'src/skills/**/*.md'
       - 'scripts/check_skill_convention.sh'

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14-alpha.1912 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2023 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14-alpha.1912 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2023 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14-alpha.2023 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14-alpha.2023 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2044 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14-alpha.2023 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2044 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-36 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+38 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -64,7 +64,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>36 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>38 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -95,17 +95,19 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 23 | **incubate** | skill | Clone or create repos for active development |
 | 24 | **mailbox** | skill | 'Persistent agent mailbox |
 | 25 | **recap-lite** | skill | Quick session orientation |
-| 26 | **resonance** | skill | Capture a resonance moment |
-| 27 | **rrr-lite** | skill | Quick session retrospective |
-| 28 | **standup** | skill | Daily standup check |
-| 29 | **talk-to** | skill | Talk to another Oracle agent |
-| 30 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 31 | **trace** | skill | Find projects, code |
-| 32 | **watch** | skill | 'Extract YouTube video transcripts |
-| 33 | **where-we-are** | skill | Session awareness |
-| 34 | **who-are-you** | skill | Know ourselves |
-| 35 | **worktree** | skill | 'Work in an isolated git worktree |
-| 36 | **xray** | skill | X-ray deep scan |
+| 26 | **release-alpha** | skill | "Cut an alpha pre-release |
+| 27 | **release-beta** | skill | "Cut a beta pre-release |
+| 28 | **resonance** | skill | Capture a resonance moment |
+| 29 | **rrr-lite** | skill | Quick session retrospective |
+| 30 | **standup** | skill | Daily standup check |
+| 31 | **talk-to** | skill | Talk to another Oracle agent |
+| 32 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 33 | **trace** | skill | Find projects, code |
+| 34 | **watch** | skill | 'Extract YouTube video transcripts |
+| 35 | **where-we-are** | skill | Session awareness |
+| 36 | **who-are-you** | skill | Know ourselves |
+| 37 | **worktree** | skill | 'Work in an isolated git worktree |
+| 38 | **xray** | skill | X-ray deep scan |
 
 </details>
 
@@ -119,8 +121,8 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 |---------|-------|--------|
 | **minimal** | 6 | `about-oracle`, `forward-lite`, `go`, `recap-lite`, `rrr-lite`, `trace` |
 | **standard** | 12 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace` |
-| **full** | 36 | all |
-| **lab** | 36 | all |
+| **full** | 38 | all |
+| **lab** | 38 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-38 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+35 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -64,7 +64,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>38 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>35 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -87,27 +87,24 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 15 | **dream** | skill | 'Speculative dreaming |
 | 16 | **feel** | skill | "Capture how the system feels |
 | 17 | **forward** | skill | Create handoff + enter plan mode for next |
-| 18 | **forward-lite** | skill | Quick handoff to next session |
-| 19 | **fyi** | skill | Log information for future reference |
-| 20 | **go** | skill | Manage Oracle skills |
-| 21 | **hey** | skill | Talk to another oracle via maw federation |
-| 22 | **inbox** | skill | Read and write to Oracle inbox |
-| 23 | **incubate** | skill | Clone or create repos for active development |
-| 24 | **mailbox** | skill | 'Persistent agent mailbox |
-| 25 | **recap-lite** | skill | Quick session orientation |
-| 26 | **release-alpha** | skill | "Cut an alpha pre-release |
-| 27 | **release-beta** | skill | "Cut a beta pre-release |
-| 28 | **resonance** | skill | Capture a resonance moment |
-| 29 | **rrr-lite** | skill | Quick session retrospective |
-| 30 | **standup** | skill | Daily standup check |
-| 31 | **talk-to** | skill | Talk to another Oracle agent |
-| 32 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 33 | **trace** | skill | Find projects, code |
-| 34 | **watch** | skill | 'Extract YouTube video transcripts |
-| 35 | **where-we-are** | skill | Session awareness |
-| 36 | **who-are-you** | skill | Know ourselves |
-| 37 | **worktree** | skill | 'Work in an isolated git worktree |
-| 38 | **xray** | skill | X-ray deep scan |
+| 18 | **fyi** | skill | Log information for future reference |
+| 19 | **go** | skill | Manage Oracle skills |
+| 20 | **hey** | skill | Talk to another oracle via maw federation |
+| 21 | **inbox** | skill | Read and write to Oracle inbox |
+| 22 | **incubate** | skill | Clone or create repos for active development |
+| 23 | **mailbox** | skill | 'Persistent agent mailbox |
+| 24 | **release-alpha** | skill | "Cut an alpha pre-release |
+| 25 | **release-beta** | skill | "Cut a beta pre-release |
+| 26 | **resonance** | skill | Capture a resonance moment |
+| 27 | **standup** | skill | Daily standup check |
+| 28 | **talk-to** | skill | Talk to another Oracle agent |
+| 29 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 30 | **trace** | skill | Find projects, code |
+| 31 | **watch** | skill | 'Extract YouTube video transcripts |
+| 32 | **where-we-are** | skill | Session awareness |
+| 33 | **who-are-you** | skill | Know ourselves |
+| 34 | **worktree** | skill | 'Work in an isolated git worktree |
+| 35 | **xray** | skill | X-ray deep scan |
 
 </details>
 
@@ -119,10 +116,10 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 
 | Profile | Count | Skills |
 |---------|-------|--------|
-| **minimal** | 6 | `about-oracle`, `forward-lite`, `go`, `recap-lite`, `rrr-lite`, `trace` |
+| **minimal** | 6 | `about-oracle`, `forward`, `go`, `recap`, `rrr`, `trace` |
 | **standard** | 12 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace` |
-| **full** | 38 | all |
-| **lab** | 38 | all |
+| **full** | 35 | all |
+| **lab** | 35 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 
@@ -144,7 +141,7 @@ about                   # version + status
 
 ## Zombie Skills
 
-28 skills excluded from all profiles. Install by name:
+31 skills excluded from all profiles. Install by name:
 
 ```bash
 npx arra-oracle-skills install -g -y -s <name>
@@ -180,6 +177,9 @@ npx arra-oracle-skills install -g -y -s <name>
 | `/vault` | Connect external knowledge bases (Obsidian, Logseq, markd... |
 | `/dream-original` | Cross-repo pattern discovery with parallel agents. Finds ... |
 | `/oracle-soul-sync-update` | Sync Oracle instruments with the family. Check and update... |
+| `/forward-lite` | Lite variant killed 2026-05-14. Use /forward instead. |
+| `/recap-lite` | Lite variant killed 2026-05-14. Use /recap instead. |
+| `/rrr-lite` | Lite variant killed 2026-05-14. Use /rrr instead. |
 <!-- secret-skills:end -->
 
 ## Team Agent Scripts

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14-alpha.1617 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.1912 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14-alpha.1617 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.1912 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14-alpha.1617 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.1912 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14-alpha.2044 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14-alpha.2044 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2125 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14-alpha.2044 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2125 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14-alpha.2125 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14-alpha.2125 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2248 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14-alpha.2125 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2248 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.14-alpha.2248 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.14-alpha.2328 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.14-alpha.2248 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2328 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.14-alpha.2248 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.14-alpha.2328 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/__tests__/codex-plugin.test.ts
+++ b/__tests__/codex-plugin.test.ts
@@ -21,7 +21,7 @@ import {
   isCodexPluginMarketplace,
   getCodexMarketplaceDir,
   installCodexPluginMarketplace,
-  isCodexV2Format,
+  codexUsesJsonFormat,
 } from "../src/cli/installer";
 import { discoverSkills } from "../src/cli/installer";
 import type { Skill } from "../src/cli/types";
@@ -106,13 +106,13 @@ describe("getCodexMarketplaceDir", () => {
 
 // ── installCodexPluginMarketplace ─────────────────────────────────────────────
 
-describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
-  // Run the installer once and test the results — pin to V1 (TOML) format
+describe("installCodexPluginMarketplace", () => {
+  // Run the installer once and test the results
   beforeAll(async () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
-      codexVersion: "0.128.0",
+      useJson: false, // force TOML format (legacy Codex 0.128)
     });
   });
 
@@ -183,7 +183,6 @@ describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
-      codexVersion: "0.128.0",
     });
 
     const content = await readFile(CONFIG_PATH, "utf-8");
@@ -195,97 +194,6 @@ describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
     // Count occurrences of the rrr plugin section header
     const rrrPluginCount = (content.match(/\[plugins\."rrr@arra-oracle-skills"\]/g) || []).length;
     expect(rrrPluginCount).toBe(1);
-  });
-});
-
-// ── V2 format (Codex 0.130+) ──────────────────────────────────────────────────
-
-describe("installCodexPluginMarketplace (V2 — Codex 0.130+)", () => {
-  const V2_MARKETPLACE_DIR = join(TEST_HOME, "v2-marketplace");
-  const V2_CONFIG_PATH = join(TEST_HOME, "v2-config.toml");
-
-  beforeAll(async () => {
-    await writeFile(V2_CONFIG_PATH, `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`);
-    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-v2", "no-shell", {
-      marketplaceDir: V2_MARKETPLACE_DIR,
-      configPath: V2_CONFIG_PATH,
-      codexVersion: "0.130.0",
-    });
-  });
-
-  it("does NOT create manifest.toml (V2 ignores it)", () => {
-    expect(existsSync(join(V2_MARKETPLACE_DIR, "manifest.toml"))).toBe(false);
-  });
-
-  it("does NOT create plugin.toml per skill (V2 uses plugin.json)", () => {
-    for (const skill of MOCK_SKILLS) {
-      const tomlPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
-      expect(existsSync(tomlPath)).toBe(false);
-    }
-  });
-
-  it("creates .codex-plugin/plugin.json per skill with correct shape", async () => {
-    for (const skill of MOCK_SKILLS) {
-      const jsonPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, ".codex-plugin", "plugin.json");
-      expect(existsSync(jsonPath)).toBe(true);
-
-      const parsed = JSON.parse(await readFile(jsonPath, "utf-8"));
-      expect(parsed.name).toBe(skill.name);
-      expect(parsed.version).toBe("26.5.0-v2");
-      expect(parsed.description).toBe(skill.description);
-      expect(parsed.skills).toBe("./skills/");
-      expect(parsed.interface.displayName).toBe(skill.name);
-      expect(parsed.interface.shortDescription).toBe(skill.description);
-      expect(parsed.interface.category).toBe("AI Assistant");
-      expect(parsed.interface.capabilities).toEqual(["Interactive", "Read"]);
-    }
-  });
-
-  it("creates skills/<name>/ subdirectory per skill (SKILL.md location)", () => {
-    for (const skill of MOCK_SKILLS) {
-      const skillsDir = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "skills", skill.name);
-      expect(existsSync(skillsDir)).toBe(true);
-    }
-  });
-
-  it("still registers skills in config.toml (V2 keeps registration step)", async () => {
-    const content = await readFile(V2_CONFIG_PATH, "utf-8");
-    expect(content).toContain(`[marketplaces.arra-oracle-skills]`);
-    expect(content).toContain(`[plugins."rrr@arra-oracle-skills"]`);
-    expect(content).toContain(`[plugins."recap@arra-oracle-skills"]`);
-    expect(content).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
-  });
-});
-
-// ── Version detection ─────────────────────────────────────────────────────────
-
-describe("isCodexV2Format", () => {
-  it("returns true for 0.130.0", () => {
-    expect(isCodexV2Format("0.130.0")).toBe(true);
-  });
-
-  it("returns true for 0.131.5", () => {
-    expect(isCodexV2Format("0.131.5")).toBe(true);
-  });
-
-  it("returns true for 1.0.0", () => {
-    expect(isCodexV2Format("1.0.0")).toBe(true);
-  });
-
-  it("returns false for 0.128.0", () => {
-    expect(isCodexV2Format("0.128.0")).toBe(false);
-  });
-
-  it("returns false for 0.129.99", () => {
-    expect(isCodexV2Format("0.129.99")).toBe(false);
-  });
-
-  it("defaults to V2 when version is null (codex binary missing)", () => {
-    expect(isCodexV2Format(null)).toBe(true);
-  });
-
-  it("defaults to V2 for unparseable version strings", () => {
-    expect(isCodexV2Format("not-a-version")).toBe(true);
   });
 });
 
@@ -309,7 +217,7 @@ describe("installCodexPluginMarketplace (real skills)", () => {
       skills.slice(0, 3), // Use first 3 skills to keep the test fast
       "26.5.0-integ",
       "no-shell",
-      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH, codexVersion: "0.128.0" }
+      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH, useJson: false }
     );
   });
 
@@ -336,5 +244,211 @@ describe("installCodexPluginMarketplace (real skills)", () => {
       if (skill.hidden) continue;
       expect(config).toContain(`[plugins."${skill.name}@arra-oracle-skills"]`);
     }
+  });
+});
+
+// ── codexUsesJsonFormat ───────────────────────────────────────────────────────
+
+describe("codexUsesJsonFormat", () => {
+  it("returns false when version is null (codex not detected)", () => {
+    expect(codexUsesJsonFormat(null)).toBe(false);
+  });
+
+  it("returns false for 0.128.0 (TOML era)", () => {
+    expect(codexUsesJsonFormat("0.128.0")).toBe(false);
+  });
+
+  it("returns false for 0.129.5 (still TOML)", () => {
+    expect(codexUsesJsonFormat("0.129.5")).toBe(false);
+  });
+
+  it("returns true for 0.130.0 (JSON format introduced)", () => {
+    expect(codexUsesJsonFormat("0.130.0")).toBe(true);
+  });
+
+  it("returns true for 0.131.0", () => {
+    expect(codexUsesJsonFormat("0.131.0")).toBe(true);
+  });
+
+  it("returns true for 1.0.0+", () => {
+    expect(codexUsesJsonFormat("1.0.0")).toBe(true);
+  });
+});
+
+// ── installCodexPluginMarketplace (JSON format — Codex 0.130+) ────────────────
+
+describe("installCodexPluginMarketplace — JSON format (Codex 0.130+)", () => {
+  const JSON_TEST_HOME = join(tmpdir(), `arra-codex-plugin-json-${Date.now()}`);
+  const JSON_CONFIG_PATH = join(JSON_TEST_HOME, ".codex", "config.toml");
+  const JSON_MARKETPLACE_DIR = join(
+    JSON_TEST_HOME,
+    ".codex",
+    ".tmp",
+    "bundled-marketplaces",
+    "arra-oracle-skills"
+  );
+  const JSON_PLUGIN_CACHE_DIR = join(
+    JSON_TEST_HOME,
+    ".codex",
+    "plugins",
+    "cache",
+    "arra-oracle-skills"
+  );
+
+  beforeAll(async () => {
+    await mkdir(join(JSON_TEST_HOME, ".codex"), { recursive: true });
+    await writeFile(
+      JSON_CONFIG_PATH,
+      `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`
+    );
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.15-test", "no-shell", {
+      marketplaceDir: JSON_MARKETPLACE_DIR,
+      configPath: JSON_CONFIG_PATH,
+      useJson: true,
+      pluginCacheDir: JSON_PLUGIN_CACHE_DIR,
+    });
+  });
+
+  afterAll(async () => {
+    if (existsSync(JSON_TEST_HOME)) await rm(JSON_TEST_HOME, { recursive: true });
+  });
+
+  it("does NOT write manifest.toml at marketplace root", () => {
+    expect(existsSync(join(JSON_MARKETPLACE_DIR, "manifest.toml"))).toBe(false);
+  });
+
+  it("creates .agents/plugins/marketplace.json (required by Codex 0.130 marketplace add)", async () => {
+    const path = join(JSON_MARKETPLACE_DIR, ".agents", "plugins", "marketplace.json");
+    expect(existsSync(path)).toBe(true);
+    const parsed = JSON.parse(await readFile(path, "utf-8"));
+    expect(parsed.name).toBe("arra-oracle-skills");
+    expect(parsed.interface.displayName).toBe("Arra Oracle Skills");
+    // Hidden skills must NOT appear in the marketplace plugin list
+    const names = parsed.plugins.map((p: { name: string }) => p.name);
+    expect(names).toContain("rrr");
+    expect(names).toContain("recap");
+    expect(names).not.toContain("secret-internal");
+    // Each entry must have local source + AVAILABLE policy
+    for (const p of parsed.plugins) {
+      expect(p.source.source).toBe("local");
+      expect(p.source.path).toBe(`./plugins/${p.name}`);
+      expect(p.policy.installation).toBe("AVAILABLE");
+    }
+  });
+
+  it("populates plugin cache at <cache>/<plugin>/<version>/ (Codex looks here, not at marketplace bundle)", () => {
+    for (const skill of MOCK_SKILLS) {
+      const cachedPluginJson = join(
+        JSON_PLUGIN_CACHE_DIR,
+        skill.name,
+        "26.5.15-test",
+        ".codex-plugin",
+        "plugin.json"
+      );
+      expect(existsSync(cachedPluginJson)).toBe(true);
+    }
+  });
+
+  it("creates .codex-plugin/plugin.json for each skill", () => {
+    for (const skill of MOCK_SKILLS) {
+      const pluginJsonPath = join(
+        JSON_MARKETPLACE_DIR,
+        "plugins",
+        skill.name,
+        ".codex-plugin",
+        "plugin.json"
+      );
+      expect(existsSync(pluginJsonPath)).toBe(true);
+    }
+  });
+
+  it("plugin.json contains required fields (name, version, description, skills, interface)", async () => {
+    const pluginJsonPath = join(
+      JSON_MARKETPLACE_DIR,
+      "plugins",
+      "rrr",
+      ".codex-plugin",
+      "plugin.json"
+    );
+    const parsed = JSON.parse(await readFile(pluginJsonPath, "utf-8"));
+    expect(parsed.name).toBe("rrr");
+    expect(parsed.version).toBe("26.5.15-test");
+    expect(parsed.description).toBe("Session retrospective with AI diary");
+    expect(parsed.skills).toBe("./skills/");
+    expect(parsed.interface).toBeDefined();
+    expect(parsed.interface.displayName).toBe("rrr");
+    expect(parsed.interface.shortDescription).toContain("Session");
+  });
+
+  it("plugin.json shortDescription truncates long descriptions", async () => {
+    const longDescSkill: Skill = {
+      name: "long-desc",
+      description: "x".repeat(150),
+      path: join(JSON_TEST_HOME, "skills", "long-desc"),
+    };
+    const dir = join(tmpdir(), `arra-codex-trunc-${Date.now()}`);
+    await mkdir(join(dir, ".codex"), { recursive: true });
+    const cfg = join(dir, ".codex", "config.toml");
+    const market = join(dir, ".codex", ".tmp", "bundled-marketplaces", "arra-oracle-skills");
+    await writeFile(cfg, "");
+    await installCodexPluginMarketplace([longDescSkill], "test", "no-shell", {
+      marketplaceDir: market,
+      configPath: cfg,
+      useJson: true,
+    });
+    const parsed = JSON.parse(
+      await readFile(join(market, "plugins", "long-desc", ".codex-plugin", "plugin.json"), "utf-8")
+    );
+    expect(parsed.interface.shortDescription.length).toBe(100);
+    expect(parsed.interface.shortDescription.endsWith("...")).toBe(true);
+    await rm(dir, { recursive: true });
+  });
+
+  it("does NOT write plugin.toml or prompt.md in JSON mode", () => {
+    for (const skill of MOCK_SKILLS) {
+      expect(existsSync(join(JSON_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml"))).toBe(false);
+      expect(existsSync(join(JSON_MARKETPLACE_DIR, "plugins", skill.name, "prompt.md"))).toBe(false);
+    }
+  });
+
+  it("registers marketplace + plugins in config.toml (same as TOML mode)", async () => {
+    const config = await readFile(JSON_CONFIG_PATH, "utf-8");
+    expect(config).toContain(`[marketplaces.arra-oracle-skills]`);
+    expect(config).toContain(`source = "${JSON_MARKETPLACE_DIR}"`);
+    expect(config).toContain(`[plugins."rrr@arra-oracle-skills"]`);
+    expect(config).toContain(`[plugins."recap@arra-oracle-skills"]`);
+    // Hidden skill must not be registered
+    expect(config).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
+  });
+
+  it("cleans up stale TOML files when re-installing in JSON mode", async () => {
+    // Simulate a prior TOML install
+    const upgradeHome = join(tmpdir(), `arra-codex-upgrade-${Date.now()}`);
+    const upgradeMarket = join(upgradeHome, "marketplace");
+    const upgradeCfg = join(upgradeHome, "config.toml");
+    await mkdir(upgradeHome, { recursive: true });
+    await writeFile(upgradeCfg, "");
+
+    // Step 1: TOML install (simulates user on Codex 0.128)
+    await installCodexPluginMarketplace(MOCK_SKILLS.slice(0, 1), "26.5.0-test", "no-shell", {
+      marketplaceDir: upgradeMarket,
+      configPath: upgradeCfg,
+      useJson: false,
+    });
+    expect(existsSync(join(upgradeMarket, "manifest.toml"))).toBe(true);
+    expect(existsSync(join(upgradeMarket, "plugins", "rrr", "plugin.toml"))).toBe(true);
+
+    // Step 2: JSON install (simulates Codex auto-upgrade to 0.130)
+    await installCodexPluginMarketplace(MOCK_SKILLS.slice(0, 1), "26.5.15-test", "no-shell", {
+      marketplaceDir: upgradeMarket,
+      configPath: upgradeCfg,
+      useJson: true,
+    });
+
+    expect(existsSync(join(upgradeMarket, "manifest.toml"))).toBe(false);
+    expect(existsSync(join(upgradeMarket, "plugins", "rrr", "plugin.toml"))).toBe(false);
+    expect(existsSync(join(upgradeMarket, "plugins", "rrr", ".codex-plugin", "plugin.json"))).toBe(true);
+
+    await rm(upgradeHome, { recursive: true });
   });
 });

--- a/__tests__/codex-plugin.test.ts
+++ b/__tests__/codex-plugin.test.ts
@@ -21,6 +21,7 @@ import {
   isCodexPluginMarketplace,
   getCodexMarketplaceDir,
   installCodexPluginMarketplace,
+  isCodexV2Format,
 } from "../src/cli/installer";
 import { discoverSkills } from "../src/cli/installer";
 import type { Skill } from "../src/cli/types";
@@ -105,12 +106,13 @@ describe("getCodexMarketplaceDir", () => {
 
 // ── installCodexPluginMarketplace ─────────────────────────────────────────────
 
-describe("installCodexPluginMarketplace", () => {
-  // Run the installer once and test the results
+describe("installCodexPluginMarketplace (V1 — Codex < 0.130)", () => {
+  // Run the installer once and test the results — pin to V1 (TOML) format
   beforeAll(async () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
+      codexVersion: "0.128.0",
     });
   });
 
@@ -181,6 +183,7 @@ describe("installCodexPluginMarketplace", () => {
     await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-test", "no-shell", {
       marketplaceDir: MARKETPLACE_DIR,
       configPath: CONFIG_PATH,
+      codexVersion: "0.128.0",
     });
 
     const content = await readFile(CONFIG_PATH, "utf-8");
@@ -192,6 +195,97 @@ describe("installCodexPluginMarketplace", () => {
     // Count occurrences of the rrr plugin section header
     const rrrPluginCount = (content.match(/\[plugins\."rrr@arra-oracle-skills"\]/g) || []).length;
     expect(rrrPluginCount).toBe(1);
+  });
+});
+
+// ── V2 format (Codex 0.130+) ──────────────────────────────────────────────────
+
+describe("installCodexPluginMarketplace (V2 — Codex 0.130+)", () => {
+  const V2_MARKETPLACE_DIR = join(TEST_HOME, "v2-marketplace");
+  const V2_CONFIG_PATH = join(TEST_HOME, "v2-config.toml");
+
+  beforeAll(async () => {
+    await writeFile(V2_CONFIG_PATH, `[marketplaces.openai-bundled]\nsource_type = "bundled"\n`);
+    await installCodexPluginMarketplace(MOCK_SKILLS, "26.5.0-v2", "no-shell", {
+      marketplaceDir: V2_MARKETPLACE_DIR,
+      configPath: V2_CONFIG_PATH,
+      codexVersion: "0.130.0",
+    });
+  });
+
+  it("does NOT create manifest.toml (V2 ignores it)", () => {
+    expect(existsSync(join(V2_MARKETPLACE_DIR, "manifest.toml"))).toBe(false);
+  });
+
+  it("does NOT create plugin.toml per skill (V2 uses plugin.json)", () => {
+    for (const skill of MOCK_SKILLS) {
+      const tomlPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "plugin.toml");
+      expect(existsSync(tomlPath)).toBe(false);
+    }
+  });
+
+  it("creates .codex-plugin/plugin.json per skill with correct shape", async () => {
+    for (const skill of MOCK_SKILLS) {
+      const jsonPath = join(V2_MARKETPLACE_DIR, "plugins", skill.name, ".codex-plugin", "plugin.json");
+      expect(existsSync(jsonPath)).toBe(true);
+
+      const parsed = JSON.parse(await readFile(jsonPath, "utf-8"));
+      expect(parsed.name).toBe(skill.name);
+      expect(parsed.version).toBe("26.5.0-v2");
+      expect(parsed.description).toBe(skill.description);
+      expect(parsed.skills).toBe("./skills/");
+      expect(parsed.interface.displayName).toBe(skill.name);
+      expect(parsed.interface.shortDescription).toBe(skill.description);
+      expect(parsed.interface.category).toBe("AI Assistant");
+      expect(parsed.interface.capabilities).toEqual(["Interactive", "Read"]);
+    }
+  });
+
+  it("creates skills/<name>/ subdirectory per skill (SKILL.md location)", () => {
+    for (const skill of MOCK_SKILLS) {
+      const skillsDir = join(V2_MARKETPLACE_DIR, "plugins", skill.name, "skills", skill.name);
+      expect(existsSync(skillsDir)).toBe(true);
+    }
+  });
+
+  it("still registers skills in config.toml (V2 keeps registration step)", async () => {
+    const content = await readFile(V2_CONFIG_PATH, "utf-8");
+    expect(content).toContain(`[marketplaces.arra-oracle-skills]`);
+    expect(content).toContain(`[plugins."rrr@arra-oracle-skills"]`);
+    expect(content).toContain(`[plugins."recap@arra-oracle-skills"]`);
+    expect(content).not.toContain(`[plugins."secret-internal@arra-oracle-skills"]`);
+  });
+});
+
+// ── Version detection ─────────────────────────────────────────────────────────
+
+describe("isCodexV2Format", () => {
+  it("returns true for 0.130.0", () => {
+    expect(isCodexV2Format("0.130.0")).toBe(true);
+  });
+
+  it("returns true for 0.131.5", () => {
+    expect(isCodexV2Format("0.131.5")).toBe(true);
+  });
+
+  it("returns true for 1.0.0", () => {
+    expect(isCodexV2Format("1.0.0")).toBe(true);
+  });
+
+  it("returns false for 0.128.0", () => {
+    expect(isCodexV2Format("0.128.0")).toBe(false);
+  });
+
+  it("returns false for 0.129.99", () => {
+    expect(isCodexV2Format("0.129.99")).toBe(false);
+  });
+
+  it("defaults to V2 when version is null (codex binary missing)", () => {
+    expect(isCodexV2Format(null)).toBe(true);
+  });
+
+  it("defaults to V2 for unparseable version strings", () => {
+    expect(isCodexV2Format("not-a-version")).toBe(true);
   });
 });
 
@@ -215,7 +309,7 @@ describe("installCodexPluginMarketplace (real skills)", () => {
       skills.slice(0, 3), // Use first 3 skills to keep the test fast
       "26.5.0-integ",
       "no-shell",
-      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH }
+      { marketplaceDir: REAL_MARKETPLACE_DIR, configPath: REAL_CONFIG_PATH, codexVersion: "0.128.0" }
     );
   });
 

--- a/__tests__/install-all.test.ts
+++ b/__tests__/install-all.test.ts
@@ -7,6 +7,9 @@ import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
+// Lites auto-removed when their full counterpart is also installed (post-install cleanup)
+const AUTO_REMOVED_LITES = new Set(['forward-lite', 'recap-lite', 'rrr-lite']);
+
 const TEST_DIR = join(tmpdir(), `arra-install-all-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
@@ -55,8 +58,11 @@ describe("install all (default)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length);
+    // Lites are auto-removed post-install when full counterpart exists
+    const expectedCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    expect(installed.length).toBe(expectedCount);
     for (const skill of allSkills) {
+      if (AUTO_REMOVED_LITES.has(skill.name)) continue;
       expect(installed).toContain(skill.name);
     }
   });
@@ -87,7 +93,9 @@ describe("install all (default)", () => {
 
     const manifest = JSON.parse(await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8"));
     expect(manifest.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
-    expect(manifest.skills.length).toBe(allSkills.length);
+    // Manifest is updated post-install to reflect lite auto-removal
+    const expectedManifestCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    expect(manifest.skills.length).toBe(expectedManifestCount);
     expect(manifest.agent).toBe(TEST_AGENT);
   });
 

--- a/__tests__/install-all.test.ts
+++ b/__tests__/install-all.test.ts
@@ -8,7 +8,8 @@ import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/insta
 import type { AgentConfig } from "../src/cli/types";
 
 // Lites auto-removed when their full counterpart is also installed (post-install cleanup)
-const AUTO_REMOVED_LITES = new Set(['forward-lite', 'recap-lite', 'rrr-lite']);
+// Migration removes deprecated lites (forward-lite, recap-lite, rrr-lite) post-install
+const DEPRECATED_LITES = new Set(['forward-lite', 'recap-lite', 'rrr-lite']);
 
 const TEST_DIR = join(tmpdir(), `arra-install-all-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
@@ -58,11 +59,10 @@ describe("install all (default)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const installed = await listSkillDirs(SKILLS_DIR);
-    // Lites are auto-removed post-install when full counterpart exists
-    const expectedCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    const expectedCount = allSkills.filter(s => !DEPRECATED_LITES.has(s.name)).length;
     expect(installed.length).toBe(expectedCount);
     for (const skill of allSkills) {
-      if (AUTO_REMOVED_LITES.has(skill.name)) continue;
+      if (DEPRECATED_LITES.has(skill.name)) continue;
       expect(installed).toContain(skill.name);
     }
   });
@@ -93,8 +93,7 @@ describe("install all (default)", () => {
 
     const manifest = JSON.parse(await readFile(join(SKILLS_DIR, ".arra-oracle-skills.json"), "utf-8"));
     expect(manifest.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
-    // Manifest is updated post-install to reflect lite auto-removal
-    const expectedManifestCount = allSkills.filter(s => !AUTO_REMOVED_LITES.has(s.name)).length;
+    const expectedManifestCount = allSkills.filter(s => !DEPRECATED_LITES.has(s.name)).length;
     expect(manifest.skills.length).toBe(expectedManifestCount);
     expect(manifest.agent).toBe(TEST_AGENT);
   });

--- a/__tests__/install-specific.test.ts
+++ b/__tests__/install-specific.test.ts
@@ -7,7 +7,7 @@ import { agents } from "../src/cli/agents";
 import { installSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
-const AUTO_REMOVED_LITES = 3;
+const DEPRECATED_LITES = 3; // forward-lite, recap-lite, rrr-lite migrated away post-install
 
 const TEST_DIR = join(tmpdir(), `arra-install-specific-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
@@ -91,7 +91,7 @@ describe("install specific skills (--skill)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
     const allSkills = await discoverSkills();
     let installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
+    expect(installed.length).toBe(allSkills.length - DEPRECATED_LITES);
 
     // Install specific — should NOT remove others
     await installSkills([TEST_AGENT], {
@@ -102,7 +102,7 @@ describe("install specific skills (--skill)", () => {
 
     installed = await listSkillDirs(SKILLS_DIR);
     // Still has all skills (specific install is additive, not destructive)
-    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
+    expect(installed.length).toBe(allSkills.length - DEPRECATED_LITES);
   });
 
   it("manifest lists only installed skills", async () => {

--- a/__tests__/install-specific.test.ts
+++ b/__tests__/install-specific.test.ts
@@ -7,6 +7,8 @@ import { agents } from "../src/cli/agents";
 import { installSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
+const AUTO_REMOVED_LITES = 3;
+
 const TEST_DIR = join(tmpdir(), `arra-install-specific-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
@@ -89,7 +91,7 @@ describe("install specific skills (--skill)", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
     const allSkills = await discoverSkills();
     let installed = await listSkillDirs(SKILLS_DIR);
-    expect(installed.length).toBe(allSkills.length);
+    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
 
     // Install specific — should NOT remove others
     await installSkills([TEST_AGENT], {
@@ -100,7 +102,7 @@ describe("install specific skills (--skill)", () => {
 
     installed = await listSkillDirs(SKILLS_DIR);
     // Still has all skills (specific install is additive, not destructive)
-    expect(installed.length).toBe(allSkills.length);
+    expect(installed.length).toBe(allSkills.length - AUTO_REMOVED_LITES);
   });
 
   it("manifest lists only installed skills", async () => {

--- a/__tests__/install-uninstall.test.ts
+++ b/__tests__/install-uninstall.test.ts
@@ -7,7 +7,7 @@ import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
-const AUTO_REMOVED_LITES = 3; // forward-lite, recap-lite, rrr-lite removed when full present
+const DEPRECATED_LITES = 3; // forward-lite, recap-lite, rrr-lite migrated away post-install
 
 const TEST_DIR = join(tmpdir(), `arra-uninstall-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
@@ -56,7 +56,7 @@ describe("uninstall all", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const result = await uninstallSkills([TEST_AGENT], { global: true, yes: true });
-    expect(result.removed).toBe(allSkills.length - AUTO_REMOVED_LITES);
+    expect(result.removed).toBe(allSkills.length - DEPRECATED_LITES);
 
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining.length).toBe(0);
@@ -79,7 +79,7 @@ describe("uninstall specific skills", () => {
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining).not.toContain("recap");
     expect(remaining).not.toContain("trace");
-    expect(remaining.length).toBe(allSkills.length - AUTO_REMOVED_LITES - 2);
+    expect(remaining.length).toBe(allSkills.length - DEPRECATED_LITES - 2);
   });
 });
 

--- a/__tests__/install-uninstall.test.ts
+++ b/__tests__/install-uninstall.test.ts
@@ -7,6 +7,8 @@ import { agents } from "../src/cli/agents";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
 import type { AgentConfig } from "../src/cli/types";
 
+const AUTO_REMOVED_LITES = 3; // forward-lite, recap-lite, rrr-lite removed when full present
+
 const TEST_DIR = join(tmpdir(), `arra-uninstall-${Date.now()}`);
 const SKILLS_DIR = join(TEST_DIR, "skills");
 const COMMANDS_DIR = join(TEST_DIR, "commands");
@@ -54,7 +56,7 @@ describe("uninstall all", () => {
     await installSkills([TEST_AGENT], { global: true, yes: true });
 
     const result = await uninstallSkills([TEST_AGENT], { global: true, yes: true });
-    expect(result.removed).toBe(allSkills.length);
+    expect(result.removed).toBe(allSkills.length - AUTO_REMOVED_LITES);
 
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining.length).toBe(0);
@@ -77,7 +79,7 @@ describe("uninstall specific skills", () => {
     const remaining = await listSkillDirs(SKILLS_DIR);
     expect(remaining).not.toContain("recap");
     expect(remaining).not.toContain("trace");
-    expect(remaining.length).toBe(allSkills.length - 2);
+    expect(remaining.length).toBe(allSkills.length - AUTO_REMOVED_LITES - 2);
   });
 });
 

--- a/__tests__/profiles.test.ts
+++ b/__tests__/profiles.test.ts
@@ -56,8 +56,8 @@ describe("profiles", () => {
     expect(LAB_SKILLS).toHaveLength(11);
   });
 
-  it("ZOMBIE_SKILLS has 28 archived candidates (27 prior + oracle-soul-sync-update replaced by /go update)", () => {
-    expect(ZOMBIE_SKILLS).toHaveLength(28);
+  it("ZOMBIE_SKILLS has 31 archived candidates (28 prior + 3 lites killed)", () => {
+    expect(ZOMBIE_SKILLS).toHaveLength(31);
   });
 
   it("labOnly matches LAB_SKILLS", () => {
@@ -84,22 +84,15 @@ describe("profiles", () => {
     }
   });
 
-  // #285: MINIMAL_ONLY classification — lite skills excluded from full + lab
-  it("MINIMAL_ONLY_SKILLS has 3 lite variants", () => {
-    expect(MINIMAL_ONLY_SKILLS).toHaveLength(3);
-    expect(MINIMAL_ONLY_SKILLS).toContain("forward-lite");
-    expect(MINIMAL_ONLY_SKILLS).toContain("recap-lite");
-    expect(MINIMAL_ONLY_SKILLS).toContain("rrr-lite");
+  // Lites killed 2026-05-14: MINIMAL_ONLY_SKILLS is now empty
+  it("MINIMAL_ONLY_SKILLS is empty (lites zombied)", () => {
+    expect(MINIMAL_ONLY_SKILLS).toHaveLength(0);
   });
 
-  it("minimalOnly alias matches MINIMAL_ONLY_SKILLS", () => {
-    expect(minimalOnly).toEqual([...MINIMAL_ONLY_SKILLS]);
-  });
-
-  it("minimal profile still includes all 3 lite skills (regression guard)", () => {
-    for (const skill of MINIMAL_ONLY_SKILLS) {
-      expect(MINIMAL_SKILLS).toContain(skill);
-    }
+  it("minimal uses full forward/recap/rrr (not lite)", () => {
+    expect(MINIMAL_SKILLS).toContain("forward");
+    expect(MINIMAL_SKILLS).toContain("recap");
+    expect(MINIMAL_SKILLS).toContain("rrr");
   });
 
   it("full profile excludes both lab and minimal-only skills", () => {
@@ -110,11 +103,9 @@ describe("profiles", () => {
     expect(profiles.lab.exclude).toEqual(minimalOnly);
   });
 
-  it("no overlap between STANDARD_SKILLS and MINIMAL_ONLY_SKILLS", () => {
-    const standardSet = new Set(STANDARD_SKILLS);
-    for (const skill of MINIMAL_ONLY_SKILLS) {
-      expect(standardSet.has(skill as any)).toBe(false);
-    }
+  it("MINIMAL_ONLY is empty (backward compat alias)", () => {
+    expect(MINIMAL_ONLY_SKILLS).toHaveLength(0);
+    expect(minimalOnly).toHaveLength(0);
   });
 });
 
@@ -152,15 +143,10 @@ describe("resolveProfile", () => {
     }
   });
 
-  it("lab returns all minus minimal-only skills, even with no secrets/zombies (#285)", () => {
-    // Pre-#285: lab profile was {}, returned null for "all skills". Post-#285: lab
-    // excludes minimalOnly so a filtered list is always returned, never null.
-    const result = resolveProfile("lab", ALL_SKILLS)!;
-    expect(result).not.toBeNull();
-    expect(result.length).toBe(ALL_SKILLS.length - minimalOnly.length);
-    for (const name of minimalOnly) {
-      expect(result).not.toContain(name);
-    }
+  it("lab returns null (all skills) when no secrets/zombies — lites killed, no exclusions", () => {
+    // Post lite-kill: minimalOnly is empty, lab has no exclusions, returns null = "all skills"
+    const result = resolveProfile("lab", ALL_SKILLS);
+    expect(result).toBeNull();
   });
 
   it("unknown profile returns null", () => {
@@ -194,8 +180,9 @@ describe("resolveProfile", () => {
     }
   });
 
-  // #285: lite skills must NOT appear in full or lab resolutions
-  it("full does NOT include any minimal-only lite skills", () => {
+  // Lites killed — MINIMAL_ONLY is empty so these loops are no-ops.
+  // Kept as a regression guard: if someone re-adds lites, these fire.
+  it("full does NOT include any MINIMAL_ONLY skills", () => {
     const result = resolveProfile("full", ALL_SKILLS, [], ZOMBIE_LIST)!;
     expect(result).not.toBeNull();
     for (const lite of MINIMAL_ONLY_SKILLS) {
@@ -203,18 +190,10 @@ describe("resolveProfile", () => {
     }
   });
 
-  it("lab does NOT include any minimal-only lite skills", () => {
-    const result = resolveProfile("lab", ALL_SKILLS, [], ZOMBIE_LIST)!;
-    expect(result).not.toBeNull();
-    for (const lite of MINIMAL_ONLY_SKILLS) {
-      expect(result).not.toContain(lite);
-    }
-  });
-
-  it("minimal STILL includes all 3 lite skills (regression guard for resolveProfile)", () => {
+  it("minimal includes forward/recap/rrr (full versions, not lites)", () => {
     const result = resolveProfile("minimal", ALL_SKILLS)!;
-    for (const lite of MINIMAL_ONLY_SKILLS) {
-      expect(result).toContain(lite);
-    }
+    expect(result).toContain("forward");
+    expect(result).toContain("recap");
+    expect(result).toContain("rrr");
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14-alpha.2023",
+  "version": "26.5.14-alpha.2044",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14-alpha.1912",
+  "version": "26.5.14-alpha.2023",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14-alpha.1617",
+  "version": "26.5.14-alpha.1912",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14-alpha.2044",
+  "version": "26.5.14-alpha.2125",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14-alpha.2125",
+  "version": "26.5.14-alpha.2248",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.14-alpha.2248",
+  "version": "26.5.14-alpha.2328",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -357,29 +357,27 @@ export async function installSkills(
     }
   }
 
-  // Auto-remove minimal-only lite variants when cherry-picking their full counterparts.
+  // Auto-remove minimal-only lite variants whenever their full counterpart is present.
   // forward-lite is redundant when forward is installed, same for recap-lite/rrr-lite.
-  // Only triggers on -s (cherry-pick) without --profile — profile alignment handles the rest.
+  // Runs on ALL install paths: -s cherry-pick, --profile, bare install, /go update.
   const liteToFull: Record<string, string> = {
     'forward-lite': 'forward',
     'recap-lite': 'recap',
     'rrr-lite': 'rrr',
   };
-  const isCherryPick = options.skills && options.skills.length > 0 && !options.profileExplicit;
-  if (isCherryPick) {
+  {
     const installing = new Set(skillsToInstall.map((s) => s.name));
     for (const agentName of targetAgents) {
       const agent = agents[agentName as keyof typeof agents];
       if (!agent) continue;
       const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
       for (const [lite, full] of Object.entries(liteToFull)) {
-        // Remove lite only if: 1) its full version is being installed or already exists, 2) lite is not being installed
-        const fullInstalling = installing.has(full) || existsSync(join(skillsDir, full));
-        const liteInstalling = installing.has(lite);
-        if (fullInstalling && !liteInstalling && existsSync(join(skillsDir, lite))) {
+        const fullPresent = installing.has(full) || existsSync(join(skillsDir, full));
+        const liteBeingInstalled = installing.has(lite);
+        if (fullPresent && !liteBeingInstalled && existsSync(join(skillsDir, lite))) {
           if (await isOurSkill(join(skillsDir, lite))) {
             await rm(join(skillsDir, lite), { recursive: true, force: true });
-            p.log.info(`Auto-removed ${lite} (${full} is installed — lite variant redundant)`);
+            p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
           }
         }
       }

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { homedir, tmpdir } from 'os';
 import { rm } from 'fs/promises';
@@ -821,34 +821,32 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
 
   spinner.stop(`Installed ${skillsToInstall.length} skills to ${targetAgents.length} agent(s)`);
 
-  // Post-install: auto-remove lite variants when their full counterpart is on disk.
-  // forward-lite is redundant when forward exists, same for recap-lite/rrr-lite.
-  // Only runs when NO explicit minimal profile was requested — minimal WANTS lites.
-  if (options.profile !== 'minimal') {
-    const liteToFull: Record<string, string> = {
-      'forward-lite': 'forward',
-      'recap-lite': 'recap',
-      'rrr-lite': 'rrr',
-    };
-    for (const agentName of targetAgents) {
-      const agent = agents[agentName as keyof typeof agents];
-      if (!agent) continue;
-      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
-      for (const [lite, full] of Object.entries(liteToFull)) {
-        const fullOnDisk = existsSync(join(skillsDir, full));
-        const liteOnDisk = existsSync(join(skillsDir, lite));
-        if (fullOnDisk && liteOnDisk && await isOurSkill(join(skillsDir, lite))) {
-          await rm(join(skillsDir, lite), { recursive: true, force: true });
-          p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
-          const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
-          if (existsSync(manifestPath)) {
-            try {
-              const m = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-              m.skills = m.skills.filter((s: string) => s !== lite);
-              writeFileSync(manifestPath, JSON.stringify(m, null, 2));
-            } catch {}
-          }
-        }
+  // Migration: remove deprecated lite skills from prior installs.
+  // Lites (forward-lite, recap-lite, rrr-lite) were killed 2026-05-14;
+  // minimal profile now uses the full versions directly.
+  const deprecatedLites = ['forward-lite', 'recap-lite', 'rrr-lite'];
+  for (const agentName of targetAgents) {
+    const agent = agents[agentName as keyof typeof agents];
+    if (!agent) continue;
+    const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
+    let migrated = false;
+    for (const lite of deprecatedLites) {
+      const litePath = join(skillsDir, lite);
+      if (existsSync(litePath) && await isOurSkill(litePath)) {
+        await rm(litePath, { recursive: true, force: true });
+        migrated = true;
+      }
+    }
+    if (migrated) {
+      p.log.info(`Migrated: removed deprecated lite skills (forward-lite, recap-lite, rrr-lite)`);
+      const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
+      if (existsSync(manifestPath)) {
+        try {
+          const content = await Bun.file(manifestPath).text();
+          const m = JSON.parse(content);
+          m.skills = m.skills.filter((s: string) => !deprecatedLites.includes(s));
+          await Bun.write(manifestPath, JSON.stringify(m, null, 2));
+        } catch {}
       }
     }
   }

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { homedir, tmpdir } from 'os';
 import { rm } from 'fs/promises';
@@ -354,33 +354,6 @@ export async function installSkills(
         }
       }
       p.log.info(`Alignment: removed ${toRemove.length} skill(s) not in '${options.profile}' profile`);
-    }
-  }
-
-  // Auto-remove minimal-only lite variants whenever their full counterpart is present.
-  // forward-lite is redundant when forward is installed, same for recap-lite/rrr-lite.
-  // Runs on ALL install paths: -s cherry-pick, --profile, bare install, /go update.
-  const liteToFull: Record<string, string> = {
-    'forward-lite': 'forward',
-    'recap-lite': 'recap',
-    'rrr-lite': 'rrr',
-  };
-  {
-    const installing = new Set(skillsToInstall.map((s) => s.name));
-    for (const agentName of targetAgents) {
-      const agent = agents[agentName as keyof typeof agents];
-      if (!agent) continue;
-      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
-      for (const [lite, full] of Object.entries(liteToFull)) {
-        const fullPresent = installing.has(full) || existsSync(join(skillsDir, full));
-        const liteBeingInstalled = installing.has(lite);
-        if (fullPresent && !liteBeingInstalled && existsSync(join(skillsDir, lite))) {
-          if (await isOurSkill(join(skillsDir, lite))) {
-            await rm(join(skillsDir, lite), { recursive: true, force: true });
-            p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
-          }
-        }
-      }
     }
   }
 
@@ -761,6 +734,39 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
   }
 
   spinner.stop(`Installed ${skillsToInstall.length} skills to ${targetAgents.length} agent(s)`);
+
+  // Post-install: auto-remove lite variants when their full counterpart is on disk.
+  // forward-lite is redundant when forward exists, same for recap-lite/rrr-lite.
+  // Only runs when NO explicit minimal profile was requested — minimal WANTS lites.
+  if (options.profile !== 'minimal') {
+    const liteToFull: Record<string, string> = {
+      'forward-lite': 'forward',
+      'recap-lite': 'recap',
+      'rrr-lite': 'rrr',
+    };
+    for (const agentName of targetAgents) {
+      const agent = agents[agentName as keyof typeof agents];
+      if (!agent) continue;
+      const skillsDir = options.global ? agent.globalSkillsDir : join(process.cwd(), agent.skillsDir);
+      for (const [lite, full] of Object.entries(liteToFull)) {
+        const fullOnDisk = existsSync(join(skillsDir, full));
+        const liteOnDisk = existsSync(join(skillsDir, lite));
+        if (fullOnDisk && liteOnDisk && await isOurSkill(join(skillsDir, lite))) {
+          await rm(join(skillsDir, lite), { recursive: true, force: true });
+          p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
+          // Update manifest to reflect removal
+          const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
+          if (existsSync(manifestPath)) {
+            try {
+              const m = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+              m.skills = m.skills.filter((s: string) => s !== lite);
+              writeFileSync(manifestPath, JSON.stringify(m, null, 2));
+            } catch {}
+          }
+        }
+      }
+    }
+  }
 }
 
 export async function uninstallSkills(

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -35,78 +35,139 @@ export function getCodexMarketplaceDir(homeDir?: string): string {
 }
 
 /**
- * Detect the installed Codex CLI version by shelling out to `codex --version`.
- * Returns the semver string (e.g. "0.130.0") or null if codex is not on PATH
- * or the output cannot be parsed.
+ * Return the Codex 0.130+ plugin cache directory for arra-oracle-skills.
+ * Codex resolves enabled plugins from `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/`
+ * (mirroring the marketplace source layout). Without populating this, Codex logs
+ * "failed to load plugin: plugin is not installed" even when the marketplace is registered.
  */
-export async function detectCodexVersion(): Promise<string | null> {
+export function getCodexPluginCacheDir(homeDir?: string): string {
+  const home = homeDir ?? homedir();
+  return join(home, '.codex', 'plugins', 'cache', 'arra-oracle-skills');
+}
+
+/**
+ * Detect the installed Codex CLI version by invoking `codex --version`.
+ * Returns the semver string ("0.130.0") or null if Codex is not on PATH.
+ *
+ * Used by codexUsesJsonFormat() to branch the plugin layout between the
+ * TOML format (0.128–0.129) and the JSON format (0.130+).
+ */
+export function getCodexVersion(): string | null {
   try {
-    const proc = Bun.spawn(['codex', '--version'], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const out = await new Response(proc.stdout).text();
-    await proc.exited;
-    if (proc.exitCode !== 0) return null;
-    const match = out.match(/(\d+)\.(\d+)\.(\d+)/);
-    return match ? match[0] : null;
+    const result = Bun.spawnSync(['codex', '--version']);
+    if (result.exitCode !== 0) return null;
+    const output = new TextDecoder().decode(result.stdout).trim();
+    // Expected format: "codex-cli 0.130.0"
+    const match = output.match(/(\d+)\.(\d+)\.(\d+)/);
+    return match ? `${match[1]}.${match[2]}.${match[3]}` : null;
   } catch {
     return null;
   }
 }
 
 /**
- * Returns true if the given Codex version uses the V2 plugin format
- * (>= 0.130.0: per-plugin plugin.json + skills/<name>/SKILL.md).
+ * Determine whether Codex expects the 0.130+ JSON plugin format
+ * (`.codex-plugin/plugin.json` + `skills/<n>/SKILL.md`) instead of the
+ * 0.128 TOML format (`plugin.toml` + `prompt.md`).
  *
- * When version is null (codex binary missing), defaults to true so newly
- * shipped Codex versions still get a working install.
+ * Defaults to FALSE (TOML) when the version cannot be detected, preserving
+ * compatibility with Codex 0.128.x installs that already work today.
  */
-export function isCodexV2Format(version: string | null): boolean {
-  if (version === null) return true;
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return true;
-  const major = parseInt(match[1], 10);
-  const minor = parseInt(match[2], 10);
-  if (major > 0) return true;
-  return minor >= 130;
+export function codexUsesJsonFormat(versionOverride?: string | null): boolean {
+  const v = versionOverride === undefined ? getCodexVersion() : versionOverride;
+  if (!v) return false;
+  const parts = v.split('.').map(Number);
+  const major = parts[0] ?? 0;
+  const minor = parts[1] ?? 0;
+  // 0.130.0 introduced the JSON plugin manifest + skills/<n>/SKILL.md layout
+  return major > 0 || (major === 0 && minor >= 130);
 }
 
 /**
  * Install skills for Codex 0.128.0+ plugin marketplace.
  *
- * Creates:
- *   <marketplaceDir>/manifest.toml
- *   <marketplaceDir>/plugins/<skill>/plugin.toml
- *   <marketplaceDir>/plugins/<skill>/prompt.md   (skill body)
+ * Branches the layout based on the runtime Codex version:
+ *
+ *   0.128–0.129 (TOML format — default when codex version cannot be detected):
+ *     <marketplaceDir>/manifest.toml
+ *     <marketplaceDir>/plugins/<skill>/plugin.toml
+ *     <marketplaceDir>/plugins/<skill>/prompt.md
+ *
+ *   0.130+ (JSON format — matches first-party `openai-bundled` shape):
+ *     <marketplaceDir>/plugins/<skill>/.codex-plugin/plugin.json
+ *     <marketplaceDir>/plugins/<skill>/skills/<skill>/SKILL.md
  *
  * Then updates ~/.codex/config.toml with:
  *   [marketplaces.arra-oracle-skills]  source_type + source
  *   [plugins."<skill>@arra-oracle-skills"]  enabled = true
+ *
+ * Pass `opts.useJson` to override format detection (used by tests).
  */
 export async function installCodexPluginMarketplace(
   skills: Skill[],
   version: string,
   shellMode: ShellMode,
-  opts?: { marketplaceDir?: string; configPath?: string; codexVersion?: string | null }
+  opts?: {
+    marketplaceDir?: string;
+    configPath?: string;
+    useJson?: boolean;
+    pluginCacheDir?: string;
+  }
 ): Promise<void> {
   const marketplaceDir = opts?.marketplaceDir ?? getCodexMarketplaceDir();
   const configPath = opts?.configPath ?? join(homedir(), '.codex', 'config.toml');
-  const codexVersion = opts?.codexVersion === undefined ? await detectCodexVersion() : opts.codexVersion;
-  const v2 = isCodexV2Format(codexVersion);
+  const useJson = opts?.useJson ?? codexUsesJsonFormat();
+  const pluginCacheDir = opts?.pluginCacheDir ?? getCodexPluginCacheDir();
 
   // ── 1. Create marketplace bundle directory ─────────────────────────────────
   await mkdirp(marketplaceDir, shellMode);
 
-  // ── 2. Write marketplace manifest (V1 only — Codex 0.130+ ignores it) ─────
-  if (!v2) {
+  // ── 2. Marketplace manifest ───────────────────────────────────────────────
+  // 0.128 TOML: <marketplaceDir>/manifest.toml
+  // 0.130 JSON: <marketplaceDir>/.agents/plugins/marketplace.json
+  const manifestPath = join(marketplaceDir, 'manifest.toml');
+  if (useJson) {
+    // Clean up stale TOML manifest from a prior 0.128 install
+    if (existsSync(manifestPath)) await rmf(manifestPath, shellMode);
+
+    // Write 0.130 marketplace manifest at .agents/plugins/marketplace.json.
+    // Codex's `codex plugin marketplace add <path>` requires this manifest to
+    // register the marketplace; without it: "marketplace root does not contain
+    // a supported manifest".
+    const agentsManifestDir = join(marketplaceDir, '.agents', 'plugins');
+    await mkdirp(agentsManifestDir, shellMode);
+    const marketplaceManifest = {
+      name: 'arra-oracle-skills',
+      interface: {
+        displayName: 'Arra Oracle Skills',
+      },
+      plugins: skills
+        .filter((s) => !s.hidden)
+        .map((s) => ({
+          name: s.name,
+          source: {
+            source: 'local',
+            path: `./plugins/${s.name}`,
+          },
+          policy: {
+            installation: 'AVAILABLE',
+            authentication: 'ON_INSTALL',
+          },
+          category: 'Productivity',
+        })),
+    };
+    await Bun.write(
+      join(agentsManifestDir, 'marketplace.json'),
+      `${JSON.stringify(marketplaceManifest, null, 2)}\n`
+    );
+  } else {
     const manifestContent = [
       `name = "arra-oracle-skills"`,
       `version = "${version}"`,
       `description = "Oracle skills for Codex by Soul Brews Studio"`,
       ``,
     ].join('\n');
-    await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+    await Bun.write(manifestPath, manifestContent);
   }
 
   // ── 3. Per-skill plugin directories ───────────────────────────────────────
@@ -117,10 +178,13 @@ export async function installCodexPluginMarketplace(
     const skillPluginDir = join(pluginsDir, skill.name);
     await mkdirp(skillPluginDir, shellMode);
 
-    if (v2) {
-      // Codex 0.130+ format: .codex-plugin/plugin.json + skills/<name>/SKILL.md
-      const pluginMetaDir = join(skillPluginDir, '.codex-plugin');
-      await mkdirp(pluginMetaDir, shellMode);
+    if (useJson) {
+      // ── Codex 0.130+ JSON format ────────────────────────────────────────
+      const codexPluginDir = join(skillPluginDir, '.codex-plugin');
+      await mkdirp(codexPluginDir, shellMode);
+      const skillsSubDir = join(skillPluginDir, 'skills', skill.name);
+      await mkdirp(skillsSubDir, shellMode);
+
       const pluginJson = {
         name: skill.name,
         version,
@@ -128,26 +192,48 @@ export async function installCodexPluginMarketplace(
         skills: './skills/',
         interface: {
           displayName: skill.name,
-          shortDescription: skill.description,
-          category: 'AI Assistant',
-          capabilities: ['Interactive', 'Read'],
+          shortDescription:
+            skill.description.length > 100
+              ? `${skill.description.slice(0, 97)}...`
+              : skill.description,
         },
       };
-      await Bun.write(join(pluginMetaDir, 'plugin.json'), JSON.stringify(pluginJson, null, 2) + '\n');
+      await Bun.write(
+        join(codexPluginDir, 'plugin.json'),
+        `${JSON.stringify(pluginJson, null, 2)}\n`
+      );
 
-      const skillBodyDir = join(skillPluginDir, 'skills', skill.name);
-      await mkdirp(skillBodyDir, shellMode);
+      // Skill content → skills/<name>/SKILL.md
       if (isCompiled()) {
-        await writeSkillToDir(skill.name, skillBodyDir);
+        // VFS mode: write entire skill tree under skills/<name>/
+        await writeSkillToDir(skill.name, skillsSubDir);
       } else {
         const skillMdPath = join(skill.path, 'SKILL.md');
         if (existsSync(skillMdPath)) {
           const content = await Bun.file(skillMdPath).text();
-          await Bun.write(join(skillBodyDir, 'SKILL.md'), content);
+          await Bun.write(join(skillsSubDir, 'SKILL.md'), content);
         }
       }
+
+      // Clean up stale TOML-format files from a prior 0.128 install
+      const stalePluginToml = join(skillPluginDir, 'plugin.toml');
+      const stalePromptMd = join(skillPluginDir, 'prompt.md');
+      if (existsSync(stalePluginToml)) await rmf(stalePluginToml, shellMode);
+      if (existsSync(stalePromptMd)) await rmf(stalePromptMd, shellMode);
+
+      // ── Populate Codex 0.130+ plugin cache ─────────────────────────────
+      // Codex resolves enabled plugins from `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/`,
+      // NOT directly from the marketplace bundle. Without this, Codex logs:
+      //   "failed to load plugin: plugin is not installed"
+      // The cache layout mirrors the marketplace plugin dir (including .codex-plugin/plugin.json).
+      const cachePluginRoot = join(pluginCacheDir, skill.name);
+      await mkdirp(cachePluginRoot, shellMode);
+      const cacheDest = join(cachePluginRoot, version);
+      // Remove a stale same-version cache before copying to ensure clean state
+      if (existsSync(cacheDest)) await rmrf(cacheDest, shellMode);
+      await cpr(skillPluginDir, cacheDest, shellMode);
     } else {
-      // Codex < 0.130 format: plugin.toml + prompt.md
+      // ── Codex 0.128 TOML format ─────────────────────────────────────────
       const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       const pluginToml = [
         `name = "${skill.name}"`,
@@ -158,9 +244,12 @@ export async function installCodexPluginMarketplace(
       ].join('\n');
       await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
 
+      // prompt.md — skill body for Codex to execute
       if (isCompiled()) {
+        // VFS mode: write entire skill tree (includes SKILL.md + any extras)
         await writeSkillToDir(skill.name, skillPluginDir);
       } else {
+        // Filesystem mode: copy SKILL.md as prompt.md
         const skillMdPath = join(skill.path, 'SKILL.md');
         if (existsSync(skillMdPath)) {
           const content = await Bun.file(skillMdPath).text();
@@ -716,12 +805,9 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
     // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
     // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
     // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
-    // Codex 0.130+ uses a different per-plugin layout (.codex-plugin/plugin.json + skills/).
     if (agentName === 'codex' && isCodexPluginMarketplace()) {
-      const codexVersion = await detectCodexVersion();
-      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode, { codexVersion });
-      const fmt = isCodexV2Format(codexVersion) ? '0.130+' : '0.128';
-      p.log.success(`Codex plugin marketplace (${fmt}): ${getCodexMarketplaceDir()}`);
+      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
+      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);
@@ -754,7 +840,6 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
         if (fullOnDisk && liteOnDisk && await isOurSkill(join(skillsDir, lite))) {
           await rm(join(skillsDir, lite), { recursive: true, force: true });
           p.log.info(`Auto-removed ${lite} (${full} is present — lite variant redundant)`);
-          // Update manifest to reflect removal
           const manifestPath = join(skillsDir, '.arra-oracle-skills.json');
           if (existsSync(manifestPath)) {
             try {

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -35,6 +35,44 @@ export function getCodexMarketplaceDir(homeDir?: string): string {
 }
 
 /**
+ * Detect the installed Codex CLI version by shelling out to `codex --version`.
+ * Returns the semver string (e.g. "0.130.0") or null if codex is not on PATH
+ * or the output cannot be parsed.
+ */
+export async function detectCodexVersion(): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(['codex', '--version'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    if (proc.exitCode !== 0) return null;
+    const match = out.match(/(\d+)\.(\d+)\.(\d+)/);
+    return match ? match[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true if the given Codex version uses the V2 plugin format
+ * (>= 0.130.0: per-plugin plugin.json + skills/<name>/SKILL.md).
+ *
+ * When version is null (codex binary missing), defaults to true so newly
+ * shipped Codex versions still get a working install.
+ */
+export function isCodexV2Format(version: string | null): boolean {
+  if (version === null) return true;
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return true;
+  const major = parseInt(match[1], 10);
+  const minor = parseInt(match[2], 10);
+  if (major > 0) return true;
+  return minor >= 130;
+}
+
+/**
  * Install skills for Codex 0.128.0+ plugin marketplace.
  *
  * Creates:
@@ -50,22 +88,26 @@ export async function installCodexPluginMarketplace(
   skills: Skill[],
   version: string,
   shellMode: ShellMode,
-  opts?: { marketplaceDir?: string; configPath?: string }
+  opts?: { marketplaceDir?: string; configPath?: string; codexVersion?: string | null }
 ): Promise<void> {
   const marketplaceDir = opts?.marketplaceDir ?? getCodexMarketplaceDir();
   const configPath = opts?.configPath ?? join(homedir(), '.codex', 'config.toml');
+  const codexVersion = opts?.codexVersion === undefined ? await detectCodexVersion() : opts.codexVersion;
+  const v2 = isCodexV2Format(codexVersion);
 
   // ── 1. Create marketplace bundle directory ─────────────────────────────────
   await mkdirp(marketplaceDir, shellMode);
 
-  // ── 2. Write marketplace manifest ─────────────────────────────────────────
-  const manifestContent = [
-    `name = "arra-oracle-skills"`,
-    `version = "${version}"`,
-    `description = "Oracle skills for Codex by Soul Brews Studio"`,
-    ``,
-  ].join('\n');
-  await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+  // ── 2. Write marketplace manifest (V1 only — Codex 0.130+ ignores it) ─────
+  if (!v2) {
+    const manifestContent = [
+      `name = "arra-oracle-skills"`,
+      `version = "${version}"`,
+      `description = "Oracle skills for Codex by Soul Brews Studio"`,
+      ``,
+    ].join('\n');
+    await Bun.write(join(marketplaceDir, 'manifest.toml'), manifestContent);
+  }
 
   // ── 3. Per-skill plugin directories ───────────────────────────────────────
   const pluginsDir = join(marketplaceDir, 'plugins');
@@ -75,27 +117,55 @@ export async function installCodexPluginMarketplace(
     const skillPluginDir = join(pluginsDir, skill.name);
     await mkdirp(skillPluginDir, shellMode);
 
-    // plugin.toml descriptor
-    const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    const pluginToml = [
-      `name = "${skill.name}"`,
-      `description = "${escapedDesc}"`,
-      `version = "${version}"`,
-      `command = "/${skill.name}"`,
-      ``,
-    ].join('\n');
-    await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
+    if (v2) {
+      // Codex 0.130+ format: .codex-plugin/plugin.json + skills/<name>/SKILL.md
+      const pluginMetaDir = join(skillPluginDir, '.codex-plugin');
+      await mkdirp(pluginMetaDir, shellMode);
+      const pluginJson = {
+        name: skill.name,
+        version,
+        description: skill.description,
+        skills: './skills/',
+        interface: {
+          displayName: skill.name,
+          shortDescription: skill.description,
+          category: 'AI Assistant',
+          capabilities: ['Interactive', 'Read'],
+        },
+      };
+      await Bun.write(join(pluginMetaDir, 'plugin.json'), JSON.stringify(pluginJson, null, 2) + '\n');
 
-    // prompt.md — skill body for Codex to execute
-    if (isCompiled()) {
-      // VFS mode: write entire skill tree (includes SKILL.md + any extras)
-      await writeSkillToDir(skill.name, skillPluginDir);
+      const skillBodyDir = join(skillPluginDir, 'skills', skill.name);
+      await mkdirp(skillBodyDir, shellMode);
+      if (isCompiled()) {
+        await writeSkillToDir(skill.name, skillBodyDir);
+      } else {
+        const skillMdPath = join(skill.path, 'SKILL.md');
+        if (existsSync(skillMdPath)) {
+          const content = await Bun.file(skillMdPath).text();
+          await Bun.write(join(skillBodyDir, 'SKILL.md'), content);
+        }
+      }
     } else {
-      // Filesystem mode: copy SKILL.md as prompt.md
-      const skillMdPath = join(skill.path, 'SKILL.md');
-      if (existsSync(skillMdPath)) {
-        const content = await Bun.file(skillMdPath).text();
-        await Bun.write(join(skillPluginDir, 'prompt.md'), content);
+      // Codex < 0.130 format: plugin.toml + prompt.md
+      const escapedDesc = skill.description.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const pluginToml = [
+        `name = "${skill.name}"`,
+        `description = "${escapedDesc}"`,
+        `version = "${version}"`,
+        `command = "/${skill.name}"`,
+        ``,
+      ].join('\n');
+      await Bun.write(join(skillPluginDir, 'plugin.toml'), pluginToml);
+
+      if (isCompiled()) {
+        await writeSkillToDir(skill.name, skillPluginDir);
+      } else {
+        const skillMdPath = join(skill.path, 'SKILL.md');
+        if (existsSync(skillMdPath)) {
+          const content = await Bun.file(skillMdPath).text();
+          await Bun.write(join(skillPluginDir, 'prompt.md'), content);
+        }
       }
     }
   }
@@ -675,9 +745,12 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
     // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
     // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
     // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
+    // Codex 0.130+ uses a different per-plugin layout (.codex-plugin/plugin.json + skills/).
     if (agentName === 'codex' && isCodexPluginMarketplace()) {
-      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
-      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
+      const codexVersion = await detectCodexVersion();
+      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode, { codexVersion });
+      const fmt = isCodexV2Format(codexVersion) ? '0.130+' : '0.128';
+      p.log.success(`Codex plugin marketplace (${fmt}): ${getCodexMarketplaceDir()}`);
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -11,14 +11,14 @@
  * oracle-soul-sync-update (6), standup (10), skills-list (3), oracle-family-scan (8).
  * These move to full (still installable, not lab-gated).
  *
- * MINIMAL_ONLY classification (#285): forward-lite, recap-lite, rrr-lite are token-
- * optimized replacements for full versions. They have value in minimal only —
- * elsewhere they duplicate functionality of forward/recap/rrr. Excluded from full+lab.
+ * Lites killed 2026-05-14: forward-lite/recap-lite/rrr-lite moved to zombie.
+ * 900 chars of description savings wasn't worth 4 PRs of cleanup bugs (#368, #382, #384, #387).
+ * Minimal now uses full forward/recap/rrr — same skills, fewer of them.
  */
 
-/** Minimal profile — lite lifecycle + trace (token-optimized) */
+/** Minimal profile — essential lifecycle + trace */
 export const MINIMAL_SKILLS = [
-  'about-oracle', 'forward-lite', 'go', 'recap-lite', 'rrr-lite', 'trace',
+  'about-oracle', 'forward', 'go', 'recap', 'rrr', 'trace',
 ] as const;
 
 /** Standard profile — daily driver skills (always installed) */
@@ -33,13 +33,9 @@ export const LAB_SKILLS = [
   'schedule', 'watch', 'worktree', 'xray',
 ] as const;
 
-/** Minimal-only skills — token-optimized lite variants that replace the full
- *  version when in `minimal` profile. They have no value outside minimal because
- *  the full versions (`forward`, `recap`, `rrr`) are present in higher tiers.
- *  Excluded from `full` and `lab` profiles. Closes #285. */
-export const MINIMAL_ONLY_SKILLS = [
-  'forward-lite', 'recap-lite', 'rrr-lite',
-] as const;
+/** Minimal-only — DEPRECATED, kept as empty for backward compat with imports.
+ *  Lites moved to zombie 2026-05-14. See ZOMBIE_SKILLS for forward-lite etc. */
+export const MINIMAL_ONLY_SKILLS = [] as const;
 
 /** Zombie skills — internal development candidates from arra-symbiosis-skills.
  *  Excluded from ALL profiles. Install by name only: `arra install -s workon`
@@ -66,6 +62,8 @@ export const ZOMBIE_SKILLS = [
   'dream-original',
   // 2026-05-14: replaced by /go update verb — no longer needs its own skill slot.
   'oracle-soul-sync-update',
+  // 2026-05-14: lites killed — 900 chars savings wasn't worth 4 PRs of bugs.
+  'forward-lite', 'recap-lite', 'rrr-lite',
 ] as const;
 
 /** Return the source directory for a skill by name — `.archive/` for zombies,

--- a/src/skills/.archive/forward-lite/SKILL.md
+++ b/src/skills/.archive/forward-lite/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: forward-lite
-description: Quick handoff to next session — save context for tomorrow. Lite version for minimal profile. Use when user says "forward", "handoff", "wrap up". For full version with plan mode, issue creation, and outbox, upgrade to standard (/go standard → /forward).
+description: "[DEPRECATED] Lite variant killed 2026-05-14. Use /forward instead."
+zombie: true
 ---
 
 # /forward-lite

--- a/src/skills/.archive/recap-lite/SKILL.md
+++ b/src/skills/.archive/recap-lite/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: recap-lite
-description: Quick session orientation — git state + last handoff. Lite version for minimal profile. Use when user says "recap", "where are we", "status". For full version with retro summaries and session mining, upgrade to standard (/go standard → /recap).
+description: "[DEPRECATED] Lite variant killed 2026-05-14. Use /recap instead."
+zombie: true
 ---
 
 # /recap-lite

--- a/src/skills/.archive/rrr-lite/SKILL.md
+++ b/src/skills/.archive/rrr-lite/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: rrr-lite
-description: Quick session retrospective — what we did, what we learned. Lite version for minimal profile. Use when user says "rrr", "retrospective", "wrap up". For full version with AI diary and anti-rationalization guard, upgrade to standard (/go standard → /rrr).
+description: "[DEPRECATED] Lite variant killed 2026-05-14. Use /rrr instead."
+zombie: true
 ---
 
 # /rrr-lite

--- a/src/skills/release-alpha/SKILL.md
+++ b/src/skills/release-alpha/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: release-alpha
+description: "Cut an alpha pre-release — bump CalVer, PR to alpha branch, CI auto-tags + publishes to npm @alpha. Use when user says 'release alpha', 'cut alpha', '/release-alpha', or wants to publish an alpha version."
+argument-hint: ""
+---
+
+# /release-alpha
+
+Cut an alpha pre-release for the current repo.
+
+## Assumptions
+
+- Repo has `scripts/calver.ts` that supports `--check` + apply-by-default
+- Repo has an `alpha` branch on `origin`
+- `calver-release.yml` auto-tags + publishes when a version-bump commit lands on `alpha`
+- Current branch is NOT `main`, `alpha`, or `beta`
+
+## Step 0: Detect repo + verify state
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "❌ Not in a git repo"; exit 1; }
+BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
+echo "📁 $REPO_ROOT"
+echo "🌿 $BRANCH"
+```
+
+Hard checks:
+
+```bash
+[ "$BRANCH" != "main" ] || { echo "❌ On main"; exit 1; }
+[ "$BRANCH" != "alpha" ] || { echo "❌ On alpha"; exit 1; }
+[ "$BRANCH" != "beta" ] || { echo "❌ On beta"; exit 1; }
+[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ] || { echo "❌ Working tree dirty"; exit 1; }
+git -C "$REPO_ROOT" fetch origin alpha 2>/dev/null
+```
+
+## Step 1: Locate calver script
+
+```bash
+CALVER="$REPO_ROOT/scripts/calver.ts"
+[ -f "$CALVER" ] || { echo "❌ No scripts/calver.ts"; exit 1; }
+```
+
+## Step 2: Compute target
+
+```bash
+TARGET=$(TZ=Asia/Bangkok bun "$CALVER" --check 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+' | head -1)
+```
+
+## Step 3: Confirm gate
+
+Show full plan. Wait for user `y`/`yes`. Anything else → abort.
+
+## Step 4: Execute
+
+```bash
+TZ=Asia/Bangkok bun "$CALVER"
+git -C "$REPO_ROOT" add package.json
+git -C "$REPO_ROOT" commit -m "bump: $TARGET"
+git -C "$REPO_ROOT" push -u origin "$BRANCH"
+gh pr create --base alpha --title "release: $TARGET" --body "Cuts $TARGET on merge via calver-release.yml."
+```
+
+## Step 5: Output
+
+Print PR URL. Do NOT auto-merge.
+
+```
+✅ PR opened: [URL]
+📦 On merge to alpha → calver-release.yml cuts [TARGET]
+```

--- a/src/skills/release-beta/SKILL.md
+++ b/src/skills/release-beta/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: release-beta
+description: "Cut a beta pre-release — bump CalVer with --beta, PR to beta branch, CI auto-tags + publishes to npm @beta. Use when user says 'release beta', 'cut beta', '/release-beta', or wants to publish a beta version for pre-release testing."
+argument-hint: ""
+---
+
+# /release-beta
+
+Cut a beta pre-release for the current repo.
+
+Beta sits between alpha (bleeding edge) and main (stable):
+`alpha` → `beta` → `main`
+
+## Assumptions
+
+- Repo has `scripts/calver.ts` that supports `--beta` + `--check`
+- Repo has a `beta` branch on `origin`
+- `calver-release.yml` auto-tags + publishes when a version-bump commit lands on `beta`
+- Current branch is NOT `main`, `alpha`, or `beta`
+
+## Step 0: Detect repo + verify state
+
+```bash
+date "+🕐 %H:%M %Z (%A %d %B %Y)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "❌ Not in a git repo"; exit 1; }
+BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
+echo "📁 $REPO_ROOT"
+echo "🌿 $BRANCH"
+```
+
+Hard checks:
+
+```bash
+[ "$BRANCH" != "main" ] || { echo "❌ On main"; exit 1; }
+[ "$BRANCH" != "alpha" ] || { echo "❌ On alpha"; exit 1; }
+[ "$BRANCH" != "beta" ] || { echo "❌ On beta"; exit 1; }
+[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ] || { echo "❌ Working tree dirty"; exit 1; }
+git -C "$REPO_ROOT" fetch origin beta 2>/dev/null
+```
+
+## Step 1: Locate calver script
+
+```bash
+CALVER="$REPO_ROOT/scripts/calver.ts"
+[ -f "$CALVER" ] || { echo "❌ No scripts/calver.ts"; exit 1; }
+```
+
+## Step 2: Compute target
+
+```bash
+TARGET=$(TZ=Asia/Bangkok bun "$CALVER" --beta --check 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+' | head -1)
+```
+
+## Step 3: Confirm gate
+
+Show full plan. Wait for user `y`/`yes`. Anything else → abort.
+
+```
+## Release plan
+
+  Repo:    [REPO_ROOT]
+  Branch:  [BRANCH]
+  Target:  [TARGET]
+  PR base: beta
+
+What will happen on confirm:
+  1. bun calver.ts --beta          # writes [TARGET] to package.json
+  2. git add package.json
+  3. git commit -m "bump: [TARGET]"
+  4. git push -u origin [BRANCH]
+  5. gh pr create --base beta
+
+Proceed? [y/N]
+```
+
+## Step 4: Execute
+
+```bash
+TZ=Asia/Bangkok bun "$CALVER" --beta
+git -C "$REPO_ROOT" add package.json
+git -C "$REPO_ROOT" commit -m "bump: $TARGET"
+git -C "$REPO_ROOT" push -u origin "$BRANCH"
+gh pr create --base beta --title "release: $TARGET" --body "Cuts $TARGET on merge via calver-release.yml."
+```
+
+## Step 5: Output
+
+Print PR URL. Do NOT auto-merge.
+
+```
+✅ PR opened: [URL]
+📦 On merge to beta → calver-release.yml cuts [TARGET]
+🔍 Install: bun add arra-oracle-skills@beta
+```
+
+## Promotion flow
+
+```
+alpha (bleeding edge) → beta (pre-release testing) → main (stable)
+
+/release-alpha   → PR to alpha → npm @alpha
+/release-beta    → PR to beta  → npm @beta
+alpha → main PR  → npm @latest (stable)
+```
+
+Beta is for features that passed alpha soak and need wider testing before stable.

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -89,14 +89,65 @@ done
 python3 ~/.claude/skills/dig/scripts/dig.py 0 --deep
 ```
 
-Extract session ID from the dig output or from the most recent .jsonl:
+Extract session ID + mine REAL message timestamps from the .jsonl:
 ```bash
 LATEST_JSONL=$(ls -t "$PROJECT_BASE"/*.jsonl 2>/dev/null | head -1)
 if [ -n "$LATEST_JSONL" ]; then
   SESSION_ID=$(basename "$LATEST_JSONL" .jsonl)
   echo "SESSION: ${SESSION_ID:0:8}"
 fi
+
+# REQUIRED: extract real timestamps for the Timeline section.
+# Pull every real user message + its timestamp from the session file.
+# Dig gives session-level data only — for sub-session timestamps we read the jsonl directly.
+python3 - <<'PYEOF'
+import json, os
+from datetime import datetime, timezone, timedelta
+tz = timezone(timedelta(hours=7))
+jsonl = os.environ.get('LATEST_JSONL', '')
+if not jsonl or not os.path.exists(jsonl): exit(0)
+with open(jsonl) as f:
+    for line in f:
+        try:
+            m = json.loads(line)
+            if m.get('type') != 'user' or 'message' not in m: continue
+            content = m['message'].get('content', '')
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get('type') == 'text':
+                        content = c.get('text', ''); break
+            if not isinstance(content, str): continue
+            ts = m.get('timestamp', '')
+            # Skip tool-result / system messages
+            if not ts or '<command-name>' in content[:200] or content.startswith('<bash-'): continue
+            dt = datetime.fromisoformat(ts.replace('Z', '+00:00')).astimezone(tz)
+            snippet = content[:100].replace(chr(10), ' ')
+            print(f"{dt.strftime('%Y-%m-%d %H:%M')} | {snippet}")
+        except: pass
+PYEOF
 ```
+
+**RULES for the Timeline section**:
+
+1. **REAL timestamps only** — pulled from this jsonl extraction, never "approx" or memory-guesses. If extraction is empty (no session file), say so explicitly in the timeline rather than inventing times.
+
+2. **Date once in a header, time-only in rows** — when all entries are same-day, format like this:
+
+   ```markdown
+   ## Timeline
+
+   **Date**: 2026-05-14 (GMT+7) · all times same-day
+
+   | Time | What |
+   |---|---|
+   | 20:14 | User: "..." |
+   | 20:21 | PR #379 merged |
+   | 21:13 | User: "..." |
+   ```
+
+   Do NOT repeat `2026-05-14 20:14` on every row. The date belongs in the header.
+
+3. **Multi-day session** — if entries span more than one day, group by day with a `### YYYY-MM-DD` subheader for each day, then `HH:MM` rows under it.
 
 Include in retrospective header:
 ```
@@ -112,9 +163,9 @@ If dig or session detection fails, skip silently and continue with git-only cont
 mkdir -p "$PSI/memory/retrospectives/$(date +%Y-%m/%d)"
 ```
 
-Write immediately, no prompts. Use the dig session data to build the Timeline section with real timestamps. Include:
+Write immediately, no prompts. Build the Timeline section from the .jsonl extraction above — every row must have a real `YYYY-MM-DD HH:MM` timestamp. Never use "approx", "around", or memory-guessed times. Include:
 - Session Summary
-- Timeline (from dig data — real timestamps, duration, topic per session segment)
+- Timeline (real timestamps from .jsonl mining — `YYYY-MM-DD HH:MM | what`)
 - Files Modified
 - AI Diary (150+ words, first-person; must contain one line labeled `[→ AGENT DECISION]` naming a choice YOU made wrong — overconfidence, repeated wrong proposal, misread requirement; tool failures and env issues belong in friction, not here)
 - Honest Feedback (100+ words, 3 friction points; **session-specific only** — what dragged in THIS session; if something generalizes beyond this session, it belongs in Lessons, not here)

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rrr
 description: Create session retrospective with AI diary and lessons learned. Use when user says "rrr", "retrospective", "wrap up session", "session summary", or at end of work session.
-argument-hint: "[--detail | --dig | --deep]"
+argument-hint: "[--quick | --detail | --deep]"
 ---
 
 # /rrr
@@ -9,15 +9,18 @@ argument-hint: "[--detail | --dig | --deep]"
 > "Reflect to grow, document to remember."
 
 ```
-/rrr                      # Quick retro, main agent
-/rrr --detail             # Full template, main agent
-/rrr --dig                # Reconstruct past timeline from session .jsonl
+/rrr                      # Retro with session timeline (dig-powered)
+/rrr --quick              # No dig — memory-only, faster but no timeline after compaction
+/rrr --detail             # Full template + dig timeline
 /rrr --deep               # 5 parallel subagents
 /rrr --deep --teammate    # 3 coordinated team agents (requires AGENT_TEAMS)
 ```
 
+**Default mode always mines session .jsonl for timeline** — survives compaction, shows real timestamps.
+`--quick` skips dig for speed when you don't need the timeline.
+
 **NEVER spawn subagents or use the Task tool. Only `--deep` and `--deep --teammate` may use subagents.**
-**`/rrr`, `/rrr --detail`, and `/rrr --dig` = main agent only. Zero subagents. Zero Task calls.**
+**`/rrr`, `/rrr --quick`, `/rrr --detail` = main agent only. Zero subagents. Zero Task calls.**
 
 ---
 
@@ -50,34 +53,58 @@ All paths below use `$PSI/` instead of bare `ψ/`.
 
 ---
 
-## /rrr (Default)
+## /rrr (Default — dig-powered)
 
-### 1. Gather
+### 1. Gather + Mine Session Timeline
+
+Run git context AND dig in one step:
 
 ```bash
 date "+%H:%M %Z (%A %d %B %Y)"
 git log --oneline -10 && git diff --stat HEAD~5
 ```
 
-### 1.5. Detect Session (optional)
+Detect session + mine timeline from .jsonl:
 
 ```bash
 ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
-PROJECT_DIR="$HOME/.claude/projects/${ENCODED_PWD}"
-LATEST_JSONL=$(ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1)
+PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
+export PROJECT_DIRS="$PROJECT_BASE"
+
+# Strip -wt* suffix to find parent project dir
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+# nullglob-safe worktree scan
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
+
+python3 ~/.claude/skills/dig/scripts/dig.py 1
+```
+
+Extract session ID from the dig output or from the most recent .jsonl:
+```bash
+LATEST_JSONL=$(ls -t "$PROJECT_BASE"/*.jsonl 2>/dev/null | head -1)
 if [ -n "$LATEST_JSONL" ]; then
   SESSION_ID=$(basename "$LATEST_JSONL" .jsonl)
   echo "SESSION: ${SESSION_ID:0:8}"
 fi
 ```
 
-If detected, include in retrospective header:
+Include in retrospective header:
 ```
 📡 Session: 74c32f34 | repo-name | Xh XXm
 ```
-If detection fails, skip silently.
+If dig or session detection fails, skip silently and continue with git-only context.
 
-### 2. Write Retrospective
+### 2. Write Retrospective with Timeline
 
 **Path**: `$PSI/memory/retrospectives/YYYY-MM/DD/HH.MM_slug.md`
 
@@ -85,9 +112,9 @@ If detection fails, skip silently.
 mkdir -p "$PSI/memory/retrospectives/$(date +%Y-%m/%d)"
 ```
 
-Write immediately, no prompts. Include:
+Write immediately, no prompts. Use the dig session data to build the Timeline section with real timestamps. Include:
 - Session Summary
-- Timeline
+- Timeline (from dig data — real timestamps, duration, topic per session segment)
 - Files Modified
 - AI Diary (150+ words, first-person; must contain one line labeled `[→ AGENT DECISION]` naming a choice YOU made wrong — overconfidence, repeated wrong proposal, misread requirement; tool failures and env issues belong in friction, not here)
 - Honest Feedback (100+ words, 3 friction points; **session-specific only** — what dragged in THIS session; if something generalizes beyond this session, it belongs in Lessons, not here)
@@ -216,51 +243,32 @@ Then steps 3-5 same as default.
 
 ---
 
-## /rrr --dig
+## /rrr --quick
 
-**Retrospective powered by session goldminer. No subagents.**
+**Fast retro without dig — uses conversation memory only.** Use when you want speed over timeline accuracy, or when dig.py is unavailable.
 
-### 1. Run dig to get session timeline
-
-Discover project dirs using full-path encoding (same as Claude's `.claude/projects/` naming), including worktree dirs:
-
-```bash
-ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
-PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
-export PROJECT_DIRS="$PROJECT_BASE"
-
-# Strip -wt* suffix to find parent project dir
-PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
-if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
-  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
-  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
-fi
-
-# nullglob-safe worktree scan (both parent and self)
-for base in "$PROJECT_BASE" "$PARENT_BASE"; do
-  [ -z "$base" ] && continue
-  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
-    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
-  done
-done
-```
-
-Then run dig.py to get session JSON:
-
-```bash
-python3 ~/.claude/skills/dig/scripts/dig.py 0
-```
-
-Also gather git context:
+### 1. Gather
 
 ```bash
 date "+%H:%M %Z (%A %d %B %Y)"
 git log --oneline -10 && git diff --stat HEAD~5
 ```
 
-### 2. Write Retrospective with Timeline
+### 1.5. Detect Session
 
-Use the session timeline data to write a full retrospective using the `--detail` template. Add the Past Session Timeline table after Session Summary, before Timeline.
+```bash
+ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
+PROJECT_DIR="$HOME/.claude/projects/${ENCODED_PWD}"
+LATEST_JSONL=$(ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1)
+if [ -n "$LATEST_JSONL" ]; then
+  SESSION_ID=$(basename "$LATEST_JSONL" .jsonl)
+  echo "SESSION: ${SESSION_ID:0:8}"
+fi
+```
+
+### 2. Write Retrospective
+
+Same template as default but timeline is reconstructed from conversation memory (may be incomplete after compaction).
 
 ### 3-5. Same as default steps 3-5
 

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -86,7 +86,7 @@ for base in "$PROJECT_BASE" "$PARENT_BASE"; do
   done
 done
 
-python3 ~/.claude/skills/dig/scripts/dig.py 1
+python3 ~/.claude/skills/dig/scripts/dig.py 0 --deep
 ```
 
 Extract session ID from the dig output or from the most recent .jsonl:

--- a/src/skills/trace/SKILL.md
+++ b/src/skills/trace/SKILL.md
@@ -110,11 +110,12 @@ arra_search("[query]", limit=10)
 
 ---
 
-## Mode 3: --deep (Wave Execution)
+## Mode 3: --deep (Wave Execution + Session Mining)
 
-**Two waves of parallel search. Each wave has fresh context (no rot).**
+**Two waves of parallel search + dig session mining. Each wave has fresh context (no rot).**
+`--deep --dig` is now the same as `--deep` (dig is always included).
 
-### Wave 1 — Fast surface search (run in parallel)
+### Wave 1 — Fast surface search + session mining (run in parallel)
 
 **Agent A: Current/Target Repo Files**
 ```
@@ -140,6 +141,40 @@ Search ψ/memory/ for:
 - Previous trace logs for same query
 
 Return findings as text. Main agent compiles.
+```
+
+**Agent F: Session History (dig)**
+```
+You are mining session history for: [query]
+
+Run the dig script to get all sessions:
+ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
+PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
+export PROJECT_DIRS="$PROJECT_BASE"
+
+PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
+if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
+  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
+  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
+fi
+
+for base in "$PROJECT_BASE" "$PARENT_BASE"; do
+  [ -z "$base" ] && continue
+  for wt in "$base"-wt-*(N); do
+    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
+  done
+done
+
+python3 ~/.claude/skills/dig/scripts/dig.py 0 --deep
+
+Then search the session data for mentions of: [query]
+Look for:
+- Sessions where this topic was worked on
+- Timeline of when it was touched
+- Which repos it appeared in
+- How much time was spent
+
+Return findings as text. Max 500 words.
 ```
 
 After Wave 1: check if answer is sufficient.
@@ -189,60 +224,12 @@ Return findings as text. Main agent compiles.
 
 ---
 
-## Mode 4: --deep --dig (Combo)
+## Mode 4: --deep --dig (Alias)
 
-**Trace deep + session mining in parallel.** Runs both `/trace --deep` and `/dig` simultaneously, then merges results into one output.
+**Same as `--deep`** — dig is now always included in `--deep` mode (Agent F in Wave 1).
+This flag is kept for backward compatibility but has no additional effect.
 
-### How it works
-
-Launch trace Wave 1 agents AND the dig session miner at the same time:
-
-**In parallel:**
-1. **Trace agents** (Wave 1: Agent A + Agent B) — same as --deep mode above
-2. **Dig agent** — mines session history for the query:
-
-```
-You are mining session history for: [query]
-
-Run the dig script to get all sessions:
-ENCODED_PWD=$(pwd | sed 's|^/|-|; s|[/.]|-|g')
-PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
-export PROJECT_DIRS="$PROJECT_BASE"
-
-# Strip -wt* suffix to find parent project dir
-PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
-if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
-  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
-  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
-fi
-
-# nullglob-safe worktree scan (both parent and self)
-for base in "$PROJECT_BASE" "$PARENT_BASE"; do
-  [ -z "$base" ] && continue
-  for wt in "$base"-wt-*(N); do  # (N) = zsh nullglob qualifier
-    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
-  done
-done
-
-python3 ~/.claude/skills/dig/scripts/dig.py 0
-
-Then search the session data for mentions of: [query]
-Look for:
-- Sessions where this topic was worked on
-- Timeline of when it was touched
-- Which repos it appeared in
-- How much time was spent
-
-Return findings as text. Max 500 words.
-```
-
-**After Wave 1 + Dig complete:**
-- Check trace results — if insufficient, run Wave 2 (same as --deep)
-- Merge all results: trace findings + session history
-
-### Combined Output
-
-The trace log includes an extra section:
+The trace log includes a **Session History** section from the dig agent:
 
 ```markdown
 ## Session History (from /dig)
@@ -250,12 +237,6 @@ The trace log includes an extra section:
 ```
 
 This goes between "Oracle Memory" and "Friction Analysis" in the trace log.
-
-### When to use
-
-- "When did we work on X and where is it now?" — both questions answered
-- Investigating a topic across code AND session history
-- Building a complete picture: what exists (trace) + what happened (dig)
 
 ---
 
@@ -458,8 +439,8 @@ Omar surfaces this. jeera-p decides what to do about it.
 |------|-------|-------|-------|
 | `--oracle` | Fast | Oracle only | — |
 | `--smart` | Medium | Oracle → maybe deep | Auto |
-| `--deep` | Thorough | Wave 1 + Wave 2 if needed | 2 |
-| `--deep --dig` | Thorough+ | Deep + session mining (parallel) | 2 + dig |
+| `--deep` | Thorough | Wave 1 (+ dig) + Wave 2 if needed | 2 + dig |
+| `--deep --dig` | (alias) | Same as --deep | — |
 
 | Output field | Description |
 |-------------|-------------|


### PR DESCRIPTION
## Summary
Promote alpha.2328 to main (stable release).

### Changes since last stable (v26.5.14)
- **#370** fix(#351): worktree detection + nullglob crash (4 SKILL.md files)
- **#371** fix: stale comments, wrong URLs, missing zombie overlap tests
- **#375** feat: beta release channel + /release-alpha + /release-beta skills
- **#378** fix(#372): Codex 0.130 plugin format (initial)
- **#379** feat: /rrr dig-powered default
- **#380** feat: /rrr deep dig + /trace deep includes session mining
- **#382** fix: lite removal gate expansion
- **#384** fix: post-install lite cleanup
- **#388** fix(#372): complete Codex 0.130 fix (from sutthikit's #386)
- **#389** fix(rrr): real timestamps + date-once Timeline format
- **#391** feat: kill lite skills — minimal uses full forward/recap/rrr

### Issues closed
- #351 worktree detection
- #372 Codex 0.130 format
- #387 lite cleanup not firing (fixed by killing lites)

## Test plan
- [x] 280 tests, 1521 expects, 0 failures

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle