### PR TITLE
release: v26.7.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-skills",
-  "version": "26.7.16-alpha.1149",
+  "version": "26.7.16",
   "description": "Install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Stable v26.7.16 — first stable with the public shelf. CI tags on merge; npm @latest publish will fail until NPM_TOKEN is rotated (tag + GitHub release unaffected; npx channel needs no npm).

🤖 ตอบโดย arra-oracle-skills-cli จาก Nat → arra-oracle-skills-cli-oracle