### PR TITLE
test(curation): lock constant↔directory↔profile invariants

### DIFF
--- a/__tests__/archive-integrity.test.ts
+++ b/__tests__/archive-integrity.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from "bun:test";
 import { readdirSync, existsSync } from "fs";
 import { join } from "path";
 import { discoverSkills } from "../src/cli/installer";
-import { resolveProfile } from "../src/profiles";
+import {
+  resolveProfile,
+  ZOMBIE_SKILLS,
+  LAB_SKILLS,
+  STANDARD_SKILLS,
+  MINIMAL_SKILLS,
+} from "../src/profiles";
 
 // Integration guard for the 2026-07 zombie-leak regression.
 //
@@ -25,6 +31,15 @@ function archivedSkillNames(): string[] {
   return readdirSync(ARCHIVE_DIR, { withFileTypes: true })
     .filter((d) => d.isDirectory() && !d.name.startsWith("."))
     .filter((d) => existsSync(join(ARCHIVE_DIR, d.name, "SKILL.md")))
+    .map((d) => d.name);
+}
+
+function activeSkillNames(): string[] {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter(
+      (d) => d.isDirectory() && !d.name.startsWith(".") && d.name !== "_template",
+    )
+    .filter((d) => existsSync(join(SKILLS_DIR, d.name, "SKILL.md")))
     .map((d) => d.name);
 }
 
@@ -59,6 +74,45 @@ describe("archive integrity (real discoverSkills)", () => {
         );
       const leaked = resolved.filter((name) => archived.has(name));
       expect({ profile, leaked }).toEqual({ profile, leaked: [] });
+    }
+  });
+});
+
+// The curation system has three views of "which skills are zombies": the
+// ZOMBIE_SKILLS constant (drives the [zombie] install label), the .archive/
+// directory (physical storage + the -s opt-in path), and the per-file
+// `zombie: true` frontmatter (drives install exclusion, checked above). They
+// currently agree — these tests keep them agreeing. The archive→frontmatter
+// axis already drifted once (PR #453); this locks the other two axes before
+// they can.
+describe("curation consistency (constant ↔ directory ↔ profiles)", () => {
+  it("ZOMBIE_SKILLS constant exactly matches the .archive/ directory set", () => {
+    const constant: string[] = [...ZOMBIE_SKILLS].sort();
+    const dirs: string[] = archivedSkillNames().sort();
+    // Both directions: a name in the constant with no dir would mislabel a
+    // non-existent skill; a dir with no constant entry loses its [zombie] tag.
+    expect(constant).toEqual(dirs);
+  });
+
+  it("no skill name exists in both active and .archive/ (shadowing)", () => {
+    // resolveSkillDir() checks the active path first, so a duplicate name would
+    // silently shadow the archived copy and change what `-s <name>` installs.
+    const active = new Set(activeSkillNames());
+    const collisions = archivedSkillNames().filter((n) => active.has(n));
+    expect(collisions).toEqual([]);
+  });
+
+  it("every minimal/standard/lab-only skill resolves to a real active dir", () => {
+    const active = new Set(activeSkillNames());
+    for (const [label, list] of [
+      ["MINIMAL", MINIMAL_SKILLS],
+      ["STANDARD", STANDARD_SKILLS],
+      ["LAB", LAB_SKILLS],
+    ] as const) {
+      const dangling = [...list].filter((n) => !active.has(n));
+      // A profile pointing at a moved/deleted skill installs nothing for that
+      // slot — silently shrinking the profile.
+      expect({ label, dangling }).toEqual({ label, dangling: [] });
     }
   });
 });


### PR DESCRIPTION
Follow-up hardening to #453.

The curation system has **three views** of "which skills are zombies":
| view | drives |
|---|---|
| `ZOMBIE_SKILLS` constant | the `[zombie]` install label |
| `.archive/` directory | physical storage + the `-s <name>` opt-in path |
| per-file `zombie: true` frontmatter | install exclusion |

#453 gated the **archive→frontmatter** axis (compile fails on a missing flag). The other two axes happened to agree, but nothing kept them agreeing — the exact shape of bug #453 fixed. An audit confirmed **zero current drift**; these tests lock it in:

- `ZOMBIE_SKILLS` constant exactly matches the `.archive/` directory set (both directions)
- no skill name lives in both `active/` and `.archive/` (`resolveSkillDir` shadowing — would change what `-s <name>` installs)
- every minimal/standard/lab-only skill resolves to a real active directory (a dangling entry silently shrinks the profile)

Pure test-only change — no runtime code touched. Full suite 252 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)