### PR TITLE
feat: sync skills with Oracle v3 phase 1 APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-35 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+36 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -64,7 +64,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>35 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>36 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -93,18 +93,19 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 21 | **inbox** | skill | Read and write to Oracle inbox |
 | 22 | **incubate** | skill | Clone or create repos for active development |
 | 23 | **mailbox** | skill | 'Persistent agent mailbox |
-| 24 | **release-alpha** | skill | "Cut an alpha pre-release |
-| 25 | **release-beta** | skill | "Cut a beta pre-release |
-| 26 | **resonance** | skill | Capture a resonance moment |
-| 27 | **standup** | skill | Daily standup check |
-| 28 | **talk-to** | skill | Talk to another Oracle agent |
-| 29 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 30 | **trace** | skill | Find projects, code |
-| 31 | **watch** | skill | 'Extract YouTube video transcripts |
-| 32 | **where-we-are** | skill | Session awareness |
-| 33 | **who-are-you** | skill | Know ourselves |
-| 34 | **worktree** | skill | 'Work in an isolated git worktree |
-| 35 | **xray** | skill | X-ray deep scan |
+| 24 | **oracle-up** | skill | '[standard] G-SKLL | Bring up a Docker-first |
+| 25 | **release-alpha** | skill | "Cut an alpha pre-release |
+| 26 | **release-beta** | skill | "Cut a beta pre-release |
+| 27 | **resonance** | skill | Capture a resonance moment |
+| 28 | **standup** | skill | Daily standup check |
+| 29 | **talk-to** | skill | Talk to another Oracle agent |
+| 30 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 31 | **trace** | skill | Find projects, code |
+| 32 | **watch** | skill | 'Extract YouTube video transcripts |
+| 33 | **where-we-are** | skill | Session awareness |
+| 34 | **who-are-you** | skill | Know ourselves |
+| 35 | **worktree** | skill | 'Work in an isolated git worktree |
+| 36 | **xray** | skill | X-ray deep scan |
 
 </details>
 
