### PR TITLE
fix(skills): trim workflow/mode enumeration from 5 descriptions

### DIFF
--- a/src/skills/calver/SKILL.md
+++ b/src/skills/calver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: calver
-description: Show or bump CalVer version via bun scripts/calver.ts in arra-oracle-skills-cli. Default is dry-run --check. Read-only by default; `--apply` writes package.json. **For full release flow (commit + push + PR), use /release-alpha or /release-stable instead** — /calver alone never commits, pushes, or PRs.
+description: Show or bump the project's CalVer version. Use when user says "calver", "bump version", "what version", or wants to check or set the skills version. For the full release flow (commit + push + PR) use /release-alpha or /release-stable instead — /calver alone never commits, pushes, or PRs.
 ---
 
 # /calver

--- a/src/skills/forward/SKILL.md
+++ b/src/skills/forward/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forward
-description: Create handoff + enter plan mode for next session. Use when user says "forward", "handoff", "wrap up", or before ending session.
+description: Hand off the current session to the next one. Use when user says "forward", "handoff", "wrap up", or before ending a session.
 argument-hint: "[asap | --only]"
 ---
 

--- a/src/skills/incubate/SKILL.md
+++ b/src/skills/incubate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: incubate
-description: Clone or create repos for active development — the right hand of /learn. Workflow modes — default (long-term dev), --flash (issue → PR → offload), --contribute (fork + multi-PR). Use when user says "incubate [repo]", "work on [repo]", "clone for dev", or wants to set up a dev workflow. Do NOT trigger for study/exploration (use /learn), finding projects (use /trace), or session mining (use /dig).
+description: Clone or create repos for active development — the right hand of /learn. Use when user says "incubate [repo]", "work on [repo]", "clone for dev", or wants to set up a dev workflow. Do NOT trigger for study/exploration (use /learn), finding projects (use /trace), or session mining (use /dig).
 argument-hint: "<repo-url|slug|name> [--flash | --contribute | --status | --offload]"
 ---
 

--- a/src/skills/oracle-family-scan/SKILL.md
+++ b/src/skills/oracle-family-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oracle-family-scan
-description: Oracle Family Registry — scan, query, welcome. 186+ Oracles indexed. Use when user says "family scan", "oracle registry", "welcome new oracles", or needs to check Oracle population.
+description: Oracle Family Registry — the index of all known Oracles (186+). Use when user says "family scan", "oracle registry", "welcome new oracles", or needs to check Oracle population.
 argument-hint: "[--scan | --query <name> | --welcome | --activity-report | --timeline | --usage | --calibrate]"
 ---
 

--- a/src/skills/project/SKILL.md
+++ b/src/skills/project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project
-description: Clone and track external repos. Use when user shares GitHub URL to study or develop, or says "search repos", "find repo", "where is [project]". Actions - learn (clone for study), search/find (search repos), list (show tracked). For active development, use /incubate.
+description: Clone and track external repos. Use when user shares a GitHub URL to study or develop, or says "search repos", "find repo", "where is [project]". For active development, use /incubate.
 argument-hint: "<github-url> | search <query>"
 ---
 


### PR DESCRIPTION
description ควรบอก "ใช้เมื่อไร" ไม่ใช่สรุป workflow — เมื่อ description แจกแจงขั้นตอน/mode/action, agent มักทำตาม description แล้วลัด body. แก้: calver, incubate, forward, project, oracle-family-scan (flag รายละเอียดยังอยู่ใน argument-hint + body ครบ)