### PR TITLE
feat: add oracle product flow skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arra-oracle-skills-cli
 
-36 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
+39 skills for AI coding agents. Give your AI persistent memory, session awareness, and collaborative tools.
 
 ## Install
 
@@ -64,7 +64,7 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 <!-- skills:start -->
 
 <details>
-<summary>📚 <strong>36 skills installed</strong> — click to expand</summary>
+<summary>📚 <strong>39 skills installed</strong> — click to expand</summary>
 
 | # | Skill | Type | Description |
 |---|-------|------|-------------|
@@ -81,31 +81,34 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 | 9 | **bampenpien** | skill | "บำเพ็ญเพียร |
 | 10 | **bud** | skill | 'Create a new oracle via maw bud |
 | 11 | **calver** | skill | Show or bump CalVer version |
-| 12 | **contacts** | skill | Manage Oracle contacts |
-| 13 | **create-shortcut** | skill | Create local skills as shortcuts |
-| 14 | **dig** | skill | Mine Claude Code sessions |
-| 15 | **dream** | skill | 'Speculative dreaming |
-| 16 | **feel** | skill | "Capture how the system feels |
-| 17 | **forward** | skill | Create handoff + enter plan mode for next |
-| 18 | **fyi** | skill | Log information for future reference |
-| 19 | **go** | skill | Manage Oracle skills |
-| 20 | **hey** | skill | Talk to another oracle via maw federation |
-| 21 | **inbox** | skill | Read and write to Oracle inbox |
-| 22 | **incubate** | skill | Clone or create repos for active development |
-| 23 | **mailbox** | skill | 'Persistent agent mailbox |
-| 24 | **oracle-up** | skill | '[standard] G-SKLL | Bring up a Docker-first |
-| 25 | **release-alpha** | skill | "Cut an alpha pre-release |
-| 26 | **release-beta** | skill | "Cut a beta pre-release |
-| 27 | **resonance** | skill | Capture a resonance moment |
-| 28 | **standup** | skill | Daily standup check |
-| 29 | **talk-to** | skill | Talk to another Oracle agent |
-| 30 | **team-agents** | skill | Spin up coordinated agent teams for any task |
-| 31 | **trace** | skill | Find projects, code |
-| 32 | **watch** | skill | 'Extract YouTube video transcripts |
-| 33 | **where-we-are** | skill | Session awareness |
-| 34 | **who-are-you** | skill | Know ourselves |
-| 35 | **worktree** | skill | 'Work in an isolated git worktree |
-| 36 | **xray** | skill | X-ray deep scan |
+| 12 | **consolidation-review** | skill | Review Arra Oracle memory consolidation |
+| 13 | **contacts** | skill | Manage Oracle contacts |
+| 14 | **create-shortcut** | skill | Create local skills as shortcuts |
+| 15 | **dig** | skill | Mine Claude Code sessions |
+| 16 | **dream** | skill | 'Speculative dreaming |
+| 17 | **feel** | skill | "Capture how the system feels |
+| 18 | **forward** | skill | Create handoff + enter plan mode for next |
+| 19 | **fyi** | skill | Log information for future reference |
+| 20 | **go** | skill | Manage Oracle skills |
+| 21 | **hey** | skill | Talk to another oracle via maw federation |
+| 22 | **inbox** | skill | Read and write to Oracle inbox |
+| 23 | **incubate** | skill | Clone or create repos for active development |
+| 24 | **mailbox** | skill | 'Persistent agent mailbox |
+| 25 | **mine-notes** | skill | Run the arra mine ingest flow for notes |
+| 26 | **oracle-ask** | skill | Ask Arra Oracle for grounded answers |
+| 27 | **oracle-up** | skill | '[standard] G-SKLL | Bring up a Docker-first |
+| 28 | **release-alpha** | skill | "Cut an alpha pre-release |
+| 29 | **release-beta** | skill | "Cut a beta pre-release |
+| 30 | **resonance** | skill | Capture a resonance moment |
+| 31 | **standup** | skill | Daily standup check |
+| 32 | **talk-to** | skill | Talk to another Oracle agent |
+| 33 | **team-agents** | skill | Spin up coordinated agent teams for any task |
+| 34 | **trace** | skill | Find projects, code |
+| 35 | **watch** | skill | 'Extract YouTube video transcripts |
+| 36 | **where-we-are** | skill | Session awareness |
+| 37 | **who-are-you** | skill | Know ourselves |
+| 38 | **worktree** | skill | 'Work in an isolated git worktree |
+| 39 | **xray** | skill | X-ray deep scan |
 
 </details>
 