@@ -118,8 +119,8 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 |---------|-------|--------|
 | **minimal** | 6 | `about-oracle`, `forward`, `go`, `recap`, `rrr`, `trace` |
 | **standard** | 12 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace` |
-| **full** | 35 | all |
-| **lab** | 35 | all |
+| **full** | 36 | all |
+| **lab** | 36 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/src/commands/about-oracle.md
+++ b/src/commands/about-oracle.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | What is Oracle — told by the AI itself. Origin story, stats, family count, ecosystem overview. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story. Do NOT trigger for "who are you" (use /who-are-you), "philosophy" (use /philosophy), or session status questions.'
+description: '[core] v26.5.16 | What is Oracle — told by the AI itself. Origin story, stats, family count, ecosystem overview. Use when someone asks "what is oracle", "about oracle", "tell me about this project", or wants the origin story. Do NOT trigger for "who are you" (use /who-are-you), "philosophy" (use /philosophy), or session status questions.'
 argument-hint: "--short | --stats | --family | --th | --en/th"
 ---
 
@@ -19,5 +19,5 @@ Execute the `about-oracle` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "about-oracle" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/awaken.md
+++ b/src/commands/awaken.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | "Guided Oracle birth and awakening ritual. Default is Soul Sync (~20min), or --fast (~5min). Use when creating a new Oracle in a fresh repo, when user says ''awaken'', ''birth oracle'', ''create oracle'', ''new oracle'', or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context."'
+description: '[core] v26.5.16 | "Guided Oracle birth and awakening ritual. Default is Soul Sync (~20min), or --fast (~5min). Use when creating a new Oracle in a fresh repo, when user says ''awaken'', ''birth oracle'', ''create oracle'', ''new oracle'', or wants to set up Oracle identity in an empty repository. Do NOT trigger for general repo setup, git init, or project scaffolding without Oracle context."'
 argument-hint: "[--fast | --soul-sync | --reawaken]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `awaken` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "awaken" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/forward.md
+++ b/src/commands/forward.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Create handoff + enter plan mode for next session. Use when user says "forward", "handoff", "wrap up", or before ending session.'
+description: '[core] v26.5.16 | Create handoff + enter plan mode for next session. Use when user says "forward", "handoff", "wrap up", or before ending session.'
 argument-hint: "[asap | --only]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `forward` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "forward" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/go.md
+++ b/src/commands/go.md
@@ -1,6 +1,6 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Switch skill profiles (standard/full/lab), fresh install, or enable/disable specific skills via arra-oracle-skills CLI. Destructive — modifies globally installed skills.'
-argument-hint: "<standard|full|lab|cleanup> | enable|disable <skill...>"
+description: '[core] v26.5.16 | Manage Oracle skills — list, install, remove, find, switch profiles, update. Use when user says "go", "install skill", "remove skill", "find skill", "switch profile", "go list", "go update", "go install", "go find". Single entry point for all skill management.'
+argument-hint: "[list] | <standard|full|lab|cleanup|update> | install|remove|find <skill...>"
 ---
 
 # /go
@@ -19,5 +19,5 @@ Execute the `go` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "go" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/learn.md
+++ b/src/commands/learn.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Explore a codebase with parallel Haiku agents — clone, read, and document. Modes — --fast (1 agent), default (3), --deep (5). Use when user says "learn [repo]", "explore codebase", "study this repo", or shares a GitHub URL to study. Do NOT trigger for finding projects (use /trace), session mining (use /dig), or cloning for active development (use /incubate).'
+description: '[core] v26.5.16 | Explore a codebase with parallel Haiku agents — clone, read, and document. Modes — --fast (1 agent), default (3), --deep (5). Use when user says "learn [repo]", "explore codebase", "study this repo", or shares a GitHub URL to study. Do NOT trigger for finding projects (use /trace), session mining (use /dig), or cloning for active development (use /incubate).'
 argument-hint: "<repo-url> [--fast | --deep]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `learn` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "learn" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/oracle-family-scan.md
+++ b/src/commands/oracle-family-scan.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Oracle Family Registry — scan, query, welcome. 186+ Oracles indexed. Use when user says "family scan", "oracle registry", "welcome new oracles", or needs to check Oracle population.'
+description: '[core] v26.5.16 | Oracle Family Registry — scan, query, welcome. 186+ Oracles indexed. Use when user says "family scan", "oracle registry", "welcome new oracles", or needs to check Oracle population.'
 argument-hint: "[--scan | --query <name> | --welcome | --activity-report | --timeline | --usage | --calibrate]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `oracle-family-scan` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "oracle-family-scan" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/oracle-up.md
+++ b/src/commands/oracle-up.md
@@ -1,0 +1,23 @@
+---
+description: '[core] v26.5.16 | ''[standard] G-SKLL | Bring up a Docker-first Oracle node with skills, MCP, maw/omx team tooling, Simple Mode, folder mining, and ask smoke. Use when user says "oracle-up", "bring up an oracle", "new oracle node", or wants a fresh self-sufficient oracle on a remote machine.'''
+argument-hint: "<name> --host <host> --user <user> [--port N] [--mirror nat] [--apply]"
+---
+
+# /oracle-up
+
+Execute the `oracle-up` skill with the provided arguments.
+
+## Instructions
+
+**If you have a Skill tool available**: Use it directly with `skill: "oracle-up"` instead of reading the file manually.
+
+**Otherwise**:
+1. Read the skill file at this exact path: `~/.claude/skills/oracle-up/SKILL.md`
+2. Follow all instructions in the skill file
+3. Pass these arguments to the skill: `$ARGUMENTS`
+
+**WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "oracle-up" in the name are NOT this skill.
+
+---
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
+*Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/project.md
+++ b/src/commands/project.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Clone and track external repos. Use when user shares GitHub URL to study or develop, or says "search repos", "find repo", "where is [project]". Actions - learn (clone for study), search/find (search repos), list (show tracked). For active development, use /incubate.'
+description: '[core] v26.5.16 | Clone and track external repos. Use when user shares GitHub URL to study or develop, or says "search repos", "find repo", "where is [project]". Actions - learn (clone for study), search/find (search repos), list (show tracked). For active development, use /incubate.'
 argument-hint: "<github-url> | search <query>"
 ---
 
@@ -19,5 +19,5 @@ Execute the `project` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "project" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/recap.md
+++ b/src/commands/recap.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Session orientation and awareness — retro summaries, handoffs, git state, focus. Use when starting a session, after /jump, lost your place, switching context, or when user asks "now", "where are we", "what are we doing", "status", "recap". Do NOT trigger for "standup" or "morning check" (use /standup), or session mining "dig", "past sessions" (use /dig).'
+description: '[core] v26.5.16 | Session orientation and awareness — retro summaries, handoffs, git state, focus. Use when starting a session, after /jump, lost your place, switching context, or when user asks "now", "where are we", "what are we doing", "status", "recap". Do NOT trigger for "standup" or "morning check" (use /standup), or session mining "dig", "past sessions" (use /dig).'
 argument-hint: "[--now | --deep]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `recap` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "recap" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/schedule.md
+++ b/src/commands/schedule.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Query schedule via Oracle API (Drizzle DB). Use when user says "schedule", "upcoming events", "what''s on today", "calendar".'
+description: '[core] v26.5.16 | Query schedule via Oracle API (Drizzle DB). Use when user says "schedule", "upcoming events", "what''s on today", "calendar".'
 argument-hint: "[today | tomorrow | week]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `schedule` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "schedule" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/standup.md
+++ b/src/commands/standup.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Daily standup check — pending tasks, appointments, recent progress, schedule. Use when user says "standup", "morning check", "what''s pending", or at the start of a work day. Do NOT trigger for mid-session status (use /recap --now), session orientation (use /recap), or retrospectives (use /rrr).'
+description: '[core] v26.5.16 | Daily standup check — pending tasks, appointments, recent progress, schedule. Use when user says "standup", "morning check", "what''s pending", or at the start of a work day. Do NOT trigger for mid-session status (use /recap --now), session orientation (use /recap), or retrospectives (use /rrr).'
 ---
 
 # /standup
@@ -18,5 +18,5 @@ Execute the `standup` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "standup" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/talk-to.md
+++ b/src/commands/talk-to.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Talk to another Oracle agent via contacts + threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent (e.g. "talk to pulse", "message neo"). Do NOT trigger for OracleNet social feed (use /oraclenet), skill management (use /oracle), or family registry (use /oracle-family-scan).'
+description: '[core] v26.5.16 | Talk to another Oracle agent via contacts + threads. Use when user says "talk to", "message", "chat with", or wants to communicate with another agent (e.g. "talk to pulse", "message neo"). Do NOT trigger for OracleNet social feed (use /oraclenet), skill management (use /oracle), or family registry (use /oracle-family-scan).'
 argument-hint: "<agent-name> [message] [--maw | --thread | --inbox]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `talk-to` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "talk-to" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/trace.md
+++ b/src/commands/trace.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (wave execution), --deep --dig (combo). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).'
+description: '[core] v26.5.16 | Find projects, code, and knowledge across git history, repos, docs, and Oracle. Use when user asks "trace", "find project", "where is [project]", "search history", or needs to locate something across the codebase. Supports --oracle (fast), --smart (default), --deep (wave execution), --deep --dig (combo). Do NOT trigger for session mining or "past sessions" (use /dig), or codebase exploration "learn repo" (use /learn).'
 argument-hint: "<query> [--oracle | --smart | --deep] [--dig]"
 ---
 
@@ -19,5 +19,5 @@ Execute the `trace` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "trace" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/where-we-are.md
+++ b/src/commands/where-we-are.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Session awareness — alias for /recap --now deep. Quick mid-session check of current topic, timeline, and pending items. Use when user asks "now", "where are we", "what are we doing". Do NOT trigger for full session start orientation (use /recap), "standup" (use /standup), or past session mining (use /dig).'
+description: '[core] v26.5.16 | Session awareness — alias for /recap --now deep. Quick mid-session check of current topic, timeline, and pending items. Use when user asks "now", "where are we", "what are we doing". Do NOT trigger for full session start orientation (use /recap), "standup" (use /standup), or past session mining (use /dig).'
 ---
 
 # /where-we-are
@@ -18,5 +18,5 @@ Execute the `where-we-are` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "where-we-are" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/who-are-you.md
+++ b/src/commands/who-are-you.md
@@ -1,5 +1,5 @@
 ---
-description: '[core] v26.5.13-alpha.1726 | Know ourselves — show current AI identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", "what model", or wants to check current AI identity and session context. Do NOT trigger for "what is oracle" (use /about-oracle), "philosophy" or "principles" (use /philosophy), or general project questions.'
+description: '[core] v26.5.16 | Know ourselves — show current AI identity, model info, session stats, and Oracle philosophy. Use when user asks "who are you", "who", "who we are", "what model", or wants to check current AI identity and session context. Do NOT trigger for "what is oracle" (use /about-oracle), "philosophy" or "principles" (use /philosophy), or general project questions.'
 ---
 
 # /who-are-you
@@ -18,5 +18,5 @@ Execute the `who-are-you` skill with the provided arguments.
 **WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "who-are-you" in the name are NOT this skill.
 
 ---
-*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.13-alpha.1726*
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
 *Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/skills/dig/SKILL.md
+++ b/src/skills/dig/SKILL.md
@@ -175,7 +175,7 @@ When `--timeline` flag is present, group sessions by date instead of a flat tabl
 After displaying the timeline, log the discovery to Oracle so it's searchable later:
 
 ```
