### PR TITLE
fix(install): stop archived zombies leaking into full/lab profiles

### DIFF
--- a/__tests__/archive-integrity.test.ts
+++ b/__tests__/archive-integrity.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "bun:test";
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { discoverSkills } from "../src/cli/installer";
+import { resolveProfile } from "../src/profiles";
+
+// Integration guard for the 2026-07 zombie-leak regression.
+//
+// profiles.test.ts is a UNIT test: it feeds resolveProfile the ZOMBIE_SKILLS
+// *constant* and checks the filtering logic. That constant was CORRECT the whole
+// time — but the actual install path excludes zombies via the frontmatter-derived
+// `.zombie` flag from discoverSkills(), NOT the constant. Zombie round 2 moved 11
+// skills into src/skills/.archive/ + added them to the constant but forgot the
+// `zombie: true` frontmatter — so discoverSkills() didn't flag them and they kept
+// installing under `full`/`lab`. The unit test stayed green while install leaked.
+//
+// These tests exercise the REAL mechanism end-to-end (disk → discoverSkills →
+// resolveProfile) so the same class of drift can't slip through again.
+
+const SKILLS_DIR = join(process.cwd(), "src", "skills");
+const ARCHIVE_DIR = join(SKILLS_DIR, ".archive");
+
+function archivedSkillNames(): string[] {
+  if (!existsSync(ARCHIVE_DIR)) return [];
+  return readdirSync(ARCHIVE_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+    .filter((d) => existsSync(join(ARCHIVE_DIR, d.name, "SKILL.md")))
+    .map((d) => d.name);
+}
+
+describe("archive integrity (real discoverSkills)", () => {
+  it("every skill under .archive/ is flagged zombie by discoverSkills", async () => {
+    const archived = archivedSkillNames();
+    expect(archived.length).toBeGreaterThan(0); // sanity: archive isn't empty
+
+    const skills = await discoverSkills();
+    const zombieFlagged = new Set(
+      skills.filter((s) => s.zombie).map((s) => s.name),
+    );
+
+    const unflagged = archived.filter((name) => !zombieFlagged.has(name));
+    // Any archived skill missing the frontmatter flag would leak into full/lab
+    // install because the compiled VFS carries no .archive/ path signal.
+    expect(unflagged).toEqual([]);
+  });
+
+  it("no archived skill leaks into the full or lab install set", async () => {
+    const archived = new Set(archivedSkillNames());
+    const skills = await discoverSkills();
+    const allNames = skills.map((s) => s.name);
+    const secretNames = skills.filter((s) => s.secret).map((s) => s.name);
+    const zombieNames = skills.filter((s) => s.zombie).map((s) => s.name);
+
+    for (const profile of ["full", "lab"]) {
+      const resolved =
+        resolveProfile(profile, allNames, secretNames, zombieNames) ??
+        allNames.filter(
+          (s) => !secretNames.includes(s) && !zombieNames.includes(s),
+        );
+      const leaked = resolved.filter((name) => archived.has(name));
+      expect({ profile, leaked }).toEqual({ profile, leaked: [] });
+    }
+  });
+});

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -113,6 +113,32 @@ async function compile() {
     }
   }
 
+  // ── Archive integrity gate ─────────────────────────────────────────────
+  // Every skill parked under src/skills/.archive/ MUST carry a curation flag
+  // (zombie/secret/hidden) in its frontmatter. That flag is the ONLY zombie
+  // signal that survives into the compiled binary: the VFS (scripts/generate-vfs.ts)
+  // flattens active + archived skills into one name→files map with NO .archive/
+  // path info, so discoverSkills() in compiled mode can't tell them apart by
+  // location. A skill moved to .archive/ but left unflagged therefore silently
+  // leaks back into the `full`/`lab` install profiles. This gate fails the
+  // build the moment that happens (regression: 2026-07 zombie round 2 moved 11
+  // skills to .archive/ but forgot the frontmatter flag → they kept installing).
+  const archiveDir = join(SKILLS_DIR, '.archive');
+  if (existsSync(archiveDir)) {
+    for (const dirent of await readdir(archiveDir, { withFileTypes: true })) {
+      if (!dirent.isDirectory() || dirent.name.startsWith('.')) continue;
+      const md = join(archiveDir, dirent.name, 'SKILL.md');
+      if (!existsSync(md)) continue;
+      const fm = (await readFile(md, 'utf-8')).split(/^---\s*$/m)[1] ?? '';
+      if (!/(zombie|secret|hidden):\s*(true|yes)/i.test(fm)) {
+        errors.push({
+          skill: `.archive/${dirent.name}`,
+          message: 'archived skill lacks a zombie/secret/hidden frontmatter flag — it would leak into full/lab install (the compiled VFS has no .archive/ path signal). Add `zombie: true` to its frontmatter.',
+        });
+      }
+    }
+  }
+
   // ── .claude-plugin/marketplace.json — explicit allowlist manifest ──────
   // The only curation mechanism external ecosystems honor (Claude Code
   // plugin marketplaces read this; nothing scans for unlisted skills).

--- a/src/cli/commands/profiles.ts
+++ b/src/cli/commands/profiles.ts
@@ -9,6 +9,15 @@ export function registerProfiles(program: Command) {
     .action(async (name?: string) => {
       const allSkills = await discoverSkills();
       const allNames = allSkills.map((s) => s.name);
+      // Secret + zombie skills are excluded from every profile — pass them to
+      // resolveProfile so this display matches what `install` actually resolves.
+      // Omitting them made `lab` print all 68 discovered skills (incl. archived
+      // zombies) instead of the ~36 it really installs.
+      const secretNames = allSkills.filter((s) => s.secret).map((s) => s.name);
+      const zombieNames = allSkills.filter((s) => s.zombie).map((s) => s.name);
+      const cleanAll = allNames.filter(
+        (s) => !secretNames.includes(s) && !zombieNames.includes(s),
+      );
 
       if (name) {
         if (!profiles[name]) {
@@ -16,16 +25,16 @@ export function registerProfiles(program: Command) {
           console.log(`  Available: ${Object.keys(profiles).join(', ')}\n`);
           return;
         }
-        const skills = resolveProfile(name, allNames) || allNames;
+        const skills = resolveProfile(name, allNames, secretNames, zombieNames) || cleanAll;
         console.log(`\n  Profile: ${name} (${skills.length} skills)`);
         console.log(`  Skills: ${skills.join(', ')}\n`);
         return;
       }
 
       console.log('\n  Available profiles:\n');
-      for (const [pName, profile] of Object.entries(profiles)) {
-        const skills = resolveProfile(pName, allNames);
-        const count = skills ? skills.length : allNames.length;
+      for (const [pName] of Object.entries(profiles)) {
+        const skills = resolveProfile(pName, allNames, secretNames, zombieNames);
+        const count = skills ? skills.length : cleanAll.length;
         console.log(`    ${pName.padEnd(12)} ${count} skills`);
       }
       console.log(`\n  Usage: arra-oracle-skills install -g -y -p <profile>\n`);

--- a/src/skills/.archive/contacts/SKILL.md
+++ b/src/skills/.archive/contacts/SKILL.md
@@ -2,6 +2,7 @@
 name: contacts
 description: Manage Oracle contacts — add, list, remove agents with their transport info (maw, inbox, thread). Use when user says "contacts", "add contact", "register agent", "who can I talk to", "list contacts". Do NOT trigger for sending messages (use /talk-to) or family registry (use /oracle-family-scan).
 argument-hint: "[list | add <name> | remove <name> | show <name>]"
+zombie: true
 ---
 
 # /contacts - Oracle Contact Registry

--- a/src/skills/.archive/feel/SKILL.md
+++ b/src/skills/.archive/feel/SKILL.md
@@ -2,6 +2,7 @@
 name: feel
 description: "Capture how the system feels — energy, momentum, burnout, breakthrough. Emotional intelligence for Oracle-human collaboration. Use when user says 'feel', 'how are we', 'energy check', 'burnout', 'momentum', or wants emotional awareness of the work."
 argument-hint: "[--deep | --log]"
+zombie: true
 ---
 
 # /feel — System Emotional Intelligence

--- a/src/skills/.archive/hey/SKILL.md
+++ b/src/skills/.archive/hey/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: hey
 description: Talk to another oracle via maw federation. Uses fleet machine names (white, mba, clinic-nat, oracle-world, phaith). Auto-signs with current oracle's [host:handle] from CLAUDE.md. Global — works from any oracle repo.
+zombie: true
 ---
 
 # /hey

--- a/src/skills/.archive/inbox/SKILL.md
+++ b/src/skills/.archive/inbox/SKILL.md
@@ -2,6 +2,7 @@
 name: inbox
 description: Read and write to Oracle inbox — notes, tasks, messages, handoffs. Use when user says "inbox", "leave a note", "write to inbox", "check inbox", "what's pending", or wants to read/write messages for self or other agents. Do NOT trigger for session handoffs (use /forward), schedule (use /schedule), or agent messaging (use /talk-to).
 argument-hint: "[read | write <topic> | ls | clean]"
+zombie: true
 ---
 
 # /inbox - Oracle Inbox

--- a/src/skills/.archive/mailbox/SKILL.md
+++ b/src/skills/.archive/mailbox/SKILL.md
@@ -3,6 +3,7 @@ name: mailbox
 description: 'Persistent agent mailbox — store findings, standing orders, and context for team agents across sessions. Use when user says "mailbox", "agent memory", "standing orders", "what did scout find", or wants to manage persistent agent knowledge.'
 argument-hint: "[read <agent> | write <agent> | orders <agent> | list | load <agent>]"
 
+zombie: true
 ---
 
 # /mailbox — Persistent Agent Memory

--- a/src/skills/.archive/oracle-soul-sync-update/SKILL.md
+++ b/src/skills/.archive/oracle-soul-sync-update/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oracle-soul-sync-update
 description: Sync Oracle instruments with the family. Check and update skills to latest version. Use when user says "soul-sync", "sync", "calibrate", "update", or before /awaken.
+zombie: true
 ---
 
 # /oracle-soul-sync-update

--- a/src/skills/.archive/oracle-up/SKILL.md
+++ b/src/skills/.archive/oracle-up/SKILL.md
@@ -2,6 +2,7 @@
 name: oracle-up
 description: '[standard] G-SKLL | Bring up a whole oracle node on a remote host — provision the user, install the full toolchain (maw-js, arra-oracle-skills, arra-oracle MCP v3, omx), create the oracle repo, and stand up its Claude-leader + omx-coder team. Idempotent, dry-run by default. Use when user says "oracle-up", "bring up an oracle", "new oracle node", "provision oracle on <host>", or wants a fresh self-sufficient oracle on a remote machine. Do NOT trigger for local identity setup (use /awaken), repo-only creation (use /bud), or cloning for dev (use /incubate).'
 argument-hint: "<name> --host <host> --user <user> [--port N] [--mirror nat] [--apply]"
+zombie: true
 ---
 
 # /oracle-up — Bring Up a Whole Oracle Node

--- a/src/skills/.archive/schedule/SKILL.md
+++ b/src/skills/.archive/schedule/SKILL.md
@@ -2,6 +2,7 @@
 name: schedule
 description: Query schedule via Oracle API (Drizzle DB). Use when user says "schedule", "upcoming events", "what's on today", "calendar".
 argument-hint: "[today | tomorrow | week]"
+zombie: true
 ---
 
 # /schedule - Query Schedule

--- a/src/skills/.archive/standup/SKILL.md
+++ b/src/skills/.archive/standup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: standup
 description: Daily standup check — pending tasks, appointments, recent progress, schedule. Use when user says "standup", "morning check", "what's pending", or at the start of a work day. Do NOT trigger for mid-session status (use /recap --now), session orientation (use /recap), or retrospectives (use /rrr).
+zombie: true
 ---
 
 # /standup - Daily Standup

--- a/src/skills/.archive/worktree/SKILL.md
+++ b/src/skills/.archive/worktree/SKILL.md
@@ -2,6 +2,7 @@
 name: worktree
 description: 'Work in an isolated git worktree — safe parallel editing, experimental branches, throwaway spikes. Use when user says "worktree", "isolate", "safe branch", "spike", "experiment", or wants to work without touching main.'
 argument-hint: "[<name> | list | exit | clean]"
+zombie: true
 ---
 
 # /worktree — Isolated Work

--- a/src/skills/.archive/xray/SKILL.md
+++ b/src/skills/.archive/xray/SKILL.md
@@ -2,6 +2,7 @@
 name: xray
 description: X-ray deep scan — inspect Claude Code auto-memory, installed skills, or session history. Use when user says "xray", "x-ray", "memory", "scan memory", "what do you remember", "show memories", "memory stats", "forget", "list skills", "installed skills", "session history", or wants to inspect what the AI remembers across sessions. Do NOT trigger for Oracle vault/ψ (use /trace) or session handoffs (use /inbox).
 argument-hint: "[memory|skills|sessions]"
+zombie: true
 ---
 
 # /xray - X-Ray Deep Scan


### PR DESCRIPTION
## The bug

`bunx github:Soul-Brews-Studio/arra-oracle-skills-cli#alpha profiles lab` printed **68 skills**. Two problems hid behind that number:

| | Display (`profiles` cmd) | Real install |
|---|---|---|
| minimal | 6 | 6 |
| standard | 12 | 12 |
| **full** | 65 | 33 → **22** |
| **lab** | **68** | 36 → **25** |

### 🔴 Bug #1 — real leak (fixed here)

Zombie round 2 (2026-07) moved 11 skills into `src/skills/.archive/` **and** added them to the `ZOMBIE_SKILLS` constant — but never set `zombie: true` in their frontmatter.

The install path excludes zombies via the **frontmatter-derived `.zombie` flag** from `discoverSkills()`, **not** the constant. And the compiled binary's VFS (`scripts/generate-vfs.ts`) flattens active + archived skills into one `name→files` map with **no `.archive/` path info** — so location can't be used as a fallback signal in shipped builds. Frontmatter is the only zombie signal that survives compilation.

Result: those 11 (`contacts, feel, hey, inbox, mailbox, oracle-soul-sync-update, oracle-up, schedule, standup, worktree, xray`) kept installing under `full`/`lab`.

**Proof it's a leak, not intent:** `lab` should be `36 − 11 = 25`, which is exactly `marketplace.json`'s 25-skill curated allowlist. The two now agree.

### 🐛 Bug #2 — misleading display (fixed here)

`src/cli/commands/profiles.ts` called `resolveProfile(name, allNames)` without the secret/zombie lists, so it printed every discovered skill instead of what `install` resolves.

## The fix

- **`zombie: true` frontmatter** on the 11 archived `SKILL.md` files → works in both dev (filesystem) and shipped (VFS) modes.
- **`compile.ts` archive-integrity gate** — build fails if any `.archive/` skill lacks a `zombie`/`secret`/`hidden` flag. Prevents recurrence (the existing unit test used the *correct* constant, so it never caught this frontmatter drift).
- **`profiles.ts` command** — pass secret/zombie names to `resolveProfile` so the display matches real install.
- **`__tests__/archive-integrity.test.ts`** — integration guard over the real `disk → discoverSkills → resolveProfile` path.

## Verification

- `bun run compile` ✅ — **`marketplace.json` byte-unchanged** (compile never scanned `.archive/`)
- Full unit suite: **249 pass / 0 fail** (+2 new)
- Gate proven: stripping a flag → compile fails with a clear error; restoring → green
- `profiles lab` now prints **25** (was 68); counts: minimal 6 / standard 12 / full 22 / lab 25
- Default `minimal`/`standard` profiles were never affected

## Blast radius

Only `arra install -p full` / `-p lab` consumers received the 11 stray skills; the default `minimal` and the common `standard` were always clean. GitHub-only — no npm involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)