### PR TITLE
fix(rrr): use UTF-8 encoding when reading JSONL on Windows Thai locale

### DIFF
--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -99,7 +99,7 @@ from datetime import datetime, timezone, timedelta
 tz = timezone(timedelta(hours=7))
 jsonl = '$LATEST_JSONL'
 if not jsonl or not os.path.exists(jsonl): exit(0)
-with open(jsonl) as f:
+with open(jsonl, encoding='utf-8') as f:
     for line in f:
         try:
             m = json.loads(line)

--- a/src/skills/rrr/SKILL.md
+++ b/src/skills/rrr/SKILL.md
@@ -94,7 +94,8 @@ PROJECT_BASE=$(ls -d "$HOME/.claude/projects/${ENCODED_PWD}" 2>/dev/null | head 
 LATEST_JSONL=$(ls -t "$PROJECT_BASE"/*.jsonl 2>/dev/null | head -1)
 echo "SESSION_FILE: $LATEST_JSONL"
 python3 -c "
-import json, os
+import json, os, sys
+sys.stdout.reconfigure(encoding='utf-8')  # Windows Thai locale: stdout defaults to cp874 -> Thai snippets mojibake; force UTF-8 output
 from datetime import datetime, timezone, timedelta
 tz = timezone(timedelta(hours=7))
 jsonl = '$LATEST_JSONL'


### PR DESCRIPTION
## Problem

On Windows with Thai locale (cp874/TIS-620), Python's `open()` defaults to the system encoding. Reading UTF-8 JSONL files causes Thai text to be garbled in the `/rrr` timeline section.

The timestamps are still correct — only Thai message content is affected.

## Fix

One-line change in the timestamp miner script:

```python
# before
with open(jsonl) as f:

# after
with open(jsonl, encoding='utf-8') as f:
```

## Tested on

- Windows 11, Thai locale (cp874) — Thai text now renders correctly in timeline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)