-arra_trace({
+oracle_trace({
   query: "dig session [N]",
   project: "[repo-name]",
   foundFiles: [],

--- a/src/skills/oracle-up/SKILL.md
+++ b/src/skills/oracle-up/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: oracle-up
+description: '[standard] G-SKLL | Bring up a Docker-first Oracle node with skills, MCP, maw/omx team tooling, Simple Mode, folder mining, and ask smoke. Use when user says "oracle-up", "bring up an oracle", "new oracle node", or wants a fresh self-sufficient oracle on a remote machine.'
+argument-hint: "<name> --host <host> --user <user> [--port N] [--mirror nat] [--apply]"
+---
+
+# /oracle-up — Docker-first Oracle Node
+
+Provision a remote user, install the oracle toolchain, start Arra Oracle V3 with
+Docker, mine notes, smoke `/simple`, and verify cited ask. Dry-run by default;
+only mutate when the user explicitly includes `--apply`.
+
+## Usage
+
+```bash
+/oracle-up oracle-world-oracle --host world.wg --user oracle --port 3463
+/oracle-up oracle-world-oracle --host world.wg --user oracle --port 3463 --apply
+```
+
+Flags: positional name, `--host`, `--user`, `--port`, `--mirror`, `--org`,
+`--code-root`, `--apply`.
+
+## P0 — Preflight
+
+- Print timestamp: `date "+🕐 %H:%M %Z (%A %d %B %Y)"`.
+- Check SSH, OS, `sudo -n true`, Docker, `gh`, `maw`, Bun, and free HTTP port.
+- If sshd has `AllowUsers`, plan adding `<user>` before verifying login.
+- If `--apply` is absent, print commands only.
+
+## P1 — User and base tooling
+
+```bash
+maw user-onboard --host <host> --user <user> --sudo --mirror <mirror> --with-tooling --port <port>
+maw user-onboard --host <host> --user <user> --sudo --mirror <mirror> --with-tooling --port <port> --apply --yes
+```
+
+Then verify:
+
+```bash
+ssh <user>@<host> 'whoami && sudo -n true && docker --version'
+```
+
+If login fails with a generic publickey error, check `sshd -T | grep allowusers`.
+Avoid repeated bad verifies that can trigger fail2ban.
+
+## P2 — GitHub key
+
+```bash
+ssh <user>@<host> 'cat ~/.ssh/id_ed25519.pub' | gh ssh-key add - --title "<user>@<host>"
+```
+
+## P3 — Skills and MCP client tooling
+
+```bash
+ssh <user>@<host> 'zsh -lc "bun add -g arra-oracle-skills && arra-oracle-skills install -g -y --agent claude-code"'
+# Install omx for Codex coders by its current installer.
+```
+
+Headless Claude flags, when needed:
+
+```json
+{
+  "hasCompletedOnboarding": true,
+  "hasTrustDialogAccepted": true,
+  "projects": { "<repo>": { "hasTrustDialogAccepted": true, "hasCompletedProjectOnboarding": true } }
+}
+```
+
+## P4 — Docker-first Arra Oracle V3
+
+Create a persistent volume and run the HTTP image first. Prefer a published GHCR
+tag from `alpha`; use `:http` only when the lead says latest alpha is acceptable.
+Mount the notes folder into the running container so `arra mine` sees the same path.
+
+```bash
+ssh <user>@<host> 'zsh -lc "mkdir -p ~/notes && docker volume create arra-oracle-data >/dev/null && docker run -d --name arra-oracle --restart unless-stopped -p 47778:47778 -v arra-oracle-data:/data -v ~/notes:/home/oracle/notes:ro ghcr.io/soul-brews-studio/arra-oracle-v3:http"'
+ssh <user>@<host> 'curl -fsS http://127.0.0.1:47778/api/health'
+```
+
+Tell the human to open Simple Mode:
+
+```text
+http://<host>:47778/simple
+```
+
+## P5 — Mine notes
+
+Use the CLI bundled inside the running HTTP container so ingestion writes to
+the same Docker volume as the server:
+
+```bash
+ssh <user>@<host> 'docker exec arra-oracle bun dist-cli/index.js mine /home/oracle/notes --dry-run'
+ssh <user>@<host> 'docker exec arra-oracle bun dist-cli/index.js mine /home/oracle/notes'
+```
+
+Re-running `arra mine` is safe. Use `--watch` only for long-lived local note
+folders where the server and CLI share the same data volume.
+
+## P6 — Ask and asOf smoke
+
+Use versioned API paths and auth/tenant headers if configured:
+
+```bash
+ORACLE_API=http://127.0.0.1:47778
+curl -fsS "$ORACLE_API/api/v1/search?q=onboarding&limit=3"
+curl -fsS -X POST "$ORACLE_API/api/v1/ask" \
+  -H 'content-type: application/json' \
+  -d '{"q":"What did we mine?","limit":3,"llm":false}'
+curl -fsS -X POST "$ORACLE_API/api/v1/ask" \
+  -H 'content-type: application/json' \
+  -d '{"q":"What was true on 2026-07-01?","asOf":"2026-07-01T00:00:00Z","limit":3,"llm":false}'
+```
+
+Read the ask response out loud with citations and warnings. If `noEvidence` is
+true, say no evidence was found instead of inventing an answer.
+
+## P7 — Team files
+
+Create the repo, then commit the team charter and engine map:
+
+- `ψ/teams/<name>-team.yaml`
+- `.maw/maw.config.80.json`
+
+Spawn isolated writers with `maw wake <org>/<name> --wt coder-1 -e omx` and
+verify each pane cwd. Do not trust roster output alone.
+
+## P8 — Done report
+
+Report only after these pass:
+
+- SSH user + sudo + Docker verified.
+- `arra-oracle-skills about` works.
+- Arra Oracle health and `/simple` URL are reachable.
+- `arra mine` dry-run and real mine completed.
+- `/api/v1/ask` smoke returns citations or `noEvidence`.
+- Team panes are live and isolated.
+
+Reference: https://nazt.github.io/agents-in-parallel/ (Ch.5–8).
+
+---
+
+ARGUMENTS: $ARGUMENTS

--- a/src/skills/schedule/SKILL.md
+++ b/src/skills/schedule/SKILL.md
@@ -27,7 +27,7 @@ Run the query script:
 bun .claude/skills/schedule/scripts/query.ts [filter]
 ```
 
-The script queries `GET /api/schedule` on the Oracle HTTP server (port 47778).
+The script queries `GET /api/v1/schedule` on the Oracle HTTP server (port 47778). It uses `ORACLE_API`, `ARRA_API_TOKEN`, `X_ORACLE_TENANT`/`ORACLE_TENANT`, and `X_ORACLE_TENANT_TOKEN`/`ORACLE_TENANT_TOKEN` when present.
 
 ## Output Format
 
@@ -56,12 +56,12 @@ Rules:
 ## API Reference
 
 ```
-GET /api/schedule                         → next 14 days (pending)
-GET /api/schedule?date=2026-03-05         → specific day
-GET /api/schedule?date=today              → today
-GET /api/schedule?from=2026-03-01&to=2026-03-31  → range
-GET /api/schedule?filter=keyword          → search
-GET /api/schedule?status=all              → include done/cancelled
+GET /api/v1/schedule                         → next 14 days (pending)
+GET /api/v1/schedule?date=2026-03-05         → specific day
+GET /api/v1/schedule?date=today              → today
+GET /api/v1/schedule?from=2026-03-01&to=2026-03-31  → range
+GET /api/v1/schedule?filter=keyword          → search
+GET /api/v1/schedule?status=all              → include done/cancelled
 ```
 
 ## See Also

--- a/src/skills/schedule/scripts/oracle-http.ts
+++ b/src/skills/schedule/scripts/oracle-http.ts
@@ -1,0 +1,59 @@
+export interface OracleRequestOptions extends RequestInit {
+  query?: URLSearchParams | Record<string, string | number | boolean | undefined>;
+}
+
+const DEFAULT_ORACLE_API = 'http://localhost:47778';
+
+export function oracleApiBase(env: Record<string, string | undefined> = process.env): string {
+  return (env.ORACLE_API ?? DEFAULT_ORACLE_API).replace(/\/+$/, '');
+}
+
+export function oracleApiUrl(
+  path: string,
+  query?: OracleRequestOptions['query'],
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const normalizedPath = path
+    .replace(/^https?:\/\/[^/]+/i, '')
+    .replace(/^\/?api\/?v1\/?/i, '')
+    .replace(/^\/?api\/?/i, '')
+    .replace(/^\/+/, '');
+  const url = new URL(`/api/v1/${normalizedPath}`, oracleApiBase(env));
+  const params = query instanceof URLSearchParams ? query : new URLSearchParams();
+  if (query && !(query instanceof URLSearchParams)) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) params.set(key, String(value));
+    }
+  }
+  for (const [key, value] of params) url.searchParams.set(key, value);
+  return url.toString();
+}
+
+export function oracleHeaders(
+  extra?: HeadersInit,
+  env: Record<string, string | undefined> = process.env,
+): Headers {
+  const headers = new Headers(extra);
+  const token = env.ARRA_API_TOKEN ?? env.ORACLE_API_TOKEN;
+  const tenant = env.X_ORACLE_TENANT ?? env.ORACLE_TENANT ?? env.ARRA_TENANT;
+  const tenantToken = env.X_ORACLE_TENANT_TOKEN ?? env.ORACLE_TENANT_TOKEN ?? env.ARRA_TENANT_TOKEN;
+  if (token && !headers.has('authorization')) headers.set('authorization', `Bearer ${token}`);
+  if (tenant && !headers.has('x-oracle-tenant')) headers.set('x-oracle-tenant', tenant);
+  if (tenantToken && !headers.has('x-oracle-tenant-token')) headers.set('x-oracle-tenant-token', tenantToken);
+  return headers;
+}
+
+export async function oracleJson<T>(path: string, options: OracleRequestOptions = {}): Promise<T> {
+  const { query, headers, ...init } = options;
+  const finalHeaders = oracleHeaders(headers);
+  if (init.body && !finalHeaders.has('content-type')) finalHeaders.set('content-type', 'application/json');
+  const response = await fetch(oracleApiUrl(path, query), {
+    ...init,
+    headers: finalHeaders,
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Oracle API ${response.status} ${response.statusText}${body ? `: ${body}` : ''}`);
+  }
+  return response.json() as Promise<T>;
+}

--- a/src/skills/schedule/scripts/query.ts
+++ b/src/skills/schedule/scripts/query.ts
@@ -2,10 +2,9 @@
 // Query schedule via Oracle HTTP API (backed by Drizzle DB)
 // Usage: bun query.ts [filter]
 // Filters: today, tomorrow, week, month, march, <keyword>
-export {};
+import { oracleApiBase, oracleJson } from "./oracle-http.js";
 
 const filter = process.argv[2] || "upcoming";
-const API = process.env.ORACLE_API || "http://localhost:47778";
 
 const MONTHS: Record<string, string> = {
   jan: "01", january: "01", feb: "02", february: "02",
@@ -76,14 +75,7 @@ switch (filter.toLowerCase()) {
 }
 
 try {
-  const res = await fetch(`${API}/api/schedule?${params}`);
-  if (!res.ok) {
-    console.error(`API error: ${res.status} ${res.statusText}`);
-    console.error("Is the Oracle server running? Start with: bun src/server.ts");
-    process.exit(1);
-  }
-
-  const data = await res.json() as {
+  const data = await oracleJson<{
     total: number;
     events: Array<{
       id: number;
@@ -96,7 +88,7 @@ try {
       status: string;
     }>;
     byDate: Record<string, any[]>;
-  };
+  }>("/schedule", { query: params });
 
   if (data.total === 0) {
     console.log(`No events found for: ${filter}`);
@@ -119,8 +111,8 @@ try {
   console.log(`\n📄 \`ψ/inbox/schedule.md\``);
 } catch (e: any) {
   if (e.code === "ConnectionRefused" || e.message?.includes("fetch")) {
-    console.error("Cannot connect to Oracle API at " + API);
-    console.error("Start the server: cd arra-oracle-v3 && bun src/server.ts");
+    console.error("Cannot connect to Oracle API at " + oracleApiBase());
+    console.error("Start the server: docker run ... ghcr.io/soul-brews-studio/arra-oracle-v3:http");
   } else {
     console.error("Error:", e.message);
   }

--- a/src/skills/standup/SKILL.md
+++ b/src/skills/standup/SKILL.md
@@ -75,7 +75,17 @@ Scan recent LINE messages for potential appointments:
    ### LINE Appointments Found
    - [date] [event] (from: [group]) — Add? Y/N
    ```
-7. On user approval → call `arra_schedule_add` for each confirmed appointment
+7. On user approval → `POST /api/v1/schedule` for each confirmed appointment (schedule MCP is not wired). Use `ORACLE_API`, `ARRA_API_TOKEN`, `X-Oracle-Tenant`, and `X-Oracle-Tenant-Token` headers when needed.
+
+   ```bash
+   ORACLE_API=${ORACLE_API:-http://localhost:47778}
+   curl -fsS -X POST "$ORACLE_API/api/v1/schedule" \
+     ${ARRA_API_TOKEN:+-H "Authorization: Bearer $ARRA_API_TOKEN"} \
+     ${ORACLE_TENANT:+-H "X-Oracle-Tenant: $ORACLE_TENANT"} \
+     ${ORACLE_TENANT_TOKEN:+-H "X-Oracle-Tenant-Token: $ORACLE_TENANT_TOKEN"} \
+     -H 'content-type: application/json' \
+     -d '{"date":"2026-03-05","event":"Team standup","time":"09:30","notes":"from LINE scan"}'
+   ```
 
 ### 8. Auto-post to Pulse Discussion
 

--- a/src/skills/talk-to/SKILL.md
+++ b/src/skills/talk-to/SKILL.md
@@ -116,7 +116,7 @@ Fall through to Mode 3 (one-shot) below.
 
 ## Mode 1: --list
 
-1. `arra_threads()` (no status filter)
+1. `oracle_threads()` (no status filter)
 2. Filter titles starting with `channel:` or `topic:`, exclude `closed`
 3. Display: `channel:arthur (#42) pending — 12 msgs`
 
@@ -125,7 +125,7 @@ Fall through to Mode 3 (one-shot) below.
 Skip lookup. One MCP call.
 
 1. Compose message from intent
-2. `arra_thread({ title: "channel:{agent}", message, role: "human" })`
+2. `oracle_thread({ title: "channel:{agent}", message, role: "human" })`
 3. **Notify**: `Bash maw hey {MAW or agent-oracle} 'Thread #{id} from {self}: {preview}'`
    - If `maw hey` fails → warn only, don't error (thread already sent)
 4. Confirm: `Created channel:{agent} (thread #{id})`
@@ -134,11 +134,11 @@ Skip lookup. One MCP call.
 
 1. Compose message from intent
 2. If first arg is `#{id}` → post directly to that thread ID
-3. Otherwise: `arra_threads()` → find `channel:{agent}`, create if missing
+3. Otherwise: `oracle_threads()` → find `channel:{agent}`, create if missing
 4. Post message to thread
 5. **Notify**: `Bash maw hey {MAW or agent-oracle} 'Thread #{id} from {self}: {preview}'`
    - If `maw hey` fails → warn only, don't error (thread already sent)
-6. `arra_thread_read({ threadId })` → show any agent responses
+6. `oracle_thread_read({ threadId })` → show any agent responses
 7. Confirm: `Posted to channel:{agent} (thread #{id})`
 
 ## Mode 4: loop (autonomous conversation)
@@ -148,7 +148,7 @@ Like Ralph loop — AI drives the conversation autonomously. No user prompts bet
 1. Find or create thread (`channel:{agent}`, or `--new` to skip lookup)
 2. Compose opening message from user's intent and post it
 3. **Autonomous loop** (max 10 iterations):
-   a. `arra_thread_read({ threadId })` — check for new messages
+   a. `oracle_thread_read({ threadId })` — check for new messages
    b. If agent responded: read their response, compose a thoughtful follow-up, post it
    c. If no new response: compose a follow-up question or probe deeper, post it
    d. After each exchange, briefly note what you learned


### PR DESCRIPTION
## Summary
- add `/oracle-up` as a Docker-first Oracle node bootstrap skill with `/simple`, `arra mine`, `/api/v1/ask`, and `asOf` smoke checks
- add schedule HTTP helper for `/api/v1` URL joining plus bearer and tenant headers, then switch schedule/standup guidance to versioned HTTP APIs
- canonicalize legacy `arra_*` examples in touched Phase 1 skills and regenerate command stubs/README skill table

## Verification
- `bun install --frozen-lockfile`
- helper smoke for `oracleApiUrl()` + bearer/tenant headers
- `bun run compile`
- `bun test` (280 pass)
- `bun test __tests__/smoke.test.ts __tests__/permissions.test.ts` (15 pass after final oracle-up wording patch)
- `bun run build`
- `git diff --cached --check`
- changed file line counts all ≤250

## Notes
- Built in a separate clean worktree from `origin/main`; the pre-existing local `src/skills/oracle-up/SKILL.md` edits in the original repo were not modified or stashed.
- PR targets the default branch (`main`) per #2675 follow-up instruction.
