### PR TITLE
fix: Codex skills-only — skip marketplace + cache (triple-duplicate fix)

### DIFF
--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -802,12 +802,21 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
       }
     }
 
-    // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
-    // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
-    // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
-    if (agentName === 'codex' && isCodexPluginMarketplace()) {
-      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
-      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
+    // Codex: skip marketplace + plugin cache — write to ~/.codex/skills/ ONLY.
+    // The marketplace bundle + cache caused triple-duplicate autocomplete entries
+    // (skills/ + marketplace/ + cache/ all visible to Codex). Skills-only is clean.
+    // Clean up stale marketplace/cache from prior installs.
+    if (agentName === 'codex') {
+      const marketplaceDir = getCodexMarketplaceDir();
+      const cacheDir = getCodexPluginCacheDir();
+      if (existsSync(marketplaceDir)) {
+        await rm(marketplaceDir, { recursive: true, force: true });
+        p.log.info('Cleaned stale Codex marketplace bundle');
+      }
+      if (existsSync(cacheDir)) {
+        await rm(cacheDir, { recursive: true, force: true });
+        p.log.info('Cleaned stale Codex plugin cache');
+      }
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);


### PR DESCRIPTION
## Problem
Codex shows 3 entries per skill in autocomplete:
1. `[Plugin]` from marketplace bundle
2. `[Skill]` from ~/.codex/skills/
3. `[Skill] (dig)` from plugin cache

## Root cause
Installer writes to THREE Codex paths on every install:
- ~/.codex/skills/ (actual skills)
- ~/.codex/.tmp/bundled-marketplaces/arra-oracle-skills/ (marketplace)
- ~/.codex/plugins/cache/arra-oracle-skills/ (cache)

## Fix
- Skip marketplace + cache entirely — write to skills/ ONLY
- Auto-clean stale marketplace/cache from prior installs
- Only wipes arra-oracle-skills paths (scoped, never touches other plugins)

## Test plan
- [x] `bun test` — 280 pass, 0 fail
- [x] Verified: marketplace dir scoped to `arra-oracle-skills` only

🤖 Written by [m5:arra-oracle-skills-cli] (Claude Opus 4.6, Oracle AI)