@@ -119,8 +122,8 @@ The `L-SKLL` marker in the SKILL.md description distinguishes locally-installed 
 |---------|-------|--------|
 | **minimal** | 6 | `about-oracle`, `forward`, `go`, `recap`, `rrr`, `trace` |
 | **standard** | 12 | `awaken`, `bampenpien`, `bud`, `dig`, `forward`, `go`, `learn`, `recap`, `rrr`, `talk-to`, `team-agents`, `trace` |
-| **full** | 36 | all |
-| **lab** | 36 | all |
+| **full** | 39 | all |
+| **lab** | 39 | all |
 
 Switch anytime: `/go standard`, `/go full`, `/go lab`
 

--- a/src/commands/consolidation-review.md
+++ b/src/commands/consolidation-review.md
@@ -1,0 +1,23 @@
+---
+description: '[core] v26.5.16 | Review Arra Oracle memory consolidation suggestions safely: list pending suggestions, inspect evidence, then explicitly approve or reject. Use when the user asks to review consolidation, dedupe memory, or clear consolidation queue.'
+argument-hint: "[list | approve <id> | reject <id>] [--limit N]"
+---
+
+# /consolidation-review
+
+Execute the `consolidation-review` skill with the provided arguments.
+
+## Instructions
+
+**If you have a Skill tool available**: Use it directly with `skill: "consolidation-review"` instead of reading the file manually.
+
+**Otherwise**:
+1. Read the skill file at this exact path: `~/.claude/skills/consolidation-review/SKILL.md`
+2. Follow all instructions in the skill file
+3. Pass these arguments to the skill: `$ARGUMENTS`
+
+**WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "consolidation-review" in the name are NOT this skill.
+
+---
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
+*Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/mine-notes.md
+++ b/src/commands/mine-notes.md
@@ -1,0 +1,23 @@
+---
+description: '[core] v26.5.16 | Run the arra mine ingest flow for notes folders: dry-run, one-shot, watch mode, Docker volume setup, and post-ingest smoke. Use when the user wants to ingest, mine, import, or watch a notes directory.'
+argument-hint: "<notes-dir> [--dry-run | --watch] [--docker]"
+---
+
+# /mine-notes
+
+Execute the `mine-notes` skill with the provided arguments.
+
+## Instructions
+
+**If you have a Skill tool available**: Use it directly with `skill: "mine-notes"` instead of reading the file manually.
+
+**Otherwise**:
+1. Read the skill file at this exact path: `~/.claude/skills/mine-notes/SKILL.md`
+2. Follow all instructions in the skill file
+3. Pass these arguments to the skill: `$ARGUMENTS`
+
+**WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "mine-notes" in the name are NOT this skill.
+
+---
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
+*Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/commands/oracle-ask.md
+++ b/src/commands/oracle-ask.md
@@ -1,0 +1,23 @@
+---
+description: '[core] v26.5.16 | Ask Arra Oracle for grounded answers with citations, warnings, llm:false, and asOf support. Use when the user asks Oracle a question, wants cited RAG over indexed memory, or needs historical evidence.'
+argument-hint: "<question> [--as-of ISO] [--llm false] [--limit N]"
+---
+
+# /oracle-ask
+
+Execute the `oracle-ask` skill with the provided arguments.
+
+## Instructions
+
+**If you have a Skill tool available**: Use it directly with `skill: "oracle-ask"` instead of reading the file manually.
+
+**Otherwise**:
+1. Read the skill file at this exact path: `~/.claude/skills/oracle-ask/SKILL.md`
+2. Follow all instructions in the skill file
+3. Pass these arguments to the skill: `$ARGUMENTS`
+
+**WARNING**: Do NOT use Glob, find, or search for this skill. The path above is the ONLY correct location. Other files with "oracle-ask" in the name are NOT this skill.
+
+---
+*🧬 Nat Weerawan × Oracle · Symbiotic Intelligence · v26.5.16*
+*Digitized from Nat Weerawan's brain — thousands of hours working alongside AI, captured as code*

