### PR TITLE
fix(ci): unbreak ci.yml YAML + named-drift count assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         run: test -z "$(git status --porcelain .claude-plugin README.md)"
       - name: Verify npm tarball ships the shelf (skills/ in package files)
         # sed strips lefthook's "sync hooks" line that pollutes npm's JSON stdout
-        run: npm pack --dry-run --json | sed -n '/^\[/,$p' | bun -e 'const files = JSON.parse(await Bun.stdin.text())[0].files.map(f => f.path); if (!files.some(p => p === "skills/rrr/SKILL.md")) { console.error("npm tarball is missing skills/ — check package.json files[]"); process.exit(1); } console.log(`tarball ok: ${files.filter(p => p.startsWith("skills/")).length} shelf files`);'
+        run: |
+          npm pack --dry-run --json | sed -n '/^\[/,$p' | bun -e 'const files = JSON.parse(await Bun.stdin.text())[0].files.map(f => f.path); if (!files.some(p => p === "skills/rrr/SKILL.md")) { console.error("npm tarball is missing skills/ — check package.json files[]"); process.exit(1); } console.log("tarball ok: " + files.filter(p => p.startsWith("skills/")).length + " shelf files");'
       - name: Verify skill scripts are executable (mode 100755)
         run: bash scripts/check_skill_scripts_exec.sh

--- a/__tests__/install-e2e.test.ts
+++ b/__tests__/install-e2e.test.ts
@@ -140,7 +140,13 @@ import { makeInstallFixture, listSkillDirs } from "./helpers/install-fixture";
 
       const installed = await listSkillDirs(SKILLS_DIR);
       const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !minimalOnly.includes(s.name) && !s.secret && !s.zombie);
-      expect(installed.length).toBe(fullSkills.length);
+      // On mismatch, name the drift — a bare count diff is undebuggable on CI.
+      const fullNames = new Set(fullSkills.map((s) => s.name));
+      expect({
+        count: installed.length,
+        extra: installed.filter((n) => !fullNames.has(n)),
+        missing: [...fullNames].filter((n) => !installed.includes(n)),
+      }).toEqual({ count: fullSkills.length, extra: [], missing: [] });
     });
 
     it("every full-profile skill has a directory", async () => {
@@ -248,7 +254,13 @@ import { makeInstallFixture, listSkillDirs } from "./helpers/install-fixture";
       const allSkills = await discoverSkills();
       const fullSkills = allSkills.filter(s => !labOnly.includes(s.name) && !minimalOnly.includes(s.name) && !s.secret && !s.zombie);
       let skills = await listSkillDirs(SKILLS_DIR);
-      expect(skills.length).toBe(fullSkills.length);
+      // On mismatch, name the drift — a bare count diff is undebuggable on CI.
+      const fullNames = new Set(fullSkills.map((s) => s.name));
+      expect({
+        count: skills.length,
+        extra: skills.filter((n) => !fullNames.has(n)),
+        missing: [...fullNames].filter((n) => !skills.includes(n)),
+      }).toEqual({ count: fullSkills.length, extra: [], missing: [] });
 
       await installSkills([TEST_AGENT], {
         global: true,


### PR DESCRIPTION
ci.yml was a 0-job startup_failure since a854fdb (unquoted ': ' in the npm-pack gate). Also instruments the two full-profile count assertions so the Linux-only 28≠27 calver failure names the extra skill.

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle