### PR TITLE
test(dig): make dig-skill e2e hermetic — 81s → 1.75s, kill flaky ghq timeout

### DIFF
--- a/src/skills/dig/scripts/dig.py
+++ b/src/skills/dig/scripts/dig.py
@@ -50,6 +50,13 @@ tz_offset, tz_name = detect_tz()
 
 
 def build_repo_map():
+    # `ghq list -p` maps encoded project-dir names → real repo names, but it can
+    # take several seconds on machines with a large ghq root — and it runs on
+    # every dig/recap/rrr invocation. DIG_SKIP_REPO_MAP=1 skips the subprocess
+    # entirely: repo names then fall back to get_repo_name()'s own parsing. The
+    # e2e test sets it so it stays hermetic (no ghq dependency) and fast.
+    if os.environ.get('DIG_SKIP_REPO_MAP', '').lower() in ('1', 'true', 'yes', 'on'):
+        return {}
     mapping = {}
     try:
         r = subprocess.run(['ghq', 'list', '-p'], capture_output=True, text=True, timeout=5)

--- a/tests-e2e/dig-skill.test.ts
+++ b/tests-e2e/dig-skill.test.ts
@@ -78,6 +78,11 @@ function runDig(args: string[]): { stdout: string; stderr: string; exitCode: num
       PROJECT_DIRS: FIXTURE_DIR,
       // Force UTC so timestamps are deterministic
       MAW_DISPLAY_TZ: "0",
+      // Skip the `ghq list -p` subprocess — on a dev machine with a big ghq root
+      // it takes ~5s per call (and hits dig.py's 5s timeout → empty stdout →
+      // flaky failures). We don't assert repo-name values, so this keeps the
+      // suite hermetic and fast without changing what's tested.
+      DIG_SKIP_REPO_MAP: "1",
     },
     encoding: "utf-8",
     timeout: 15_000,
@@ -291,7 +296,7 @@ describe("fix #274 — timezone detection", () => {
   it("respects MAW_DISPLAY_TZ env var", () => {
     // MAW_DISPLAY_TZ=0 → UTC; timestamps should show UTC times
     const result = spawnSync("python3", [DIG_PY, "10"], {
-      env: { ...process.env, PROJECT_DIRS: FIXTURE_DIR, MAW_DISPLAY_TZ: "0" },
+      env: { ...process.env, PROJECT_DIRS: FIXTURE_DIR, MAW_DISPLAY_TZ: "0", DIG_SKIP_REPO_MAP: "1" },
       encoding: "utf-8",
       timeout: 15_000,
     });
@@ -305,7 +310,7 @@ describe("fix #274 — timezone detection", () => {
   it("timezone offset shifts timestamps correctly", () => {
     // MAW_DISPLAY_TZ=7 → GMT+7; 08:00Z + 7h = 15:00
     const result = spawnSync("python3", [DIG_PY, "10"], {
-      env: { ...process.env, PROJECT_DIRS: FIXTURE_DIR, MAW_DISPLAY_TZ: "7" },
+      env: { ...process.env, PROJECT_DIRS: FIXTURE_DIR, MAW_DISPLAY_TZ: "7", DIG_SKIP_REPO_MAP: "1" },
       encoding: "utf-8",
       timeout: 15_000,
     });


### PR DESCRIPTION
## Problem

\`tests-e2e/dig-skill.test.ts\` ran **81s** and flaked: 2 tests failed locally with \`JSON Parse error: Unexpected EOF\` (empty stdout). CI passed only because its ghq root is empty.

**Root cause:** \`dig.py\` calls \`ghq list -p\` on *every* invocation (\`build_repo_map()\`) to map project dirs → repo names, with a 5s timeout. On a dev machine with a large ghq root that call takes ~5s and hits the timeout → \`TimeoutExpired\` → the process yields empty stdout on the flaky runs. The suite spawns python3 25× → 25 × ~5s.

Measured on this machine:
| dig.py invocation | time |
|---|---|
| ghq on PATH (default) | **4.77s** |
| ghq skipped | **0.22s** (22×) |

## Fix

Gate the ghq lookup behind \`DIG_SKIP_REPO_MAP\` (**default OFF — production behaviour unchanged**). The e2e sets it; repo names then fall back to \`get_repo_name()\`'s own dir-name parsing, which the suite never asserts a *value* on (only \`toHaveProperty("repoName")\`).

## Result
- **81s → 1.75s** (~46×), **2 fail → 0 fail**, no ghq dependency in the test
- Bonus: real \`/dig\`, \`/recap\`, \`/rrr\` callers can opt out of the ~5s ghq tax with the same env var
- Also fixes \`dig.py\` file mode \`100644 → 100755\` (was violating the "scripts must be +x" convention in CLAUDE.md)

## Files
- \`src/skills/dig/scripts/dig.py\` — \`DIG_SKIP_REPO_MAP\` guard + comment (+x)
- \`tests-e2e/dig-skill.test.ts\` — set the env var in all 3 spawn sites

## Note (out of scope, flagged separately)
5 other skill scripts are also non-exec on \`alpha\` (team-agents: cleanup/killshot/panes/shutdown-skills/spawn-skills \`.sh\`) — same convention violation, not touched here. Worth a small follow-up + a lefthook/CI gate so it stops regressing.