--- a/src/skills/consolidation-review/SKILL.md
+++ b/src/skills/consolidation-review/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: consolidation-review
+description: Review Arra Oracle memory consolidation suggestions safely: list pending suggestions, inspect evidence, then explicitly approve or reject. Use when the user asks to review consolidation, dedupe memory, or clear consolidation queue.
+argument-hint: "[list | approve <id> | reject <id>] [--limit N]"
+---
+
+# /consolidation-review — Suggest-only Memory Cleanup
+
+Review memory consolidation suggestions without auto-applying them. Approval can
+supersede evidence, so every action requires an explicit user decision.
+
+## Hard rules
+
+- Default action is **list only**.
+- Never auto-apply, approve-all, or reject-all from a vague instruction like
+  “clean it up”. Show suggestions first.
+- Approve or reject only when the user explicitly names the action and ID(s)
+  after seeing the evidence.
+- Preserve tenant isolation by passing tenant headers when configured.
+- Include a reason for every approve/reject.
+
+## Setup
+
+```bash
+ORACLE_API=${ORACLE_API:-${ARRA_API:-http://localhost:47778}}
+LIMIT=${LIMIT:-20}
+ACTOR=${ORACLE_ACTOR:-${USER:-oracle-reviewer}}
+```
+
+Use these headers when present:
+
+```bash
+${ARRA_API_TOKEN:+-H "Authorization: Bearer $ARRA_API_TOKEN"}
+${ORACLE_TENANT:+-H "X-Oracle-Tenant: $ORACLE_TENANT"}
+${ORACLE_TENANT_TOKEN:+-H "X-Oracle-Tenant-Token: $ORACLE_TENANT_TOKEN"}
+-H "X-Oracle-Actor: $ACTOR"
+```
+
+## List pending suggestions
+
+```bash
+curl -fsS "$ORACLE_API/api/v1/memory/consolidation/pending?limit=$LIMIT"
+```
+
+Equivalent endpoint:
+
+```bash
+curl -fsS "$ORACLE_API/api/v1/memory/consolidation/suggestions?limit=$LIMIT"
+```
+
+Render a review table:
+
+```markdown
+| ID | Confidence | Original | Suggested successor | Reason |
+|----|------------|----------|---------------------|--------|
+| old->new | 0.91 | notes/old.md | notes/new.md | async duplicate... |
+```
+
+For each row include:
+- `id`, `confidence`/`score`, and `metrics.cosine`/`metrics.ftsOverlap`;
+- `original.id`, `original.sourceFile`, and preview;
+- `suggested.id`, `suggested.sourceFile`, and preview;
+- warning that approve supersedes `oldId` with `newId`.
+
+Then stop and ask for explicit IDs if the user has not already provided them.
+
+## Approve one suggestion
+
+Approve only after explicit user approval for that ID:
+
+```bash
+ID='old-doc-id->new-doc-id'
+ID_ENC=$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$ID")
+REASON='reviewed matching evidence; suggested successor is newer and more complete'
+
+curl -fsS -X POST "$ORACLE_API/api/v1/memory/consolidation/$ID_ENC/approve" \
+  ${ARRA_API_TOKEN:+-H "Authorization: Bearer $ARRA_API_TOKEN"} \
+  ${ORACLE_TENANT:+-H "X-Oracle-Tenant: $ORACLE_TENANT"} \
+  ${ORACLE_TENANT_TOKEN:+-H "X-Oracle-Tenant-Token: $ORACLE_TENANT_TOKEN"} \
+  -H "X-Oracle-Actor: $ACTOR" \
+  -H 'content-type: application/json' \
+  -d "$(jq -nc --arg reason "$REASON" '{reason:$reason}')"
+```
+
+Expected response includes `success: true`, `suggestion`, `result`, and `audit`.
+
+## Reject one suggestion
+
+Reject only after explicit user rejection for that ID:
+
+```bash
+ID='old-doc-id->new-doc-id'
+ID_ENC=$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$ID")
+REASON='not a duplicate; keep both facts visible'
+
+curl -fsS -X POST "$ORACLE_API/api/v1/memory/consolidation/suggestions/$ID_ENC/reject" \
+  ${ARRA_API_TOKEN:+-H "Authorization: Bearer $ARRA_API_TOKEN"} \
+  ${ORACLE_TENANT:+-H "X-Oracle-Tenant: $ORACLE_TENANT"} \
+  ${ORACLE_TENANT_TOKEN:+-H "X-Oracle-Tenant-Token: $ORACLE_TENANT_TOKEN"} \
+  -H "X-Oracle-Actor: $ACTOR" \
+  -H 'content-type: application/json' \
+  -d "$(jq -nc --arg reason "$REASON" '{reason:$reason}')"
+```
+
+Expected response includes `success: true`, `suggestion`, and `audit`. Rejecting a
+suggestion dismisses it for the active tenant; it does not delete memory.
+
+## Final response
+
+```markdown
+Consolidation review
+- Listed: <N> suggestions
+- Approved: <IDs or none>
+- Rejected: <IDs or none>
+- Skipped: <IDs + reason>
+- Audit actor: <actor>
+```

