### PR TITLE
fix(recap): prefer CLAUDE_CODE_SESSION_ID over ls -t mtime guess

### DIFF
--- a/skills/recap/recap-rich.ts
+++ b/skills/recap/recap-rich.ts
@@ -17,13 +17,17 @@ const month = now.toISOString().slice(0, 7);
 let sessionLine = "";
 try {
   const encodedPwd = ROOT.replace(/^\//, '-').replace(/[\/.]/g, '-');
-  const projectDir = `${process.env.HOME}/.claude/projects/${encodedPwd}`;
+  const claudeHome = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  const projectDir = `${claudeHome}/projects/${encodedPwd}`;
   if (existsSync(projectDir)) {
     const jsonls = (await $`ls -t ${projectDir}/*.jsonl 2>/dev/null`.text()).trim().split('\n').filter(Boolean);
     if (jsonls.length) {
-      const sessionId = jsonls[0].split('/').pop()!.replace('.jsonl', '');
+      const envSessionId = process.env.CLAUDE_CODE_SESSION_ID;
+      const envJsonl = envSessionId ? `${projectDir}/${envSessionId}.jsonl` : "";
+      const chosenJsonl = envJsonl && existsSync(envJsonl) ? envJsonl : jsonls[0];
+      const sessionId = chosenJsonl.split('/').pop()!.replace('.jsonl', '');
       const shortId = sessionId.slice(0, 8);
-      const firstLine = (await $`head -1 ${jsonls[0]}`.text()).trim();
+      const firstLine = (await $`head -1 ${chosenJsonl}`.text()).trim();
       let startStr = "";
       try {
         const ts = JSON.parse(firstLine).timestamp;

--- a/skills/recap/recap.ts
+++ b/skills/recap/recap.ts
@@ -71,13 +71,17 @@ const untracked = lines.filter(l => l.startsWith('??'));
 let sessionLine = "";
 try {
   const encodedPwd = root.replace(/^\//, '-').replace(/[\/.]/g, '-');
-  const projectDir = `${process.env.HOME}/.claude/projects/${encodedPwd}`;
+  const claudeHome = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  const projectDir = `${claudeHome}/projects/${encodedPwd}`;
   if (existsSync(projectDir)) {
     const jsonls = (await $`ls -t ${projectDir}/*.jsonl 2>/dev/null`.text()).trim().split('\n').filter(Boolean);
     if (jsonls.length) {
-      const sessionId = jsonls[0].split('/').pop()!.replace('.jsonl', '');
+      const envSessionId = process.env.CLAUDE_CODE_SESSION_ID;
+      const envJsonl = envSessionId ? `${projectDir}/${envSessionId}.jsonl` : "";
+      const chosenJsonl = envJsonl && existsSync(envJsonl) ? envJsonl : jsonls[0];
+      const sessionId = chosenJsonl.split('/').pop()!.replace('.jsonl', '');
       const shortId = sessionId.slice(0, 8);
-      const firstLine = (await $`head -1 ${jsonls[0]}`.text()).trim();
+      const firstLine = (await $`head -1 ${chosenJsonl}`.text()).trim();
       let startStr = "";
       try {
         const ts = JSON.parse(firstLine).timestamp;


### PR DESCRIPTION
## Summary
- `/recap` and `/recap-rich` guessed the current session file with `ls -t *.jsonl` (newest mtime). Subagent/sidecar transcripts can write concurrently and race the main session's mtime, so the guess can pick the wrong session mid-run.
- Fix: when `$CLAUDE_CODE_SESSION_ID` is set and `<projectDir>/$CLAUDE_CODE_SESSION_ID.jsonl` exists, use it directly. Falls back to the previous `ls -t` behavior unchanged when the env var/file isn't available.

Fixes #465

## Test plan
- [x] `bun build skills/recap/recap.ts --target=bun` — OK
- [x] `bun build skills/recap/recap-rich.ts --target=bun` — OK
- [x] Ran patched `recap.ts` live against a real session where `$CLAUDE_CODE_SESSION_ID` and `ls -t` newest-mtime file disagreed — patched version correctly picked the env-id session, unpatched picked the wrong one