### PR TITLE
fix(dig): repo map key must replace '.' → '-' to match Claude encoding

### DIFF
--- a/src/skills/dig/scripts/dig.py
+++ b/src/skills/dig/scripts/dig.py
@@ -55,7 +55,7 @@ def build_repo_map():
         r = subprocess.run(['ghq', 'list', '-p'], capture_output=True, text=True, timeout=5)
         for path in r.stdout.strip().split('\n'):
             if path:
-                mapping[path.replace('/', '-')] = path.split('/')[-1]
+                mapping[path.replace('/', '-').replace('.', '-')] = path.split('/')[-1]
     except:
         pass
     return mapping


### PR DESCRIPTION
One-line fix from m5:mawjs-explore team. `build_repo_map()` at line 58 was missing `.replace('.', '-')`. All github.com repos fell back to wrong repoName.