### PR TITLE
fix(dig): resolve repoName for github.com/* paths

### DIFF
--- a/src/skills/dig/scripts/dig.py
+++ b/src/skills/dig/scripts/dig.py
@@ -55,7 +55,7 @@ def build_repo_map():
         r = subprocess.run(['ghq', 'list', '-p'], capture_output=True, text=True, timeout=5)
         for path in r.stdout.strip().split('\n'):
             if path:
-                mapping[path.replace('/', '-')] = path.split('/')[-1]
+                mapping[path.replace('/', '-').replace('.', '-')] = path.split('/')[-1]
     except:
         pass
     return mapping


### PR DESCRIPTION
## Summary
- One-line fix in `build_repo_map`: also apply `.` → `-` when keying ghq paths, matching Claude Code's project-dir encoding.
- Without this, every `github.com/*` ghq path missed the lookup and silently fell back to `clean.split('-')[-1]`, collapsing all `*-oracle` repos to `"oracle"`, `*-cli` to `"cli"`, etc.

## Why it mattered
- `/dig` cross-repo output and `deep.py` aggregation both reported the wrong `repoName` for ~every session.
- `Counter(repoName)` analytics collapsed dozens of repos into the trailing-suffix bucket.
- Bug hid because the fallback returned a value-shaped string instead of `None` — never threw.

## Verification
- Before: `m5 deep.py` filtered by `repoName == 'mawjs-oracle'` → **0 sessions**.
- After: same filter → **776 sessions** (correct local count).
- Single-repo `/dig` already showed `repoName: mawjs-oracle` immediately after the fix.

## Test plan
- [ ] Run `/dig` in a `github.com/*-oracle` repo — confirm `repoName` is the full repo slug, not the last `-` segment.
- [ ] Run `/dig --all` across multiple repos — confirm distinct `repoName` values per repo.
- [ ] Spot-check `deep.py` JSON output for non-`oracle` slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)