### PR TITLE
docs(talk-to): how to reply to another oracle, and never to a pane id (#434)

### DIFF
--- a/src/skills/talk-to/SKILL.md
+++ b/src/skills/talk-to/SKILL.md
@@ -95,6 +95,31 @@ else
 fi
 ```
 
+### Replying to a message another oracle sent you (#434)
+
+A ping arrives in your context looking like `[m5:digger] …`. The reflex is to
+answer in your own transcript — but that text goes to Nat, not to digger, who is
+sitting in a different pane waiting. Reply with `maw hey` or the conversation is
+one-sided and nobody notices for hours.
+
+```bash
+maw hey <their-oracle-name> 'your reply'     # name, not a pane id
+```
+
+**Never reply to a pane id.** `maw peek %3001` works, so it is tempting to paste
+that same `%3001` into `maw hey` — it hard-errors (`bare target '%3001' not found
+locally`). Pane ids are a peek-only handle. `maw ls -v` is the source of truth
+for targets; a bare `maw ls | grep` finds the row but not the addressable name,
+which is why the auto-detect above should be treated as a hint, not an answer:
+
+```bash
+maw ls -v | grep -i <name>      # resolves the real target
+maw hey <target> ping --dry-run # confirm it resolves BEFORE sending
+```
+
+`--dry-run` is the cheap check. It costs nothing and catches a wrong target
+before the message goes somewhere confusing.
+
 When using `--maw`:
 1. Compose message from intent
 2. Use contacts maw name if available: `maw hey {MAW or agent-oracle} '{message}'`


### PR DESCRIPTION
Addresses the in-scope half of #434.

An oracle receiving a federation ping answers **in its own transcript** — so the reply reaches Nat, not the oracle sitting in another pane waiting for it.

## Half of this was already fixed today, in the wrong place

`/codex-team` carries the pane-id warning (#472) — but that's a *coder-team-lead* skill a general oracle answering a ping will never load. `/talk-to`, the generic messaging verb (and the one that survived the `/hey` + `/contacts` + `/mailbox` + `/inbox` consolidation), had **no reply section at all** and still taught `maw ls | grep`, which finds the row but not the addressable name.

## Added

A *"Replying to a message another oracle sent you"* section that says it plainly: answering in your own transcript is a one-sided conversation nobody notices for hours.

Both claims **re-verified on this machine** before writing them down:

```
maw hey %3001 ping --dry-run  →  error: bare target '%3001' not found locally
maw ls -v | grep -i digger    →  4 matching rows with real targets
```

So: `maw ls -v` for the target, `--dry-run` to confirm it resolves before sending. The dry-run costs nothing and catches a wrong target before the message lands somewhere confusing.

> Proposal 3 in the issue (`maw hey` resolving fleet names directly) is a maw-rs CLI change and stays out of scope here.

**264 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)