--- a/src/skills/mine-notes/SKILL.md
+++ b/src/skills/mine-notes/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: mine-notes
+description: Run the arra mine ingest flow for notes folders: dry-run, one-shot, watch mode, Docker volume setup, and post-ingest smoke. Use when the user wants to ingest, mine, import, or watch a notes directory.
+argument-hint: "<notes-dir> [--dry-run | --watch] [--docker]"
+---
+
+# /mine-notes — Arra Mine Ingest Flow
+
+Use the current `arra mine` CLI path to ingest Markdown, MDX, and text notes into
+Arra Oracle. Do not use the archived `/mine` zombie skill for session mining.
+
+## Contract
+
+- Dry-run first unless the user explicitly asks to ingest now.
+- Never edit or delete source notes.
+- Prefer Docker-first for product smoke because it writes to the same `/data`
+  volume as the HTTP server.
+- Re-runs are safe: unchanged files are skipped by deterministic IDs.
+- Finish by proving search/ask can see the ingested content.
+
+## Docker-first preflight
+
+```bash
+export ARRA_PORT="${ARRA_PORT:-47778}"
+export ARRA_URL="http://127.0.0.1:${ARRA_PORT}"
+export ARRA_CONTAINER="${ARRA_CONTAINER:-arra-oracle}"
+export ARRA_VOLUME="${ARRA_VOLUME:-arra-oracle-data}"
+export ARRA_NOTES_DIR="${ARRA_NOTES_DIR:-$HOME/notes}"
+
+mkdir -p "$ARRA_NOTES_DIR"
+docker volume create "$ARRA_VOLUME" >/dev/null
+```
+
+Start Oracle if it is not already running:
+
+```bash
+docker run --rm -d --name "$ARRA_CONTAINER" \
+  -p "${ARRA_PORT}:47778" \
+  -v "${ARRA_VOLUME}:/data" \
+  -v "${ARRA_NOTES_DIR}:${ARRA_NOTES_DIR}:ro" \
+  ghcr.io/soul-brews-studio/arra-oracle-v3:http
+
+until curl -sf "$ARRA_URL/api/health" >/dev/null; do sleep 1; done
+```
+
+Helper for the CLI inside the running container:
+
+```bash
+arra() { docker exec "$ARRA_CONTAINER" bun dist-cli/index.js "$@"; }
+```
+
+## Dry-run
+
+```bash
+arra mine "$ARRA_NOTES_DIR" --dry-run
+```
+
+Report scanned/stored/skipped counts and detected project. If `stored` is zero,
+call out whether it was an empty folder or all files were unchanged.
+
+## One-shot ingest
+
+```bash
+arra mine "$ARRA_NOTES_DIR"
+```
+
+Expected output:
+
+```text
+Mined N documents from M files (K skipped) into project "<project>".
+```
+
+## Watch mode
+
+Only run watch mode when the user wants a long-running watcher:
+
+```bash
+arra mine "$ARRA_NOTES_DIR" --watch
+```
+
+Stop with Ctrl-C. If running in a remote session, warn the user that watch mode
+keeps the process attached until stopped.
+
+## Local/dev variant
+
+When working inside a source checkout instead of Docker:
+
+```bash
+bun run src/cli/index.ts mine "$ARRA_NOTES_DIR" --dry-run
+bun run src/cli/index.ts mine "$ARRA_NOTES_DIR"
+bun run src/cli/index.ts mine "$ARRA_NOTES_DIR" --watch
+```
+
+Use `--db-path <file>` only for isolated test databases.
+
+## Post-ingest smoke
+
+```bash
+curl -sfS "$ARRA_URL/api/health"
+curl -sfS "$ARRA_URL/api/v1/search?q=runbook&mode=fts&limit=5"
+curl -sfS -X POST "$ARRA_URL/api/v1/ask" \
+  -H 'content-type: application/json' \
+  -d '{"q":"What did I write about runbooks?","limit":5,"llm":false}'
+```
+
+Pass criteria:
+- health is OK;
+- search returns results or a clear zero-result response for the chosen query;
+- ask returns JSON with `answer`, `citations`, `sources`, and `warnings`.
+
+## Output to user
+
+Summarize:
+
+```markdown
+Mined <stored> docs from <scanned> files (<skipped> skipped) into project `<project>`.
+Smoke: health <ok/fail>, search <N results>, ask <cited/no evidence>.
+UI: <ARRA_URL>/simple
+```

