### PR TITLE
release: v26.7.16-alpha.1137

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.7.6-alpha.1059",
+  "version": "26.7.16-alpha.1137",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
First alpha carrying the public shelf / vault split (PR #457).

On merge, calver-release.yml tags v26.7.16-alpha.1137 + GitHub release + npm @alpha.

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle