### PR TITLE
release: alpha → main for v26.5.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 ```bash
 # Claude Code — standard profile (default)
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y --agent claude-code
 
 # Full profile (all skills)
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y -p full --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y -p full --agent claude-code
 
 # Lab profile (full + experimental)
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y -p lab --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y -p lab --agent claude-code
 
 # Specific skills only
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y -s recap rrr trace --agent claude-code
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y -s recap rrr trace --agent claude-code
 
 # Other agents (skills + commands)
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent codex --with-commands
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent opencode --with-commands
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent cursor
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent gemini-cli --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y --agent codex --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y --agent opencode --with-commands
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y --agent cursor
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y --agent gemini-cli --with-commands
 
 # Multiple agents
-npx arra-oracle-skills@26.5.15-alpha.1342 install -g -y --agent claude-code codex opencode
+npx arra-oracle-skills@26.5.15-alpha.1631 install -g -y --agent claude-code codex opencode
 
 # thClaws (federated agent — explicit opt-in)
 bunx arra-oracle-skills@github:Soul-Brews-Studio/arra-oracle-skills-cli install -y -g --with-thclaws
@@ -44,10 +44,10 @@ By default (no `-g` flag), skills install to the current project's `.claude/skil
 
 ```bash
 # Local install (current project)
-npx arra-oracle-skills@26.5.15-alpha.1342 install -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1631 install -a claude-code -s trace -y
 
 # Same with explicit -l flag (symmetric to -g)
-npx arra-oracle-skills@26.5.15-alpha.1342 install -l -a claude-code -s trace -y
+npx arra-oracle-skills@26.5.15-alpha.1631 install -l -a claude-code -s trace -y
 ```
 
 Use when:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.5.15-alpha.1342",
+  "version": "26.5.15-alpha.1631",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {

--- a/src/skills/release-alpha/SKILL.md
+++ b/src/skills/release-alpha/SKILL.md
@@ -2,6 +2,7 @@
 name: release-alpha
 description: "Cut an alpha pre-release — bump CalVer, PR to alpha branch, CI auto-tags + publishes to npm @alpha. Use when user says 'release alpha', 'cut alpha', '/release-alpha', or wants to publish an alpha version."
 argument-hint: ""
+secret: true
 ---
 
 # /release-alpha

--- a/src/skills/release-beta/SKILL.md
+++ b/src/skills/release-beta/SKILL.md
@@ -2,6 +2,7 @@
 name: release-beta
 description: "Cut a beta pre-release — bump CalVer with --beta, PR to beta branch, CI auto-tags + publishes to npm @beta. Use when user says 'release beta', 'cut beta', '/release-beta', or wants to publish a beta version for pre-release testing."
 argument-hint: ""
+secret: true
 ---
 
 # /release-beta


### PR DESCRIPTION
## Summary
- Merge alpha into main for stable v26.5.16 cut
- Includes #407 (secret release skills) and #408 (alpha bump)

## After merge
- `bun scripts/calver.ts --stable` on main
- CI auto-tags + publishes to npm @latest

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle