### PR TITLE
fix(release): make alpha-only structural, not just documented

### DIFF
--- a/.github/workflows/calver-release.yml
+++ b/.github/workflows/calver-release.yml
@@ -17,7 +17,13 @@ name: CalVer Release
 
 on:
   push:
-    branches: [main, alpha, beta]
+    # alpha ONLY. The standing rule is alpha-only releases (CLAUDE.md, 2026-07-25):
+    # no alpha->main PRs, no stable cuts, no beta channel. Leaving main and beta
+    # armed here made the rule a convention that one stray push could break — and
+    # one did: a docs branch accidentally cut from a release branch carried a
+    # stable version onto alpha and this workflow happily tagged v26.7.25 off it.
+    # Narrowing the trigger makes the rule structural instead of documented.
+    branches: [alpha]
     paths:
       - package.json
 

--- a/src/skills/release-beta/SKILL.md
+++ b/src/skills/release-beta/SKILL.md
@@ -7,6 +7,19 @@ metadata:
   internal: true
 ---
 
+> ## ⚠️ Retired — alpha-only since 2026-07-25
+>
+> The fleet ships from `alpha` and nowhere else: no `alpha → beta`, no
+> `beta → main`, no stable versions. `alpha` is the repo's default branch, the
+> plugin marketplace clones it, every documented install reads `#alpha`, and
+> `calver-release.yml` now only triggers on `alpha` — so the pipeline this skill
+> describes has no runway left. See CLAUDE.md → Branch Strategy.
+>
+> Kept rather than deleted (Nothing is Deleted) in case a beta channel is ever
+> wanted again; if so, re-check every command here against the current maw/CI
+> before trusting it.
+
+
 # /release-beta
 
 Cut a beta pre-release for the current repo.


### PR DESCRIPTION
Found while **adversarially re-checking #412 before closing it** — two pieces of plumbing still assumed the main/beta pipeline that the alpha-only rule retired.

## 1. `calver-release.yml` triggered on `[main, alpha, beta]`

That left the rule as a convention one stray push could break — **and one did, hours ago**: a docs branch accidentally cut from a release branch carried a stable version onto alpha, and this workflow cheerfully tagged `v26.7.25` off it.

Narrowed to `[alpha]`. The rule is now enforced by the pipeline instead of by remembering it.

## 2. `release-beta` still taught `alpha → beta → main`

Marked **retired** at the top with the reason, rather than deleted (Nothing is Deleted) — if a beta channel is ever wanted again, its commands need re-verifying against current maw/CI anyway.

---

Neither was in #412's scope, so they were reported in that issue's closing comment rather than smuggled into it.

compile 34 skills · **263 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)