### PR TITLE
feat: mark release-alpha + release-beta as secret skills

### DIFF
--- a/src/skills/release-alpha/SKILL.md
+++ b/src/skills/release-alpha/SKILL.md
@@ -2,6 +2,7 @@
 name: release-alpha
 description: "Cut an alpha pre-release — bump CalVer, PR to alpha branch, CI auto-tags + publishes to npm @alpha. Use when user says 'release alpha', 'cut alpha', '/release-alpha', or wants to publish an alpha version."
 argument-hint: ""
+secret: true
 ---
 
 # /release-alpha

--- a/src/skills/release-beta/SKILL.md
+++ b/src/skills/release-beta/SKILL.md
@@ -2,6 +2,7 @@
 name: release-beta
 description: "Cut a beta pre-release — bump CalVer with --beta, PR to beta branch, CI auto-tags + publishes to npm @beta. Use when user says 'release beta', 'cut beta', '/release-beta', or wants to publish a beta version for pre-release testing."
 argument-hint: ""
+secret: true
 ---
 
 # /release-beta


### PR DESCRIPTION
Adds `secret: true` to frontmatter. Discoverable via `/go find release`, installable by name.