### PR TITLE
release: v26.5.16 stable (alpha.1342 → main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.15-alpha.1123 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1220 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.15-alpha.1123 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1220 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.15-alpha.1220 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.15-alpha.1220 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1342 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.15-alpha.1220 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1342 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.15 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.15 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.15 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.15 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.15 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.15 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.15 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.15 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.15 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.15-alpha.1123 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.15 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1123 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.15 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1123 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.15-alpha.1123",
+  "version": "26.5.15-alpha.1220",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.15-alpha.1220",
+  "version": "26.5.15-alpha.1342",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.15",
+  "version": "26.5.15-alpha.1123",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,4 +1,6 @@
 import type { Command } from 'commander';
+import { join } from 'path';
+import { existsSync } from 'fs';
 import * as p from '@clack/prompts';
 import { agents, getDefaultAgents, getAgentNames, detectInstalledAgents, thClawsAvailable } from '../agents.js';
 import { listSkills, installSkills, discoverSkills } from '../installer.js';
@@ -133,7 +135,17 @@ export function registerInstall(program: Command, version: string) {
                 targetAgents = detected;
               }
             } else {
-              targetAgents = detected;
+              // #398: with -y (non-interactive), only update agents that ALREADY
+              // have arra skills installed. Prevents cross-contamination where
+              // /go update from Claude Code also writes to ~/.codex/skills/.
+              // First install is always interactive (no -y) so user chooses.
+              const alreadyInstalled = detected.filter((a) => {
+                const agent = agents[a as keyof typeof agents];
+                if (!agent) return false;
+                const manifestPath = join(agent.globalSkillsDir, '.arra-oracle-skills.json');
+                return existsSync(manifestPath);
+              });
+              targetAgents = alreadyInstalled.length > 0 ? alreadyInstalled : detected;
             }
           }
 

--- a/src/cli/installer.ts
+++ b/src/cli/installer.ts
@@ -802,12 +802,21 @@ Execute the \`${skill.name}\` skill with args: \`$ARGUMENTS\`
       }
     }
 
-    // Codex 0.128.0+: install plugin marketplace bundle in addition to skills/+prompts/
-    // The old ~/.codex/skills/ + ~/.codex/prompts/ layout is kept for backward compat
-    // with Codex < 0.128.0, but 0.128.0+ requires the plugin marketplace registration.
-    if (agentName === 'codex' && isCodexPluginMarketplace()) {
-      await installCodexPluginMarketplace(agentSkillsToInstall, pkg.version, shellMode);
-      p.log.success(`Codex plugin marketplace: ${getCodexMarketplaceDir()}`);
+    // Codex: skip marketplace + plugin cache — write to ~/.codex/skills/ ONLY.
+    // The marketplace bundle + cache caused triple-duplicate autocomplete entries
+    // (skills/ + marketplace/ + cache/ all visible to Codex). Skills-only is clean.
+    // Clean up stale marketplace/cache from prior installs.
+    if (agentName === 'codex') {
+      const marketplaceDir = getCodexMarketplaceDir();
+      const cacheDir = getCodexPluginCacheDir();
+      if (existsSync(marketplaceDir)) {
+        await rm(marketplaceDir, { recursive: true, force: true });
+        p.log.info('Cleaned stale Codex marketplace bundle');
+      }
+      if (existsSync(cacheDir)) {
+        await rm(cacheDir, { recursive: true, force: true });
+        p.log.info('Cleaned stale Codex plugin cache');
+      }
     }
 
     p.log.success(`${agent.displayName}: ${targetDir}`);

--- a/src/skills/dig/scripts/dig.py
+++ b/src/skills/dig/scripts/dig.py
@@ -55,7 +55,7 @@ def build_repo_map():
         r = subprocess.run(['ghq', 'list', '-p'], capture_output=True, text=True, timeout=5)
         for path in r.stdout.strip().split('\n'):
             if path:
-                mapping[path.replace('/', '-')] = path.split('/')[-1]
+                mapping[path.replace('/', '-').replace('.', '-')] = path.split('/')[-1]
     except:
         pass
     return mapping

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -9,18 +9,22 @@ argument-hint: "[--quick | --detail | --deep]"
 > "Reflect to grow, document to remember."
 
 ```
-/rrr                      # Retro with session timeline (dig-powered)
-/rrr --quick              # No dig — memory-only, faster but no timeline after compaction
-/rrr --detail             # Full template + dig timeline
+/rrr                      # Retro + 1 background dig subagent (parallel, fast)
+/rrr --quick              # No dig, no subagent — memory only (fastest)
+/rrr --detail             # Full template + background dig
 /rrr --deep               # 5 parallel subagents
 /rrr --deep --teammate    # 3 coordinated team agents (requires AGENT_TEAMS)
 ```
 
-**Default mode always mines session .jsonl for timeline** — survives compaction, shows real timestamps.
-`--quick` skips dig for speed when you don't need the timeline.
+**Default mode**: main agent starts writing the retro immediately from conversation memory.
+One background subagent runs dig + .jsonl timestamp extraction in parallel.
+When the subagent returns, main agent merges real timestamps into the Timeline section.
+**No speed penalty** — dig runs while you write.
 
-**NEVER spawn subagents or use the Task tool. Only `--deep` and `--deep --teammate` may use subagents.**
-**`/rrr`, `/rrr --quick`, `/rrr --detail` = main agent only. Zero subagents. Zero Task calls.**
+`--quick` skips dig entirely — memory only, zero subagents.
+
+**Subagent rules**: default /rrr spawns exactly 1 background Agent (dig miner). `--deep` spawns 5. `--quick` spawns 0.
+**NEVER use the Task tool.** Only `--deep` and `--deep --teammate` use TeamCreate.
 
 ---
 
@@ -53,58 +57,47 @@ All paths below use `$PSI/` instead of bare `ψ/`.
 
 ---
 
-## /rrr (Default — dig-powered)
+## /rrr (Default — background dig + parallel write)
 
-### 1. Gather + Mine Session Timeline
-
-Run git context AND dig in one step:
+### 1. Gather git context (main agent)
 
 ```bash
 date "+%H:%M %Z (%A %d %B %Y)"
 git log --oneline -10 && git diff --stat HEAD~5
 ```
 
-Detect session + mine timeline from .jsonl:
+Detect session ID:
 
 ```bash
 ENCODED_PWD=$(echo "$ORACLE_ROOT" | sed 's|^/|-|; s|[/.]|-|g')
 PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
