### PR TITLE
fix(rrr,forward): --bg couldn't find dig-session.py when installed as a plugin

### DIFF
--- a/skills/forward/SKILL.md
+++ b/skills/forward/SKILL.md
@@ -58,7 +58,10 @@ Repo: <REPO_NAME>
 Date: <YYYY-MM-DD HH:MM>
 
 Steps:
-1. Run: python3 "$(ls ~/.claude/skills/forward/scripts/dig-session.py ~/.claude/skills/forward/dig-session.py 2>/dev/null | head -1)" "<LATEST_JSONL>"
+1. Run: python3 "$(ls ~/.claude/skills/forward/scripts/dig-session.py \
+             ~/.claude/plugins/marketplaces/*/skills/forward/scripts/dig-session.py \
+             ~/.claude/plugins/cache/*/*/*/skills/forward/scripts/dig-session.py \
+             ~/.claude/skills/forward/dig-session.py 2>/dev/null | head -1)" "<LATEST_JSONL>"
 2. From the JSON output, write 4-8 bullets summarizing what happened. Be specific:
    skills invoked, teammates used, files changed, key outputs.
 3. Run: git -C <ORACLE_ROOT> status --short

--- a/skills/rrr/SKILL.md
+++ b/skills/rrr/SKILL.md
@@ -331,7 +331,10 @@ Vault (PSI): <PSI>
 Session: <SESSION_ID> | <REPO_NAME> | Date: <YYYY-MM-DD HH:MM>
 
 Steps:
-1. Run: python3 "$(ls ~/.claude/skills/forward/scripts/dig-session.py ~/.claude/skills/forward/dig-session.py 2>/dev/null | head -1)" "<LATEST_JSONL>"
+1. Run: python3 "$(ls ~/.claude/skills/forward/scripts/dig-session.py \
+             ~/.claude/plugins/marketplaces/*/skills/forward/scripts/dig-session.py \
+             ~/.claude/plugins/cache/*/*/*/skills/forward/scripts/dig-session.py \
+             ~/.claude/skills/forward/dig-session.py 2>/dev/null | head -1)" "<LATEST_JSONL>"
    (real timestamps for the Timeline — never guess or approximate times)
 2. mkdir -p "<PSI>/memory/retrospectives/<YYYY-MM>/<DD>"
 3. git -C <ORACLE_ROOT> status --short   (for an "Uncommitted" note)


### PR DESCRIPTION
Caught by **running `/rrr --bg` for real** on this machine rather than reading it.

The fallback chain checked only `~/.claude/skills/forward/`, so both `--bg` modes resolved to an **empty path** and would have handed the subagent `python3 ""`.

The script itself shipped correctly in #470 — the *resolution* didn't keep up with where a skill actually lands. Three install shapes, one covered:

```
~/.claude/skills/forward/scripts/                          local install     ← only this
~/.claude/plugins/marketplaces/*/skills/forward/scripts/   plugin marketplace
~/.claude/plugins/cache/*/*/*/skills/forward/scripts/      plugin cache (versioned)
```

This machine is now plugin-installed (the local copy was archived earlier today as a duplicate), so **the only surviving copy sat at a path the skill never looked at**. Anyone installing via `/plugin` — the path we recommend to newcomers, and the one tomorrow's workshop uses — hits exactly this.

## Fix

All four candidates globbed in one `ls`, first match wins, **local first** so a dev checkout still shadows the packaged copy.

Verified end to end: the chain resolves to the plugin-cache copy, and that copy runs, returning real session JSON (3,648 messages).

> Lesson worth keeping: bundling a script is only half the fix — the other half is every path it can legitimately live at.

compile 34 skills · **264 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)