--- a/src/skills/oracle-ask/SKILL.md
+++ b/src/skills/oracle-ask/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: oracle-ask
+description: Ask Arra Oracle for grounded answers with citations, warnings, llm:false, and asOf support. Use when the user asks Oracle a question, wants cited RAG over indexed memory, or needs historical evidence.
+argument-hint: "<question> [--as-of ISO] [--llm false] [--limit N]"
+---
+
+# /oracle-ask — Cited Oracle Answers
+
+Answer from Arra Oracle memory/search with citations. The product contract is
+**grounded answer first**: never present uncited synthesis as fact.
+
+## Inputs
+
+- Question text from `$ARGUMENTS` or the user message.
+- Optional `--as-of <ISO>` for valid-time/historical answers.
+- Optional `--llm false` for deterministic extractive answers. Prefer this for
+  smoke tests, audits, and anything that must avoid provider calls.
+- Optional filters: `--limit`, `--type`, `--project`, `--cwd`, `--model`.
+
+## Contract
+
+1. Use `oracle_ask` MCP first when available.
+2. Fallback to `POST /api/v1/ask` when MCP is unavailable.
+3. Render `answer`, `citations`, `warnings`, `noEvidence`, and stale metadata.
+4. If `noEvidence: true` or `citations` is empty, say Oracle has no cited
+   evidence. Do not fill the gap from model memory.
+5. If warnings mention stale/superseded evidence, show them near the answer.
+6. Outside knowledge may be added only under a clearly labeled “Not in Oracle”
+   section, never as the cited answer.
+
+## MCP-first call
+
+Use this shape with the Oracle MCP server:
+
+```json
+{
+  "tool": "oracle_ask",
+  "arguments": {
+    "question": "What did I write about runbooks?",
+    "limit": 5,
+    "llm": false
+  }
+}
+```
+
+Historical/asOf example:
+
+```json
+{
+  "tool": "oracle_ask",
+  "arguments": {
+    "question": "Who owned the deploy checklist?",
+    "asOf": "2026-06-17T00:00:00Z",
+    "limit": 8,
+    "llm": false
+  }
+}
+```
+
+Accepted argument aliases: `q` or `question`. Supported filters: `type`,
+`limit`, `project`, `cwd`, `model`, `asOf`, `llm`.
+
+## HTTP fallback
+
+```bash
+ORACLE_API=${ORACLE_API:-${ARRA_API:-http://localhost:47778}}
+QUESTION='What did I write about runbooks?'
+
+curl -fsS -X POST "$ORACLE_API/api/v1/ask" \
+  ${ARRA_API_TOKEN:+-H "Authorization: Bearer $ARRA_API_TOKEN"} \
+  ${ORACLE_TENANT:+-H "X-Oracle-Tenant: $ORACLE_TENANT"} \
+  ${ORACLE_TENANT_TOKEN:+-H "X-Oracle-Tenant-Token: $ORACLE_TENANT_TOKEN"} \
+  -H 'content-type: application/json' \
+  -d "$(jq -nc --arg q "$QUESTION" '{q:$q,limit:5,llm:false}')"
+```
+
+As-of fallback:
+
+```bash
+curl -fsS -X POST "$ORACLE_API/api/v1/ask" \
+  -H 'content-type: application/json' \
+  -d '{"q":"Who owned the deploy checklist?","asOf":"2026-06-17T00:00:00Z","limit":8,"llm":false}'
+```
+
+## Rendering
+
+Show a compact, user-facing result:
+
+```markdown
+## Oracle answer
+<answer text>
+
+### Citations
+[1] <title> — <sourceFile>
+    <excerpt>
+[2] <title> — <sourceFile>
+    <excerpt>
+
+### Warnings
+- <warning or stale/superseded note>
+```
+
+Rules:
+- Keep citation indexes exactly as returned.
+- Include `sourceFile`, `id`, and excerpt when present.
+- Mark stale sources: `stale: true`, `supersededBy`, `valid_time`, or
+  `valid_until` from the source/citation payload.
+- Include `asOf` in the heading when supplied: `Oracle answer as of <ISO>`.
+
+## Failure modes
+
+- 400 invalid query/asOf/model: show the server error and ask for corrected input.
+- Connection refused: suggest `/oracle-up` or verify `ORACLE_API`.
+- Empty evidence: stop after the no-evidence message unless the user explicitly
+  asks for a non-Oracle brainstorm.


