### PR TITLE
fix(install): -y with no detected agents must fail, not exit 0 silently (#459)

### DIFF
--- a/__tests__/install-e2e.test.ts
+++ b/__tests__/install-e2e.test.ts
@@ -14,8 +14,8 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
 import { readdir, readFile, rm, mkdir, writeFile } from "fs/promises";
 import { join } from "path";
-import { existsSync } from "fs";
-import { homedir } from "os";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { $ } from "bun";
 import { installSkills, uninstallSkills, discoverSkills } from "../src/cli/installer";
 import { profiles, labOnly, minimalOnly } from "../src/profiles";
@@ -624,3 +624,40 @@ import { makeInstallFixture, listSkillDirs } from "./helpers/install-fixture";
 
   });
 }
+
+// #459: `-y` promises "don't ask me". When no agent is detected the CLI used to
+// fall through to the interactive picker anyway, hit EOF on stdin, resolve to
+// nothing, and exit 0 having installed NOTHING — so CI and `/go update`
+// automation read a silent no-op as success. A fresh machine with no ~/.claude
+// is exactly the case the README's first command lands on.
+describe("#459 — non-interactive install with no detected agents", () => {
+  const cliPath = join(process.cwd(), "src/cli/index.ts");
+
+  it("exits non-zero instead of silently installing nothing", () => {
+    const emptyHome = mkdtempSync(join(tmpdir(), "arra-459-"));
+    const proc = Bun.spawnSync(
+      ["bun", cliPath, "install", "-g", "--profile", "minimal", "-y"],
+      { env: { ...process.env, HOME: emptyHome }, stdin: "ignore" },
+    );
+
+    expect(proc.exitCode).not.toBe(0);
+    // and it must say what to do about it, not just fail
+    const out = proc.stdout.toString() + proc.stderr.toString();
+    expect(out).toContain("-a claude-code");
+
+    rmSync(emptyHome, { recursive: true, force: true });
+  });
+
+  it("still succeeds when an agent is named explicitly", () => {
+    const home = mkdtempSync(join(tmpdir(), "arra-459-ok-"));
+    const proc = Bun.spawnSync(
+      ["bun", cliPath, "install", "-g", "--profile", "minimal", "-y", "-a", "claude-code"],
+      { env: { ...process.env, HOME: home }, stdin: "ignore" },
+    );
+
+    expect(proc.exitCode).toBe(0);
+    expect(existsSync(join(home, ".claude/skills/recap"))).toBe(true);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -150,6 +150,21 @@ export function registerInstall(program: Command, version: string) {
           }
 
           if (targetAgents.length === 0) {
+            // #459: -y means "don't ask me". Falling through to the picker here
+            // made a non-interactive run hit EOF on stdin, resolve to nothing,
+            // and exit 0 having installed NOTHING — so CI and `/go update`
+            // automation read a silent no-op as success. Fail loudly instead,
+            // and say what to pass, since "no agents detected" is usually a
+            // fresh machine rather than a mistake.
+            if (options.yes) {
+              p.log.error(
+                'No agents detected, so there is nothing to install.\n' +
+                '  Name one explicitly, e.g.:  -a claude-code\n' +
+                `  Supported: ${getAgentNames().join(', ')}`
+              );
+              process.exit(1);
+            }
+
             const selected = await p.multiselect({
               message: 'Select agents to install to:',
               options: Object.entries(agents).map(([key, config]) => ({


### PR DESCRIPTION
Closes #459.

On a machine with no `~/.claude` and no `~/.codex` — a fresh install, i.e. **exactly where the README's first command lands** — `install -g -p minimal -y` printed the banner, fell through to the **interactive agent picker despite `-y`**, hit EOF on stdin, resolved to nothing, and returned **0 having installed nothing**.

## Reproduced, before and after | | result |
|---|---|
| **before** | `EXIT=0`, **0 skills** in the fake HOME, interactive multiselect rendered |
| **after** | `EXIT=1`, error names the fix (`-a claude-code`) and lists supported agents |
| **control** | `-a claude-code` → still `EXIT=0`, 8 skills installed |

`-y` means *"don't ask me"*, so reaching a prompt at all is the bug — but **exiting 0 on a no-op is what makes it dangerous**, because CI and `/go update` automation read that as success.

The guard prints the supported agent list too, since "no agents detected" is usually a fresh machine rather than a typo.

## Regression tests

Two tests in `install-e2e.test.ts` drive the **real CLI** against an isolated empty `HOME`:

1. asserts non-zero exit **and** that the message names the flag — a bare failure with an unhelpful message would still be a bad first-run experience
2. asserts the explicit-agent path still succeeds, so the guard can't regress into blocking normal installs

**263 pass / 0 fail** (was 261).

🤖 Generated with [Claude Code](https://claude.com/claude-code)