-export PROJECT_DIRS="$PROJECT_BASE"
-
-# Strip -wt* suffix to find parent project dir
-PARENT_ENCODED=$(echo "$ENCODED_PWD" | sed 's/-wt-[^/]*$//')
-if [ "$PARENT_ENCODED" != "$ENCODED_PWD" ]; then
-  PARENT_BASE=$(ls -d "$HOME/.claude/projects/${PARENT_ENCODED}" 2>/dev/null | head -1)
-  [ -n "$PARENT_BASE" ] && export PROJECT_DIRS="$PROJECT_DIRS:$PARENT_BASE"
-fi
-
-# nullglob-safe worktree scan
-for base in "$PROJECT_BASE" "$PARENT_BASE"; do
-  [ -z "$base" ] && continue
-  for wt in "$base"-wt-*(N); do
-    [ -d "$wt" ] && export PROJECT_DIRS="$PROJECT_DIRS:$wt"
-  done
-done
-
-python3 ~/.claude/skills/dig/scripts/dig.py 0 --deep
+LATEST_JSONL=$(ls -t "$PROJECT_BASE"/*.jsonl 2>/dev/null | head -1)
+[ -n "$LATEST_JSONL" ] && SESSION_ID=$(basename "$LATEST_JSONL" .jsonl) && echo "SESSION: ${SESSION_ID:0:8}"
 ```
 
-Extract session ID + mine REAL message timestamps from the .jsonl:
-```bash
-LATEST_JSONL=$(ls -t "$PROJECT_BASE"/*.jsonl 2>/dev/null | head -1)
-if [ -n "$LATEST_JSONL" ]; then
-  SESSION_ID=$(basename "$LATEST_JSONL" .jsonl)
-  echo "SESSION: ${SESSION_ID:0:8}"
-fi
+### 1.5. Spawn timestamp miner (background subagent)
 
-# REQUIRED: extract real timestamps for the Timeline section.
-# Pull every real user message + its timestamp from the session file.
-# Dig gives session-level data only — for sub-session timestamps we read the jsonl directly.
-python3 - <<'PYEOF'
+Spawn ONE background Agent to extract real timestamps from the session .jsonl:
+
+```
+Agent({
+  name: "timestamp-miner",
+  description: "Extract session timestamps for /rrr",
+  run_in_background: true,
+  prompt: `Extract real user message timestamps from a Claude Code session file.
+Read-only — do NOT write files.
+
+Run this single command:
+
+ENCODED_PWD=$(echo "[ORACLE_ROOT]" | sed 's|^/|-|; s|[/.]|-|g')
+PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head -1)
+LATEST_JSONL=$(ls -t "$PROJECT_BASE"/*.jsonl 2>/dev/null | head -1)
+echo "SESSION_FILE: $LATEST_JSONL"
+python3 -c "
 import json, os
 from datetime import datetime, timezone, timedelta
 tz = timezone(timedelta(hours=7))
-jsonl = os.environ.get('LATEST_JSONL', '')
+jsonl = '$LATEST_JSONL'
 if not jsonl or not os.path.exists(jsonl): exit(0)
 with open(jsonl) as f:
     for line in f:
@@ -118,44 +111,20 @@ with open(jsonl) as f:
                         content = c.get('text', ''); break
             if not isinstance(content, str): continue
             ts = m.get('timestamp', '')
-            # Skip tool-result / system messages
-            if not ts or '<command-name>' in content[:200] or content.startswith('<bash-'): continue
+            if not ts or '<command-name>' in content[:200]: continue
             dt = datetime.fromisoformat(ts.replace('Z', '+00:00')).astimezone(tz)
-            snippet = content[:100].replace(chr(10), ' ')
-            print(f"{dt.strftime('%Y-%m-%d %H:%M')} | {snippet}")
+            snippet = content[:80].replace(chr(10), ' ')
+            print(f'{dt.strftime(\"%Y-%m-%d %H:%M\")} | {snippet}')
         except: pass
-PYEOF
+"
+
+Return ALL output lines. The main agent will use them for the Timeline.`
+})
 ```
 
-**RULES for the Timeline section**:
+**Why only .jsonl, not dig.py**: the subagent has no conversation context — it can't interpret dig session summaries. The .jsonl timestamps are objective data (real ISO timestamps from every user message). That's all we need for the Timeline.
 
-1. **REAL timestamps only** — pulled from this jsonl extraction, never "approx" or memory-guesses. If extraction is empty (no session file), say so explicitly in the timeline rather than inventing times.
-
-2. **Date once in a header, time-only in rows** — when all entries are same-day, format like this:
-
-   ```markdown
-   ## Timeline
-
-   **Date**: 2026-05-14 (GMT+7) · all times same-day
-
-   | Time | What |
-   |---|---|
-   | 20:14 | User: "..." |
-   | 20:21 | PR #379 merged |
-   | 21:13 | User: "..." |
-   ```
-
-   Do NOT repeat `2026-05-14 20:14` on every row. The date belongs in the header.
-
-3. **Multi-day session** — if entries span more than one day, group by day with a `### YYYY-MM-DD` subheader for each day, then `HH:MM` rows under it.
-
-Include in retrospective header:
-```
-📡 Session: 74c32f34 | repo-name | Xh XXm
-```
-If dig or session detection fails, skip silently and continue with git-only context.
-
-### 2. Write Retrospective with Timeline
+### 2. Write Retrospective (main agent — start immediately, don't wait for dig)
 
 **Path**: `$PSI/memory/retrospectives/YYYY-MM/DD/HH.MM_slug.md`
 
@@ -163,7 +132,35 @@ If dig or session detection fails, skip silently and continue with git-only cont
 mkdir -p "$PSI/memory/retrospectives/$(date +%Y-%m/%d)"
 ```
 
-Write immediately, no prompts. Build the Timeline section from the .jsonl extraction above — every row must have a real `YYYY-MM-DD HH:MM` timestamp. Never use "approx", "around", or memory-guessed times. Include:
+**Start writing NOW from conversation memory.** Draft all sections. When the dig-miner subagent returns (background notification), merge its timestamp data into the Timeline section.
+
+### Timeline format rules
+
+1. **Use dig-miner timestamps when available** — real `HH:MM` from .jsonl extraction. If dig-miner hasn't returned yet or failed, write `[timestamps pending from dig-miner]` and fill in when it returns.
+
+2. **Date once in header, time-only in rows** — same-day sessions:
+
+   ```markdown
+   ## Timeline
+
+   **Date**: 2026-05-14 (GMT+7)
+
+   | Time | What |
+   |---|---|
+   | 20:14 | User: "..." |
+   | 20:21 | PR #379 merged |
+   ```
+
+3. **Multi-day session** — group by `### YYYY-MM-DD` subheader, `HH:MM` rows under each.
+
+4. **Never invent timestamps.** If dig-miner fails, say "timestamps unavailable" — don't guess.
+
+Include in retrospective header:
+```
+📡 Session: 74c32f34 | repo-name | Xh XXm
+```
+
+**Write immediately, no prompts.** Include:
 - Session Summary
 - Timeline (real timestamps from .jsonl mining — `YYYY-MM-DD HH:MM | what`)
 - Files Modified

--- a/src/skills/team-agents/SKILL.md
+++ b/src/skills/team-agents/SKILL.md
@@ -79,18 +79,20 @@ Exit code 2 from any hook = reject action + send feedback to agent.
 
 ## When to Use
 
-| Tier | When | Tools |
-|------|------|-------|
-| **Subagents** | < 3 agents, independent work | Agent tool |
-| **Team Agents** | 3-5 agents, need coordination | TeamCreate + SendMessage + TaskList |
-| **Cross-Oracle** | Inter-session, multi-repo | /talk-to + contacts |
+| Context | What happens |
+|---------|-------------|
+| **User types `/team-agents`** | Always Tier 1 (tmux) or Tier 2 (in-process). Never downgrade. |
+| **Agent tool without `/team-agents`** | AI spawns subagents directly — no tmux, no TeamCreate. |
+| **Cross-Oracle messaging** | Use /talk-to + contacts, not team-agents. |
 
-**Rule**: 2 independent agents → subagents. Coordinated work → team-agents.
+**Rule**: `/team-agents` = tmux panes. Plain `Agent()` = quiet subagents. The user's choice of invocation decides the tier.
 **Sizing**: 3-5 teammates, 5-6 tasks each. Tokens scale linearly per teammate.
 
 ### Spawn Fallback Order
 
-When the user asks for `/team-agents`, try in this order. Stop at the first tier whose preflight passes — don't skip ahead.
+When the user explicitly invokes `/team-agents`, they want tmux panes. **Never downgrade to Tier 3 when Tier 1 or 2 preflight passes** — even for "read-only" or "simple" tasks. The user typed `/team-agents` because they want to SEE agents working. If they wanted quiet subagents, they'd just ask without the skill.
+
+Try tiers in order. Stop at the first whose preflight passes — **never skip ahead**.
 
 #### Tier 1 — tmux + team-agents framework (preferred)
 
@@ -109,9 +111,9 @@ All four pass → real team. Teammates spawn into **split tmux panes** with isol
 
 env var + tools present but `$TMUX` empty → set `teammateMode: "in-process"` (per-session: `claude --teammate-mode in-process`) and proceed with TeamCreate. All teammates run in the main terminal — cycle with `Shift+Down`, view with `Enter`. Same coordination machinery, less visual separation.
 
-#### Tier 3 — parallel subagents (Agent tool, graceful fallback)
+#### Tier 3 — parallel subagents (Agent tool, ONLY when preflight fails)
 
-env var missing, tools didn't load, version too old, or task is read-only multi-lens analysis → fall back to plain `Agent` tool calls.
+env var missing, tools didn't load, or version too old → fall back to plain `Agent` tool calls. **Never choose Tier 3 because the task "seems simple" or "read-only" — that's the user's call, not yours.**
 
 - Spawn N parallel `Agent` calls in a **single message** — same role prompts, no SendMessage/TaskUpdate
 - Each agent returns its report as the tool result
@@ -123,14 +125,14 @@ env var missing, tools didn't load, version too old, or task is read-only multi-
 | Cheaper — no heartbeats, no mailbox archiving | No task dependencies (all spawn at once, parallel only) |
 | Simpler for read-only analysis | No per-agent worktree (agents share main repo state) |
 
-**Best for**: read-only multi-lens analysis (≤5 lenses, no shared-file writes). Downstream skills that wrap parallel reads should target Tier 3 by default and only escalate to Tier 1/2 when peer coordination or per-agent writes are actually needed.
+**Only used when**: Tier 1/2 preflight fails (no tmux, no env var, CLI too old). Never chosen based on task complexity — `/team-agents` means the user wants the full framework.
 
 #### Decision rule
 
-> Framework (Tier 1/2) when **coordination matters** — sequencing, file writes, peer messaging, worktrees.
-> Subagents (Tier 3) when **angles don't need to talk to each other**.
+> `/team-agents` = user wants tmux panes. Period.
+> Tier 3 is a **fallback for broken environments**, not an optimization for simple tasks.
 
-If unsure, run the preflight. If Tier 1 passes, use it — the cost is per-teammate tokens, which the user opted into by saying `/team-agents`.
+If Tier 1 preflight passes → use Tier 1. Always. The user opted into the token cost by typing `/team-agents`.
 
 ### Subagent Definitions
 


### PR DESCRIPTION
Promote alpha to main. Carries:
- #396 team-agents no downgrade
- #397 dig repo map fix
- #399 single-agent update (#398)
- #401 rrr background dig
- #403 Codex skills-only (triple-duplicate fix)

Note: v26.5.15 tag exists from earlier today. CalVer will need tomorrow for v26.5.16, or a manual tag.