### PR DESCRIPTION
## Summary

Phase 2 of #2675 product-facing skills-cli sync, stacked on Phase 1 PR #439.

Adds three active skills plus generated command stubs:

- `/oracle-ask`: MCP-first `oracle_ask` flow with HTTP `POST /api/v1/ask` fallback, `llm:false`, `asOf`, citations/warnings rendering, and no uncited synthesis-as-fact rule.
- `/mine-notes`: `arra mine` ingest flow covering Docker volume setup, dry-run, one-shot ingest, watch mode, local/dev variant, and search/ask smoke.
- `/consolidation-review`: suggest-only consolidation queue review with explicit approve/reject, tenant/actor headers, reasons, and no auto-apply.

README generated skill table moves 36 → 39 skills.

## Safety

- No code execution path auto-applies consolidation; `/consolidation-review` defaults to list-only.
- Original dirty `oracle-up/SKILL.md` worktree was not touched; this branch was created from the Phase 1 clean worktree.
- PR is stacked on `feat/2675-phase1-api-sync` to keep Phase 2 separate from #439 while #439 waits for review.

## Verification

- `bun run compile`
- `bun scripts/update-readme-table.ts`
- `bun test` — 280 pass
- `bun run build` — bundled successfully
- pre-commit hook reran `bun test` — 280 pass
- `git diff --check` and `git diff --cached --check`
- changed files line counts ≤250
